### PR TITLE
feat: add kairos-floor-score — ML trade scoring skill

### DIFF
--- a/skills/kairos-floor-score/LICENSE
+++ b/skills/kairos-floor-score/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Valisthea (Kairos Lab)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/kairos-floor-score/SKILL.md
+++ b/skills/kairos-floor-score/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kairos-floor-score
-version: 1.0.0
-description: "Institutional-grade ML trade scoring for AI agents. Regime classification, microstructure analysis, confluence scoring, GO/REDUCE/REJECT recommendation. Trigger on: trade scoring, market analysis, regime detection, risk assessment, entry quality, VPIN, order flow."
+version: 1.1.0
+description: "Institutional-grade ML trade scoring for AI agents. Regime classification, microstructure analysis, confluence scoring, GO/REDUCE/REJECT recommendation. Now with native Uniswap V3 pool scoring. Trigger on: trade scoring, market analysis, regime detection, risk assessment, entry quality, VPIN, order flow, Uniswap pool analysis, DEX trade scoring, AMM liquidity, pool depth check, ethereum pool, polygon pool, base pool, arbitrum pool."
 author: Valisthea
 ---
 
@@ -18,6 +18,10 @@ Invoke this skill whenever you need to determine the quality of a trade entry. C
 - "Check confluence for this entry"
 - "What's the VPIN / order flow saying?"
 - "Evaluate this trade for risk"
+- "Score this Uniswap pool"
+- "Should I trade on this Uniswap V3 pool?"
+- "Analyze ETH-USDC pool on ethereum"
+- "Check DEX liquidity before swapping"
 
 ## How to Call
 
@@ -87,6 +91,30 @@ The regime classifier identifies 5 states: `trending_up`, `trending_down`, `rang
 - **Kyle Lambda high**: Thin liquidity, expect slippage
 - **Order Imbalance > 0.3**: Strong directional pressure
 
+## Uniswap V3 Integration
+
+Score any Uniswap V3 pool directly by pool address — no manual candle data needed:
+
+```bash
+# ETH-USDC 0.30% pool on Ethereum
+kairos-floor-score analyze \
+  --symbol ETH-USDC \
+  --side long \
+  --source uniswap \
+  --pool 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 \
+  --chain ethereum
+
+# Any pool on Polygon, Base, Arbitrum, Optimism
+kairos-floor-score analyze \
+  --symbol MATIC-USDC \
+  --side long \
+  --source uniswap \
+  --pool <pool-address> \
+  --chain polygon
+```
+
+Supported chains: `ethereum`, `polygon`, `base`, `arbitrum`, `optimism`
+
 ## Integration with OKX Onchain OS
 
 If `onchainos` CLI is installed, data can be fetched directly:
@@ -96,14 +124,14 @@ kairos-floor-score analyze \
   --symbol BTC-USDT \
   --side long \
   --source onchainos \
-  --chain solana
+  --chain ethereum
 ```
 
 ## Agent Workflow
 
 1. Receive trade signal from upstream strategy
-2. Call `kairos-floor-score analyze` with current market data
-3. If recommendation is `GO`, proceed to position sizing
+2. Call `kairos-floor-score analyze` with current market data or `--source uniswap --pool <addr>`
+3. If recommendation is `GO`, proceed to position sizing or submit swap
 4. If `REDUCE`, cut position size by 50%
 5. If `REJECT`, skip this trade entirely
 6. Log the full score result for post-trade analysis

