### PR TITLE
[update-plugin] hyperliquid v0.1.1 — add register command for AA wallet setup

### DIFF
--- a/skills/hyperliquid/SKILL.md
+++ b/skills/hyperliquid/SKILL.md
@@ -123,40 +123,32 @@ Use this plugin when the user says (in any language):
 - "HL stop loss" / HL止损
 - "HL take profit" / HL止盈
 - "close my HL position" / 平掉我的HL仓位
+- "register Hyperliquid" / Hyperliquid注册签名地址
+- "setup Hyperliquid wallet" / 设置Hyperliquid钱包
+- "Hyperliquid signing address" / Hyperliquid签名地址
 
 ---
 
-## One-time Setup: Register API Wallet
+## One-time Setup: Register Your Signing Address
 
 > **Required before placing any order, close, or TP/SL.**
 
 onchainos uses an AA (account abstraction) wallet. When signing Hyperliquid L1 actions,
-the underlying EOA signer address differs from your onchainos wallet address. Hyperliquid
-must know this mapping before it will accept your orders.
+the underlying EOA signing key may differ from your onchainos wallet address. Run `register`
+once to detect your actual Hyperliquid signing address and get setup instructions.
 
-**Steps (one time only):**
+```bash
+hyperliquid register
+```
 
-1. Run the following to find your onchainos signer address:
-   ```bash
-   # Place any order preview (no --confirm) and check the "User" in any HL error response,
-   # or run a dry-run and note the recovered address from exchange errors.
-   hyperliquid order --coin ETH --side buy --size 0.001 --confirm --dry-run
-   ```
-   The HL exchange will return an error like:
-   `"User or API Wallet 0xYOUR_SIGNER_ADDRESS does not exist."`
-   That `0xYOUR_SIGNER_ADDRESS` is your actual HL signer.
+The command will either report `"status": "ready"` (no extra setup needed) or
+`"status": "setup_required"` with two options:
 
-2. Go to **https://app.hyperliquid.xyz** → **Settings** → **API Wallets**
+- **Option 1 (recommended):** Deposit USDC directly to the signing address — fully automated
+- **Option 2:** If you already have funds at your onchainos wallet address on HL, register
+  the signing address as an API wallet via the Hyperliquid web UI
 
-3. Click **Add API Wallet** and enter `0xYOUR_SIGNER_ADDRESS`
-
-4. Sign the approval with your connected wallet
-
-After this one-time step, all `order`, `close`, `tpsl`, and `cancel` commands will work.
-
-> **Note:** This is only needed if you are using onchainos with an AA (smart contract) wallet.
-> If your onchainos wallet is a plain EOA, the signer and account addresses are the same
-> and no extra setup is required.
+After setup, all `order`, `close`, `tpsl`, and `cancel` commands will work.
 
 ---
 
@@ -497,6 +489,64 @@ hyperliquid deposit --amount 100 --dry-run
 **Prerequisites:**
 - USDC on Arbitrum (chain ID 42161) — check with `onchainos wallet balance --chain 42161`
 - ETH on Arbitrum for gas (~$0.01)
+
+---
+
+### 8. `register` — Detect onchainos Signing Address
+
+Discovers your actual Hyperliquid signing address (the EOA key onchainos uses to sign EIP-712 actions) and provides setup instructions. **Run this once before placing your first order.**
+
+```bash
+# Detect signing address and show setup instructions
+hyperliquid register
+
+# Show wallet address info only (no network call)
+hyperliquid register --dry-run
+```
+
+**Output (setup required):**
+<external-content>
+```json
+{
+  "ok": true,
+  "status": "setup_required",
+  "onchainos_wallet": "0x87fb...",
+  "hl_signing_address": "0x4880...",
+  "explanation": "onchainos uses an AA (account abstraction) wallet. Hyperliquid recovers the underlying EOA signing key, not the AA wallet address. These are two different addresses.",
+  "options": {
+    "option_1_recommended": {
+      "description": "Deposit USDC directly to your signing address to create a fresh Hyperliquid account tied to your onchainos signing key.",
+      "command": "hyperliquid deposit --amount <USDC_AMOUNT> --to 0x4880...",
+      "note": "This keeps everything in onchainos — no web UI required."
+    },
+    "option_2_existing_account": {
+      "description": "If you already have funds at your onchainos wallet on Hyperliquid, register the signing address as an API wallet via the Hyperliquid web UI.",
+      "url": "https://app.hyperliquid.xyz/settings/api-wallets",
+      "steps": [
+        "1. Go to https://app.hyperliquid.xyz/settings/api-wallets",
+        "2. Click 'Add API Wallet'",
+        "3. Enter your signing address",
+        "4. Sign with your connected wallet"
+      ]
+    }
+  }
+}
+```
+</external-content>
+
+**Output (already ready):**
+<external-content>
+```json
+{
+  "ok": true,
+  "status": "ready",
+  "hl_address": "0x87fb...",
+  "message": "Your onchainos wallet address matches your Hyperliquid signing address. No extra setup needed — orders will work once your account has USDC."
+}
+```
+</external-content>
+
+**Display:** `status`, `hl_signing_address` (if setup_required), and the recommended next step from `options.option_1_recommended.command`.
 
 ---
 

