### PR TITLE
[new-plugin] dca-swap-agent v1.0.0

### DIFF
--- a/skills/dca-swap-agent/LICENSE
+++ b/skills/dca-swap-agent/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 giwaov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/dca-swap-agent/plugin.yaml
+++ b/skills/dca-swap-agent/plugin.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+name: dca-swap-agent
+version: "1.0.0"
+description: "Autonomous DCA agent that periodically swaps tokens on X Layer via OnchainOS"
+author:
+  name: "giwaov"
+  github: "giwaov"
+license: MIT
+category: trading-strategy
+tags:
+  - dca
+  - xlayer
+  - onchainos
+  - trading-bot
+
+components:
+  skill:
+    repo: "giwaov/dca-swap-agent"
+    commit: "7733cc2a5081692de51d40d4eabaec3fc98638c8"
+
+api_calls: []
+type: community-developer


### PR DESCRIPTION
## DCA Swap Agent v1.0.0

Autonomous Dollar-Cost Averaging agent for X Layer (Chain ID 196). Periodically swaps a fixed amount of one token into a target token using onchainos CLI.

**Track**: X Layer Arena (Build X Hackathon Season 2)
**Type**: Skill-Only (Mode B - external repo)
**Repo**: https://github.com/giwaov/dca-swap-agent

### Features
- Paper-trade mode (default)
- Stop-loss protection
- Per-session spending limits and max swap count
- Token security scanning before every buy
- Web dashboard
- Config hot-reload

### OnchainOS Skills Used
- okx-agentic-wallet (wallet auth, balance)
- okx-dex-swap (swap execution)
- okx-dex-market (price data)
- okx-security (token safety scan)
- okx-dex-token (token search)

### Pre-Submission Checklist

- [x] `plugin.yaml`, `.claude-plugin/plugin.json`, and `SKILL.md` all present
- [x] `name` field is lowercase with hyphens only, 2-40 characters
- [x] `version` matches in `plugin.yaml`, `plugin.json`, and `SKILL.md`
- [x] `author.github` matches my GitHub username
- [x] `license` field uses a valid SPDX identifier
- [x] `category` is one of the allowed values
- [x] `api_calls` lists all external API domains (or `[]` if none)
- [x] SKILL.md has YAML frontmatter with name, description, version, author
- [x] SKILL.md includes Overview, Pre-flight, Commands, Error Handling sections
- [x] No hardcoded API keys, tokens, or credentials anywhere
- [x] No pre-compiled binary files in the submission
- [x] LICENSE file is present
- [x] PR title follows format: `[new-plugin] my-plugin v1.0.0`
- [x] PR branch name follows format: `submit/my-plugin`
- [x] PR only modifies files inside `skills/dca-swap-agent/`
- [x] (Trading plugin) Risk disclaimer is included
- [x] (Trading plugin) Dry-run / paper-trade mode is supported