--- a/skills/kairos-floor-score/SKILL.md
+++ b/skills/kairos-floor-score/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: kairos-floor-score
+version: 1.0.0
+description: "Institutional-grade ML trade scoring for AI agents. Regime classification, microstructure analysis, confluence scoring, GO/REDUCE/REJECT recommendation. Trigger on: trade scoring, market analysis, regime detection, risk assessment, entry quality, VPIN, order flow."
+author: Valisthea
+---
+
+# Kairos Floor Score
+
+## When to Use
+
+Invoke this skill whenever you need to determine the quality of a trade entry. Common triggers:
+
+- "Should I go long/short on X?"
+- "Score this trade setup"
+- "What's the market regime right now?"
+- "Is there enough liquidity to enter?"
+- "Check confluence for this entry"
+- "What's the VPIN / order flow saying?"
+- "Evaluate this trade for risk"
+
+## How to Call
+
+### Full Trade Scoring
+
+```bash
+kairos-floor-score analyze \
+  --symbol BTC-USDT \
+  --side long \
+  --klines '<json array of {o,h,l,c,v} candles>' \
+  --funding-rate 0.0001 \
+  --output json
+```
+
+The output JSON contains:
+- `recommendation`: `GO` (score >= 0.55), `REDUCE` (>= 0.45), or `REJECT` (< 0.45)
+- `score`: ML probability [0, 1]
+- `confidence`: HIGH / MEDIUM / LOW
+- `regime`: market regime classification with tradability assessment
+- `confluence`: 5-group weighted confluence breakdown
+- `microstructure`: Kyle Lambda, VPIN, order imbalance, spread
+
+### Regime Detection Only
+
+```bash
+kairos-floor-score regime --klines '<json>'
+```
+
+### Microstructure Only
+
+```bash
+kairos-floor-score microstructure --klines '<json>'
+```
+
+### Health Check
+
+```bash
+kairos-floor-score health
+```
+
+## Interpreting Results
+
+### Recommendation
+
+| Value   | Score Range | Action |
+|---------|-------------|--------|
+| GO      | >= 0.55     | Execute the trade with normal sizing |
+| REDUCE  | 0.45 - 0.55 | Trade with reduced size or wait for better setup |
+| REJECT  | < 0.45      | Do not enter this trade |
+
+### Regime
+
+The regime classifier identifies 5 states: `trending_up`, `trending_down`, `ranging`, `volatile`, `dead`. Only trade when `tradable: true`.
+
+### Confluence
+
+5 factor groups are scored independently:
+- **Trend** (25%): EMA cross, SMA position, multi-timeframe alignment
+- **Momentum** (20%): RSI, ADX, MACD histogram
+- **Volatility** (20%): ATR percentage, Bollinger bandwidth
+- **Flow** (20%): Volume ratio, order imbalance
+- **Sentiment** (15%): Funding rate, premium/discount
+
+### Microstructure
+
+- **VPIN > 0.7**: High probability of informed trading — caution
+- **Kyle Lambda high**: Thin liquidity, expect slippage
+- **Order Imbalance > 0.3**: Strong directional pressure
+
+## Integration with OKX Onchain OS
+
+If `onchainos` CLI is installed, data can be fetched directly:
+
+```bash
+kairos-floor-score analyze \
+  --symbol BTC-USDT \
+  --side long \
+  --source onchainos \
+  --chain solana
+```
+
+## Agent Workflow
+
+1. Receive trade signal from upstream strategy
+2. Call `kairos-floor-score analyze` with current market data
+3. If recommendation is `GO`, proceed to position sizing
+4. If `REDUCE`, cut position size by 50%
+5. If `REJECT`, skip this trade entirely
+6. Log the full score result for post-trade analysis

--- a/skills/kairos-floor-score/plugin.yaml
+++ b/skills/kairos-floor-score/plugin.yaml
@@ -1,0 +1,23 @@
+schema_version: 1
+name: kairos-floor-score
+version: "1.0.0"
+description: "Institutional-grade ML trade scoring for AI trading agents. GBDT model + regime detection + microstructure analysis + confluence scoring. GO/REDUCE/REJECT recommendations."
+author:
+  name: "Valisthea"
+  github: "Valisthea"
+license: MIT
+category: trading-strategy
+type: community-developer
+tags:
+  - trading
+  - ml
+  - scoring
+  - onchainos
+  - xlayer
+
+components:
+  skill:
+    repo: "Valisthea/kairos-floor-score"
+    commit: "2cf14a97042542a5cdeeb3e8f5a9aac4de5834ff"
+
+api_calls: []

--- a/skills/kairos-floor-score/plugin.yaml
+++ b/skills/kairos-floor-score/plugin.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: kairos-floor-score
-version: "1.0.0"
-description: "Institutional-grade ML trade scoring for AI trading agents. GBDT model + regime detection + microstructure analysis + confluence scoring. GO/REDUCE/REJECT recommendations."
+version: "1.1.0"
+description: "Institutional-grade ML trade scoring for AI agents. GBDT model + regime detection + microstructure analysis + confluence scoring + Uniswap V3 pool scoring. GO/REDUCE/REJECT recommendations. Supports ethereum, polygon, base, arbitrum."
 author:
   name: "Valisthea"
   github: "Valisthea"
@@ -14,10 +14,13 @@ tags:
   - scoring
   - onchainos
   - xlayer
+  - uniswap
+  - uniswap-v3
+  - defi
 
 components:
   skill:
     repo: "Valisthea/kairos-floor-score"
-    commit: "2cf14a97042542a5cdeeb3e8f5a9aac4de5834ff"
+    commit: "f9eee1b2dd15c64278d216c02dbcd43f31830175"
 
 api_calls: []


### PR DESCRIPTION
## Plugin: kairos-floor-score

**Track:** Skills Arena (OKX Build X Hackathon April 2026)

### What it does
Institutional-grade ML trade scoring for AI trading agents. Any agent can call `kairos-floor-score` with market data and get back a GO/REDUCE/REJECT recommendation backed by a gradient-boosted decision tree.

### Components
- **GBDT Model** — 30-tree gradient-boosted classifier (pure TypeScript, zero deps)
- **Regime Detection** — Classifies market state (trending/ranging/volatile/dead)
- **Microstructure Analysis** — Kyle's Lambda, Amihud illiquidity, VPIN, order flow
- **5-Group Confluence Scoring** — Trend, momentum, volatility, flow, sentiment
- **onchainos Integration** — Optional data fetching via OKX Onchain OS

### Source repo
https://github.com/Valisthea/kairos-floor-score

### Checklist
- [x] `plugin.yaml` with correct schema
- [x] `SKILL.md` with YAML frontmatter and usage instructions
- [x] Source repo is public
- [x] MIT license
- [x] No external ML dependencies (pure TypeScript)