--- a/skills/hyperliquid/src/commands/mod.rs
+++ b/skills/hyperliquid/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod deposit;
 pub mod order;
 pub mod positions;
 pub mod prices;
+pub mod register;
 pub mod tpsl;

--- a/skills/hyperliquid/src/commands/register.rs
+++ b/skills/hyperliquid/src/commands/register.rs
@@ -1,0 +1,146 @@
+// commands/register.rs — Detect and set up the onchainos signing address on Hyperliquid
+//
+// onchainos uses AA wallets. The EVM address shown by `wallet addresses` may differ
+// from the underlying EOA signing key that Hyperliquid recovers from EIP-712 signatures.
+//
+// This command discovers the actual signing address by submitting a signed test request
+// to HL exchange (which returns the recovered signer in the error response), then outputs
+// clear instructions for how to fund and set up that address.
+
+use clap::Args;
+use serde_json::json;
+
+use crate::api::get_asset_index;
+use crate::config::{exchange_url, info_url, now_ms, CHAIN_ID};
+use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
+use crate::signing::{build_market_order_action, submit_exchange_request};
+
+#[derive(Args)]
+pub struct RegisterArgs {
+    /// Skip the signing test; just show wallet address info
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
+    let wallet = resolve_wallet(CHAIN_ID)?;
+
+    if args.dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "onchainos_wallet": wallet,
+                "note": "Run without --dry-run to detect your Hyperliquid signing address via a test signature."
+            }))?
+        );
+        return Ok(());
+    }
+
+    eprintln!("Detecting your Hyperliquid signing address via onchainos...");
+
+    // Build a minimal action — 0-size orders are rejected by HL but still reveal
+    // the recovered signer address in the error response.
+    let nonce = now_ms();
+    let asset_idx = get_asset_index(info_url(), "ETH").await.unwrap_or(1);
+    let dummy_action = build_market_order_action(asset_idx, true, "0", false);
+
+    // Sign through onchainos (real signing required to get HL to reveal signer)
+    let signed = onchainos_hl_sign(&dummy_action, nonce, &wallet, true, false)
+        .map_err(|e| anyhow::anyhow!(
+            "onchainos signing failed: {}. Ensure onchainos is installed and a wallet is configured.",
+            e
+        ))?;
+
+    // Submit to HL — expect an error response containing the recovered signer address
+    let response = submit_exchange_request(exchange_url(), signed).await;
+
+    let signer = match &response {
+        Ok(v) => extract_0x_address(
+            v["response"].as_str().unwrap_or("")
+        ),
+        Err(e) => extract_0x_address(&e.to_string()),
+    };
+
+    let signer = match signer {
+        Some(addr) => addr,
+        None => {
+            // If HL returned ok (shouldn't happen for size=0), signer == wallet
+            if response.as_ref().map(|v| v["status"].as_str() == Some("ok")).unwrap_or(false) {
+                wallet.clone()
+            } else {
+                anyhow::bail!(
+                    "Could not detect signing address from HL response: {:?}",
+                    response
+                );
+            }
+        }
+    };
+
+    let addresses_match = signer.to_lowercase() == wallet.to_lowercase();
+
+    if addresses_match {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "ready",
+                "hl_address": signer,
+                "message": "Your onchainos wallet address matches your Hyperliquid signing address. No extra setup needed — orders will work once your account has USDC."
+            }))?
+        );
+    } else {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "setup_required",
+                "onchainos_wallet": wallet,
+                "hl_signing_address": signer,
+                "explanation": "onchainos uses an AA (account abstraction) wallet. Hyperliquid recovers the underlying EOA signing key, not the AA wallet address. These are two different addresses.",
+                "options": {
+                    "option_1_recommended": {
+                        "description": "Deposit USDC directly to your signing address to create a fresh Hyperliquid account tied to your onchainos signing key.",
+                        "command": format!("hyperliquid deposit --amount <USDC_AMOUNT> --to {}", signer),
+                        "note": "This keeps everything in onchainos — no web UI required."
+                    },
+                    "option_2_existing_account": {
+                        "description": format!(
+                            "If you already have funds at {} on Hyperliquid, register {} as an API wallet via the Hyperliquid web UI.",
+                            wallet, signer
+                        ),
+                        "url": "https://app.hyperliquid.xyz/settings/api-wallets",
+                        "steps": [
+                            format!("1. Go to https://app.hyperliquid.xyz/settings/api-wallets"),
+                            format!("2. Click 'Add API Wallet'"),
+                            format!("3. Enter your signing address: {}", signer),
+                            "4. Sign with your connected wallet"
+                        ]
+                    }
+                }
+            }))?
+        );
+    }
+
+    Ok(())
+}
+
+/// Extract the first `0x` + 40 hex char address from a string.
+fn extract_0x_address(s: &str) -> Option<String> {
+    let lower = s.to_lowercase();
+    let start = lower.find("0x")?;
+    let rest = &s[start..];
+    let end = rest
+        .char_indices()
+        .skip(2) // skip "0x"
+        .take_while(|(_, c)| c.is_ascii_hexdigit())
+        .last()
+        .map(|(i, _)| i + 1)
+        .unwrap_or(2);
+    if end == 42 {
+        // Exactly 40 hex chars = valid EVM address
+        Some(rest[..42].to_lowercase())
+    } else {
+        None
+    }
+}

