### PR TITLE
[new-plugin] test-rust-cli v1.0.0

### DIFF
--- a/skills/test-rust-cli/.claude-plugin/plugin.json
+++ b/skills/test-rust-cli/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-rust-cli",
+  "description": "E2E test - Rust CLI querying ETH price via OnchainOS",
+  "version": "1.0.0",
+  "author": {"name": "E2E Test"},
+  "license": "MIT",
+  "keywords": ["test", "e2e", "rust", "onchainos"]
+}

--- a/skills/test-rust-cli/Cargo.toml
+++ b/skills/test-rust-cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test-rust-cli"
+version = "1.0.0"
+edition = "2021"

--- a/skills/test-rust-cli/LICENSE
+++ b/skills/test-rust-cli/LICENSE
@@ -1,0 +1,1 @@
+MIT License - Copyright 2026 E2E Test

--- a/skills/test-rust-cli/SKILL.md
+++ b/skills/test-rust-cli/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: test-rust-cli
+description: "E2E test - Rust CLI querying ETH price via OnchainOS"
+version: "1.0.0"
+author: "E2E Test"
+tags: [test, rust, onchainos]
+---
+
+# Test Rust CLI
+
+## Overview
+E2E test plugin with Rust CLI binary. Queries ETH price via OnchainOS.
+
+## Pre-flight Checks
+1. Install onchainos CLI: `curl -sSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh`
+2. Ensure test-rust-cli binary is installed
+
+## Commands
+
+### Query ETH Price via CLI
+```bash
+test-rust-cli --query eth-price
+```
+**When to use:** When user asks about ETH price.
+**Output:** Calls `onchainos token price-info --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --chain ethereum` and formats the result.
+
+### Direct OnchainOS Query
+```bash
+onchainos token price-info --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --chain ethereum
+```
+
+## Error Handling
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| Binary not found | CLI not installed | Install via plugin-store |
+| Command not found | onchainos not installed | Run pre-flight install |

--- a/skills/test-rust-cli/plugin.yaml
+++ b/skills/test-rust-cli/plugin.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+name: test-rust-cli
+version: "1.0.0"
+description: "E2E test - Rust CLI querying ETH price via OnchainOS"
+author:
+  name: "E2E Test"
+  github: "MigOKG"
+license: MIT
+category: utility
+tags: [test, e2e, rust, onchainos]
+components:
+  skill:
+    dir: .
+build:
+  lang: rust
+  binary_name: test-rust-cli

--- a/skills/test-rust-cli/src/main.rs
+++ b/skills/test-rust-cli/src/main.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() > 1 && args[1] == "--query" && args.get(2).map(|s| s.as_str()) == Some("eth-price") {
+        println!("Querying ETH price via onchainos...");
+        let output = Command::new("onchainos")
+            .args(["token", "price-info", "--address", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "--chain", "ethereum"])
+            .output();
+        match output {
+            Ok(o) => print!("{}", String::from_utf8_lossy(&o.stdout)),
+            Err(e) => eprintln!("Error: {}", e),
+        }
+    } else if args.len() > 1 && args[1] == "--help" {
+        println!("test-rust-cli v1.0.0");
+        println!("Usage: test-rust-cli --query eth-price");
+        println!("Queries ETH price via onchainos token price-info");
+    } else {
+        println!("test-rust-cli v1.0.0 - Querying ETH price via onchainos...");
+        let output = Command::new("onchainos")
+            .args(["token", "price-info", "--address", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "--chain", "ethereum"])
+            .output();
+        match output {
+            Ok(o) => print!("{}", String::from_utf8_lossy(&o.stdout)),
+            Err(e) => eprintln!("Error running onchainos: {}", e),
+        }
+    }
+}


### PR DESCRIPTION
## Plugin Submission
- **Plugin name**: test-rust-cli
- **Version**: 1.0.0
- **Type**: new-plugin

### Description
E2E test: Rust CLI querying ETH price via onchainos. Default run queries ETH price.

### OnchainOS commands
- `onchainos token price-info --address 0xC02...Cc2 --chain ethereum`

### Checklist
- [x] plugin-store lint passes
- [x] .claude-plugin/plugin.json included
- [x] SKILL.md has YAML frontmatter
- [x] LICENSE included

🤖 Generated with [Claude Code](https://claude.com/claude-code)