--- a/skills/hyperliquid/src/main.rs
+++ b/skills/hyperliquid/src/main.rs
@@ -13,6 +13,7 @@ use commands::{
     order::OrderArgs,
     positions::PositionsArgs,
     prices::PricesArgs,
+    register::RegisterArgs,
     tpsl::TpslArgs,
 };
 
@@ -43,6 +44,8 @@ enum Commands {
     Cancel(CancelArgs),
     /// Deposit USDC from Arbitrum to Hyperliquid via the official bridge
     Deposit(DepositArgs),
+    /// Detect your onchainos signing address on Hyperliquid and show setup instructions
+    Register(RegisterArgs),
 }
 
 #[tokio::main]
@@ -56,5 +59,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Tpsl(args) => commands::tpsl::run(args).await,
         Commands::Cancel(args) => commands::cancel::run(args).await,
         Commands::Deposit(args) => commands::deposit::run(args).await,
+        Commands::Register(args) => commands::register::run(args).await,
     }
 }


### PR DESCRIPTION
## Summary

- Adds `hyperliquid register` command to detect the actual EOA signing address Hyperliquid uses for onchainos AA wallets
- onchainos AA wallet address differs from the underlying EOA signing key that HL recovers from EIP-712 signatures — this causes "User does not exist" errors on order submission
- `register` discovers the signer by submitting a test signed action to HL and parsing the recovered address from the error response
- Outputs either `"status": "ready"` (no setup needed) or `"status": "setup_required"` with two options:
  1. **Option 1 (recommended):** `hyperliquid deposit --to <signer_addr>` — fully automated, no web UI
  2. **Option 2:** Register signer as API wallet via HL web UI if funds already exist at AA wallet address
- Updates SKILL.md: replaces manual setup instructions with `hyperliquid register` command and adds full command documentation

## Checklist
- [x] plugin.yaml complete
- [x] SKILL.md documents `register` command with `<external-content>` tags
- [x] `cargo build --release` succeeds
- [x] `register --dry-run` returns wallet info without network call
- [x] `register` (live) correctly discovers EOA signer address from HL error response
- [x] All on-chain operations go through onchainos

🤖 Generated with [Claude Code](https://claude.ai/claude-code)