### PR TITLE
feat(hyperliquid): fix EIP-712 signing + add orders/batch-cancel commands

### DIFF
--- a/skills/hyperliquid/SKILL.md
+++ b/skills/hyperliquid/SKILL.md
@@ -123,40 +123,32 @@ Use this plugin when the user says (in any language):
 - "HL stop loss" / HL止损
 - "HL take profit" / HL止盈
 - "close my HL position" / 平掉我的HL仓位
+- "register Hyperliquid" / Hyperliquid注册签名地址
+- "setup Hyperliquid wallet" / 设置Hyperliquid钱包
+- "Hyperliquid signing address" / Hyperliquid签名地址
 
 ---
 
-## One-time Setup: Register API Wallet
+## One-time Setup: Register Your Signing Address
 
 > **Required before placing any order, close, or TP/SL.**
 
 onchainos uses an AA (account abstraction) wallet. When signing Hyperliquid L1 actions,
-the underlying EOA signer address differs from your onchainos wallet address. Hyperliquid
-must know this mapping before it will accept your orders.
+the underlying EOA signing key may differ from your onchainos wallet address. Run `register`
+once to detect your actual Hyperliquid signing address and get setup instructions.
 
-**Steps (one time only):**
+```bash
+hyperliquid register
+```
 
-1. Run the following to find your onchainos signer address:
-   ```bash
-   # Place any order preview (no --confirm) and check the "User" in any HL error response,
-   # or run a dry-run and note the recovered address from exchange errors.
-   hyperliquid order --coin ETH --side buy --size 0.001 --confirm --dry-run
-   ```
-   The HL exchange will return an error like:
-   `"User or API Wallet 0xYOUR_SIGNER_ADDRESS does not exist."`
-   That `0xYOUR_SIGNER_ADDRESS` is your actual HL signer.
+The command will either report `"status": "ready"` (no extra setup needed) or
+`"status": "setup_required"` with two options:
 
-2. Go to **https://app.hyperliquid.xyz** → **Settings** → **API Wallets**
+- **Option 1 (recommended):** Deposit USDC directly to the signing address — fully automated
+- **Option 2:** If you already have funds at your onchainos wallet address on HL, register
+  the signing address as an API wallet via the Hyperliquid web UI
 
-3. Click **Add API Wallet** and enter `0xYOUR_SIGNER_ADDRESS`
-
-4. Sign the approval with your connected wallet
-
-After this one-time step, all `order`, `close`, `tpsl`, and `cancel` commands will work.
-
-> **Note:** This is only needed if you are using onchainos with an AA (smart contract) wallet.
-> If your onchainos wallet is a plain EOA, the signer and account addresses are the same
-> and no extra setup is required.
+After setup, all `order`, `close`, `tpsl`, and `cancel` commands will work.
 
 ---
 
@@ -497,6 +489,64 @@ hyperliquid deposit --amount 100 --dry-run
 **Prerequisites:**
 - USDC on Arbitrum (chain ID 42161) — check with `onchainos wallet balance --chain 42161`
 - ETH on Arbitrum for gas (~$0.01)
+
+---
+
+### 8. `register` — Detect onchainos Signing Address
+
+Discovers your actual Hyperliquid signing address (the EOA key onchainos uses to sign EIP-712 actions) and provides setup instructions. **Run this once before placing your first order.**
+
+```bash
+# Detect signing address and show setup instructions
+hyperliquid register
+
+# Show wallet address info only (no network call)
+hyperliquid register --dry-run
+```
+
+**Output (setup required):**
+<external-content>
+```json
+{
+  "ok": true,
+  "status": "setup_required",
+  "onchainos_wallet": "0x87fb...",
+  "hl_signing_address": "0x4880...",
+  "explanation": "onchainos uses an AA (account abstraction) wallet. Hyperliquid recovers the underlying EOA signing key, not the AA wallet address. These are two different addresses.",
+  "options": {
+    "option_1_recommended": {
+      "description": "Deposit USDC directly to your signing address to create a fresh Hyperliquid account tied to your onchainos signing key.",
+      "command": "hyperliquid deposit --amount <USDC_AMOUNT> --to 0x4880...",
+      "note": "This keeps everything in onchainos — no web UI required."
+    },
+    "option_2_existing_account": {
+      "description": "If you already have funds at your onchainos wallet on Hyperliquid, register the signing address as an API wallet via the Hyperliquid web UI.",
+      "url": "https://app.hyperliquid.xyz/settings/api-wallets",
+      "steps": [
+        "1. Go to https://app.hyperliquid.xyz/settings/api-wallets",
+        "2. Click 'Add API Wallet'",
+        "3. Enter your signing address",
+        "4. Sign with your connected wallet"
+      ]
+    }
+  }
+}
+```
+</external-content>
+
+**Output (already ready):**
+<external-content>
+```json
+{
+  "ok": true,
+  "status": "ready",
+  "hl_address": "0x87fb...",
+  "message": "Your onchainos wallet address matches your Hyperliquid signing address. No extra setup needed — orders will work once your account has USDC."
+}
+```
+</external-content>
+
+**Display:** `status`, `hl_signing_address` (if setup_required), and the recommended next step from `options.option_1_recommended.command`.
 
 ---
 

--- a/skills/hyperliquid/src/api.rs
+++ b/skills/hyperliquid/src/api.rs
@@ -63,6 +63,12 @@ pub async fn get_meta(info_url: &str) -> anyhow::Result<Value> {
 /// Look up the asset index for a coin symbol from meta.
 /// Returns None if the coin is not found.
 pub async fn get_asset_index(info_url: &str, coin: &str) -> anyhow::Result<usize> {
+    let (idx, _) = get_asset_meta(info_url, coin).await?;
+    Ok(idx)
+}
+
+/// Look up the asset index AND szDecimals for a coin symbol from meta.
+pub async fn get_asset_meta(info_url: &str, coin: &str) -> anyhow::Result<(usize, u32)> {
     let meta = get_meta(info_url).await?;
     let universe = meta["universe"]
         .as_array()
@@ -72,7 +78,8 @@ pub async fn get_asset_index(info_url: &str, coin: &str) -> anyhow::Result<usize
     for (i, asset) in universe.iter().enumerate() {
         if let Some(name) = asset["name"].as_str() {
             if name.to_uppercase() == coin_upper {
-                return Ok(i);
+                let sz_dec = asset["szDecimals"].as_u64().unwrap_or(4) as u32;
+                return Ok((i, sz_dec));
             }
         }
     }

--- a/skills/hyperliquid/src/commands/cancel.rs
+++ b/skills/hyperliquid/src/commands/cancel.rs
@@ -1,18 +1,24 @@
 use clap::Args;
-use crate::api::{get_asset_index, get_open_orders};
-use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID};
+use crate::api::{get_asset_index, get_meta, get_open_orders};
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
-use crate::signing::{build_cancel_action, submit_exchange_request};
+use crate::signing::{build_cancel_action, build_batch_cancel_action, submit_exchange_request};
 
 #[derive(Args)]
 pub struct CancelArgs {
-    /// Order ID to cancel
+    /// Cancel a specific order by ID. Also requires --coin.
     #[arg(long)]
-    pub order_id: u64,
+    pub order_id: Option<u64>,
 
-    /// Coin symbol (e.g. BTC, ETH). Required to determine asset index.
+    /// Coin symbol (e.g. BTC, ETH).
+    /// With --order-id: required to resolve asset index.
+    /// Without --order-id: cancels ALL open orders for this coin.
     #[arg(long)]
-    pub coin: String,
+    pub coin: Option<String>,
+
+    /// Cancel ALL open orders across all coins.
+    #[arg(long, conflicts_with_all = ["order_id", "coin"])]
+    pub all: bool,
 
     /// Dry run — preview cancel payload without signing or submitting
     #[arg(long)]
@@ -26,24 +32,154 @@ pub struct CancelArgs {
 pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
     let info = info_url();
     let exchange = exchange_url();
-
-    let coin = normalize_coin(&args.coin);
     let nonce = now_ms();
 
-    // Look up asset index
-    let asset_idx = get_asset_index(info, &coin).await?;
+    let wallet = resolve_wallet(CHAIN_ID)?;
 
-    // Build cancel action
-    let action = build_cancel_action(asset_idx, args.order_id);
+    // ── Determine which orders to cancel ──────────────────────────────────────
 
-    // Show preview
+    // Case 1: single order by ID
+    if let Some(oid) = args.order_id {
+        let coin = args
+            .coin
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("--coin is required when using --order-id"))?;
+        let coin = normalize_coin(coin);
+        let asset_idx = get_asset_index(info, &coin).await?;
+        let action = build_cancel_action(asset_idx, oid);
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "preview": {
+                    "mode": "single",
+                    "coin": coin,
+                    "assetIndex": asset_idx,
+                    "orderId": oid,
+                    "nonce": nonce
+                },
+                "action": action
+            }))?
+        );
+
+        if args.dry_run {
+            println!("\n[DRY RUN] Cancel not signed or submitted.");
+            return Ok(());
+        }
+        if !args.confirm {
+            println!("\n[PREVIEW] Add --confirm to sign and submit this cancellation.");
+            return Ok(());
+        }
+
+        let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
+        let result = submit_exchange_request(exchange, signed).await?;
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "mode": "single",
+                "coin": coin,
+                "orderId": oid,
+                "result": result
+            }))?
+        );
+        return Ok(());
+    }
+
+    // Case 2: batch by coin or --all — fetch open orders first
+    let open_orders = get_open_orders(info, &wallet).await?;
+    let empty_vec = vec![];
+    let all_orders = open_orders.as_array().unwrap_or(&empty_vec);
+
+    if all_orders.is_empty() {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "message": "No open orders to cancel."
+        }))?);
+        return Ok(());
+    }
+
+    // Filter by coin if provided
+    let coin_filter = args.coin.as_deref().map(normalize_coin);
+
+    let to_cancel: Vec<_> = all_orders
+        .iter()
+        .filter(|o| {
+            if let Some(ref f) = coin_filter {
+                o["coin"].as_str().map(|c| c.to_uppercase()) == Some(f.clone())
+            } else {
+                true // --all
+            }
+        })
+        .collect();
+
+    if to_cancel.is_empty() {
+        let msg = if let Some(ref f) = coin_filter {
+            format!("No open orders found for {}.", f)
+        } else {
+            "No open orders to cancel.".to_string()
+        };
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "message": msg
+        }))?);
+        return Ok(());
+    }
+
+    // Build asset index map from meta (one call instead of N)
+    let meta = get_meta(info).await?;
+    let universe = meta["universe"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("meta.universe missing"))?;
+
+    let get_asset_idx = |coin_name: &str| -> Option<usize> {
+        let upper = coin_name.to_uppercase();
+        universe
+            .iter()
+            .enumerate()
+            .find(|(_, a)| a["name"].as_str().map(|n| n.to_uppercase()) == Some(upper.clone()))
+            .map(|(i, _)| i)
+    };
+
+    let mut batch: Vec<(usize, u64)> = Vec::new();
+    let mut preview_list = Vec::new();
+
+    for o in &to_cancel {
+        let coin_name = o["coin"].as_str().unwrap_or("?");
+        let oid = match o["oid"].as_u64() {
+            Some(id) => id,
+            None => continue,
+        };
+        let limit_px = o["limitPx"].as_str().unwrap_or("?");
+        let sz = o["sz"].as_str().unwrap_or("?");
+
+        let asset_idx = get_asset_idx(coin_name)
+            .ok_or_else(|| anyhow::anyhow!("Coin '{}' not found in universe", coin_name))?;
+
+        batch.push((asset_idx, oid));
+        preview_list.push(serde_json::json!({
+            "coin": coin_name,
+            "oid": oid,
+            "limitPrice": limit_px,
+            "size": sz
+        }));
+    }
+
+    let action = build_batch_cancel_action(&batch);
+
+    let mode = if coin_filter.is_some() {
+        format!("cancel-by-coin ({})", coin_filter.as_deref().unwrap_or("?"))
+    } else {
+        "cancel-all".to_string()
+    };
+
     println!(
         "{}",
         serde_json::to_string_pretty(&serde_json::json!({
             "preview": {
-                "coin": coin,
-                "assetIndex": asset_idx,
-                "orderId": args.order_id,
+                "mode": mode,
+                "count": batch.len(),
+                "orders": preview_list,
                 "nonce": nonce
             },
             "action": action
@@ -54,41 +190,19 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
         println!("\n[DRY RUN] Cancel not signed or submitted.");
         return Ok(());
     }
-
     if !args.confirm {
-        println!("\n[PREVIEW] Add --confirm to sign and submit this cancellation.");
+        println!("\n[PREVIEW] Add --confirm to sign and submit this batch cancellation.");
         return Ok(());
     }
 
-    // Resolve wallet
-    let wallet = resolve_wallet(CHAIN_ID)?;
-
-    // Verify the order exists before cancelling
-    let open_orders = get_open_orders(info, &wallet).await?;
-    let order_exists = open_orders
-        .as_array()
-        .map(|arr| arr.iter().any(|o| o["oid"].as_u64() == Some(args.order_id)))
-        .unwrap_or(false);
-
-    if !order_exists {
-        eprintln!(
-            "Warning: order {} not found in open orders for {}. Proceeding anyway.",
-            args.order_id, wallet
-        );
-    }
-
-    // Sign via onchainos
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, true, false)?;
-
-    // Submit to exchange
+    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
     let result = submit_exchange_request(exchange, signed).await?;
 
     println!(
         "{}",
         serde_json::to_string_pretty(&serde_json::json!({
             "ok": true,
-            "coin": coin,
-            "orderId": args.order_id,
+            "cancelled": batch.len(),
             "result": result
         }))?
     );

--- a/skills/hyperliquid/src/commands/close.rs
+++ b/skills/hyperliquid/src/commands/close.rs
@@ -1,8 +1,8 @@
 use clap::Args;
-use crate::api::{get_asset_index, get_all_mids, get_clearinghouse_state};
-use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID};
+use crate::api::{get_asset_meta, get_all_mids, get_clearinghouse_state};
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
-use crate::signing::{build_close_action, submit_exchange_request};
+use crate::signing::{build_close_action, market_slippage_px, submit_exchange_request};
 
 #[derive(Args)]
 pub struct CloseArgs {
@@ -30,8 +30,8 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     let coin = normalize_coin(&args.coin);
     let nonce = now_ms();
 
-    // Look up asset index
-    let asset_idx = get_asset_index(info, &coin).await?;
+    // Look up asset index and sz_decimals for price rounding
+    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
 
     // Resolve wallet
     let wallet = resolve_wallet(CHAIN_ID)?;
@@ -93,8 +93,11 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
         .unwrap_or("unknown");
 
     let closing_side = if position_is_long { "sell" } else { "buy" };
+    let close_is_buy = !position_is_long;
+    let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
+    let slippage_px_str = market_slippage_px(mid_f, close_is_buy, sz_decimals);
 
-    let action = build_close_action(asset_idx, position_is_long, &close_size);
+    let action = build_close_action(asset_idx, position_is_long, &close_size, &slippage_px_str);
 
     println!(
         "{}",
@@ -125,7 +128,7 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, true, false)?;
+    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
     let result = submit_exchange_request(exchange, signed).await?;
 
     println!(

--- a/skills/hyperliquid/src/commands/mod.rs
+++ b/skills/hyperliquid/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod cancel;
 pub mod close;
 pub mod deposit;
 pub mod order;
+pub mod orders;
 pub mod positions;
 pub mod prices;
 pub mod register;

--- a/skills/hyperliquid/src/commands/mod.rs
+++ b/skills/hyperliquid/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod deposit;
 pub mod order;
 pub mod positions;
 pub mod prices;
+pub mod register;
 pub mod tpsl;

--- a/skills/hyperliquid/src/commands/order.rs
+++ b/skills/hyperliquid/src/commands/order.rs
@@ -1,10 +1,10 @@
 use clap::Args;
-use crate::api::{get_asset_index, get_all_mids};
-use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID};
+use crate::api::{get_asset_meta, get_all_mids};
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
 use crate::signing::{
     build_bracketed_order_action, build_limit_order_action, build_market_order_action,
-    format_px, submit_exchange_request,
+    format_px, market_slippage_px, submit_exchange_request,
 };
 
 #[derive(Args)]
@@ -73,13 +73,18 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         }
     }
 
-    let asset_idx = get_asset_index(info, &coin).await?;
+    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
 
     let mids = get_all_mids(info).await?;
     let current_price = mids
         .get(&coin)
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
+
+    // Slippage-protected price for market orders — 5% tolerance, rounded to HL's
+    // sz_decimals significant figures (matches Python SDK round_to_sz_decimals).
+    let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
+    let slippage_px_str = market_slippage_px(mid_f, is_buy, sz_decimals);
 
     let has_bracket = args.sl_px.is_some() || args.tp_px.is_some();
 
@@ -89,16 +94,10 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             "market" => serde_json::json!({
                 "a": asset_idx,
                 "b": is_buy,
-                "p": "0",
+                "p": slippage_px_str,
                 "s": args.size,
                 "r": args.reduce_only,
-                "t": {
-                    "trigger": {
-                        "isMarket": true,
-                        "tpsl": "tp",
-                        "triggerPx": "0"
-                    }
-                }
+                "t": { "limit": { "tif": "Ioc" } }
             }),
             "limit" => {
                 let price_str = args
@@ -133,7 +132,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         )
     } else {
         match args.r#type.as_str() {
-            "market" => build_market_order_action(asset_idx, is_buy, &args.size, args.reduce_only),
+            "market" => build_market_order_action(asset_idx, is_buy, &args.size, args.reduce_only, &slippage_px_str),
             "limit" => {
                 let price_str = args
                     .price
@@ -182,7 +181,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     }
 
     let wallet = resolve_wallet(CHAIN_ID)?;
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, true, false)?;
+    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
     let result = submit_exchange_request(exchange, signed).await?;
 
     println!(

--- a/skills/hyperliquid/src/commands/orders.rs
+++ b/skills/hyperliquid/src/commands/orders.rs
@@ -1,0 +1,81 @@
+use clap::Args;
+use crate::api::get_open_orders;
+use crate::config::{info_url, normalize_coin, CHAIN_ID};
+use crate::onchainos::resolve_wallet;
+
+#[derive(Args)]
+pub struct OrdersArgs {
+    /// Filter by coin (e.g. BTC, ETH). If omitted, shows all open orders.
+    #[arg(long)]
+    pub coin: Option<String>,
+
+    /// Wallet address to query. Defaults to the connected onchainos wallet.
+    #[arg(long)]
+    pub address: Option<String>,
+}
+
+pub async fn run(args: OrdersArgs) -> anyhow::Result<()> {
+    let url = info_url();
+
+    let address = match args.address {
+        Some(addr) => addr,
+        None => resolve_wallet(CHAIN_ID)?,
+    };
+
+    let orders = get_open_orders(url, &address).await?;
+
+    let empty_vec = vec![];
+    let all_orders = orders.as_array().unwrap_or(&empty_vec);
+
+    let coin_filter = args.coin.map(|c| normalize_coin(&c));
+
+    let mut out = Vec::new();
+    for o in all_orders {
+        let coin = o["coin"].as_str().unwrap_or("?");
+        if let Some(ref filter) = coin_filter {
+            if coin.to_uppercase() != *filter {
+                continue;
+            }
+        }
+
+        let side_raw = o["side"].as_str().unwrap_or("?");
+        let side = match side_raw {
+            "B" => "buy",
+            "A" => "sell",
+            other => other,
+        };
+
+        let limit_px = o["limitPx"].as_str().unwrap_or("?");
+        let sz = o["sz"].as_str().unwrap_or("?");
+        let orig_sz = o["origSz"].as_str().unwrap_or(sz);
+        let oid = o["oid"].as_u64().unwrap_or(0);
+        let timestamp = o["timestamp"].as_u64().unwrap_or(0);
+        let reduce_only = o["reduceOnly"].as_bool().unwrap_or(false);
+
+        // Determine order type label
+        let order_type = if reduce_only { "reduce-only (TP/SL)" } else { "limit" };
+
+        out.push(serde_json::json!({
+            "oid": oid,
+            "coin": coin,
+            "side": side,
+            "limitPrice": limit_px,
+            "size": sz,
+            "origSize": orig_sz,
+            "type": order_type,
+            "timestamp": timestamp
+        }));
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "address": address,
+            "count": out.len(),
+            "orders": out
+        }))?
+    );
+
+    Ok(())
+}

--- a/skills/hyperliquid/src/commands/prices.rs
+++ b/skills/hyperliquid/src/commands/prices.rs
@@ -7,14 +7,14 @@ pub struct PricesArgs {
     /// Specific coin to get price for (e.g. BTC, ETH, SOL).
     /// If omitted, returns all market mid prices.
     #[arg(long)]
-    pub market: Option<String>,
+    pub coin: Option<String>,
 }
 
 pub async fn run(args: PricesArgs) -> anyhow::Result<()> {
     let url = info_url();
     let mids = get_all_mids(url).await?;
 
-    match args.market {
+    match args.coin {
         Some(coin) => {
             let coin_upper = normalize_coin(&coin);
             match mids.get(&coin_upper) {
@@ -30,7 +30,7 @@ pub async fn run(args: PricesArgs) -> anyhow::Result<()> {
                 }
                 None => {
                     anyhow::bail!(
-                        "Coin '{}' not found. Check spelling or run `hyperliquid prices` without --market to list all coins.",
+                        "Coin '{}' not found. Check spelling or run `hyperliquid prices` without --coin to list all coins.",
                         coin_upper
                     );
                 }

--- a/skills/hyperliquid/src/commands/register.rs
+++ b/skills/hyperliquid/src/commands/register.rs
@@ -11,7 +11,7 @@ use clap::Args;
 use serde_json::json;
 
 use crate::api::get_asset_index;
-use crate::config::{exchange_url, info_url, now_ms, CHAIN_ID};
+use crate::config::{exchange_url, info_url, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
 use crate::signing::{build_market_order_action, submit_exchange_request};
 
@@ -43,10 +43,11 @@ pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
     // the recovered signer address in the error response.
     let nonce = now_ms();
     let asset_idx = get_asset_index(info_url(), "ETH").await.unwrap_or(1);
-    let dummy_action = build_market_order_action(asset_idx, true, "0", false);
+    // Price "0" is intentionally invalid — we want HL to reject this but reveal the signer.
+    let dummy_action = build_market_order_action(asset_idx, true, "0", false, "0");
 
     // Sign through onchainos (real signing required to get HL to reveal signer)
-    let signed = onchainos_hl_sign(&dummy_action, nonce, &wallet, true, false)
+    let signed = onchainos_hl_sign(&dummy_action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)
         .map_err(|e| anyhow::anyhow!(
             "onchainos signing failed: {}. Ensure onchainos is installed and a wallet is configured.",
             e

--- a/skills/hyperliquid/src/commands/register.rs
+++ b/skills/hyperliquid/src/commands/register.rs
@@ -1,0 +1,146 @@
+// commands/register.rs — Detect and set up the onchainos signing address on Hyperliquid
+//
+// onchainos uses AA wallets. The EVM address shown by `wallet addresses` may differ
+// from the underlying EOA signing key that Hyperliquid recovers from EIP-712 signatures.
+//
+// This command discovers the actual signing address by submitting a signed test request
+// to HL exchange (which returns the recovered signer in the error response), then outputs
+// clear instructions for how to fund and set up that address.
+
+use clap::Args;
+use serde_json::json;
+
+use crate::api::get_asset_index;
+use crate::config::{exchange_url, info_url, now_ms, CHAIN_ID};
+use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
+use crate::signing::{build_market_order_action, submit_exchange_request};
+
+#[derive(Args)]
+pub struct RegisterArgs {
+    /// Skip the signing test; just show wallet address info
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
+    let wallet = resolve_wallet(CHAIN_ID)?;
+
+    if args.dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "onchainos_wallet": wallet,
+                "note": "Run without --dry-run to detect your Hyperliquid signing address via a test signature."
+            }))?
+        );
+        return Ok(());
+    }
+
+    eprintln!("Detecting your Hyperliquid signing address via onchainos...");
+
+    // Build a minimal action — 0-size orders are rejected by HL but still reveal
+    // the recovered signer address in the error response.
+    let nonce = now_ms();
+    let asset_idx = get_asset_index(info_url(), "ETH").await.unwrap_or(1);
+    let dummy_action = build_market_order_action(asset_idx, true, "0", false);
+
+    // Sign through onchainos (real signing required to get HL to reveal signer)
+    let signed = onchainos_hl_sign(&dummy_action, nonce, &wallet, true, false)
+        .map_err(|e| anyhow::anyhow!(
+            "onchainos signing failed: {}. Ensure onchainos is installed and a wallet is configured.",
+            e
+        ))?;
+
+    // Submit to HL — expect an error response containing the recovered signer address
+    let response = submit_exchange_request(exchange_url(), signed).await;
+
+    let signer = match &response {
+        Ok(v) => extract_0x_address(
+            v["response"].as_str().unwrap_or("")
+        ),
+        Err(e) => extract_0x_address(&e.to_string()),
+    };
+
+    let signer = match signer {
+        Some(addr) => addr,
+        None => {
+            // If HL returned ok (shouldn't happen for size=0), signer == wallet
+            if response.as_ref().map(|v| v["status"].as_str() == Some("ok")).unwrap_or(false) {
+                wallet.clone()
+            } else {
+                anyhow::bail!(
+                    "Could not detect signing address from HL response: {:?}",
+                    response
+                );
+            }
+        }
+    };
+
+    let addresses_match = signer.to_lowercase() == wallet.to_lowercase();
+
+    if addresses_match {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "ready",
+                "hl_address": signer,
+                "message": "Your onchainos wallet address matches your Hyperliquid signing address. No extra setup needed — orders will work once your account has USDC."
+            }))?
+        );
+    } else {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "setup_required",
+                "onchainos_wallet": wallet,
+                "hl_signing_address": signer,
+                "explanation": "onchainos uses an AA (account abstraction) wallet. Hyperliquid recovers the underlying EOA signing key, not the AA wallet address. These are two different addresses.",
+                "options": {
+                    "option_1_recommended": {
+                        "description": "Deposit USDC directly to your signing address to create a fresh Hyperliquid account tied to your onchainos signing key.",
+                        "command": format!("hyperliquid deposit --amount <USDC_AMOUNT> --to {}", signer),
+                        "note": "This keeps everything in onchainos — no web UI required."
+                    },
+                    "option_2_existing_account": {
+                        "description": format!(
+                            "If you already have funds at {} on Hyperliquid, register {} as an API wallet via the Hyperliquid web UI.",
+                            wallet, signer
+                        ),
+                        "url": "https://app.hyperliquid.xyz/settings/api-wallets",
+                        "steps": [
+                            format!("1. Go to https://app.hyperliquid.xyz/settings/api-wallets"),
+                            format!("2. Click 'Add API Wallet'"),
+                            format!("3. Enter your signing address: {}", signer),
+                            "4. Sign with your connected wallet"
+                        ]
+                    }
+                }
+            }))?
+        );
+    }
+
+    Ok(())
+}
+
+/// Extract the first `0x` + 40 hex char address from a string.
+fn extract_0x_address(s: &str) -> Option<String> {
+    let lower = s.to_lowercase();
+    let start = lower.find("0x")?;
+    let rest = &s[start..];
+    let end = rest
+        .char_indices()
+        .skip(2) // skip "0x"
+        .take_while(|(_, c)| c.is_ascii_hexdigit())
+        .last()
+        .map(|(i, _)| i + 1)
+        .unwrap_or(2);
+    if end == 42 {
+        // Exactly 40 hex chars = valid EVM address
+        Some(rest[..42].to_lowercase())
+    } else {
+        None
+    }
+}

--- a/skills/hyperliquid/src/commands/tpsl.rs
+++ b/skills/hyperliquid/src/commands/tpsl.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use crate::api::{get_asset_index, get_all_mids, get_clearinghouse_state};
-use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID};
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
 use crate::signing::{build_standalone_tpsl_action, format_px, submit_exchange_request};
 
@@ -201,7 +201,7 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, true, false)?;
+    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
     let result = submit_exchange_request(exchange, signed).await?;
 
     println!(

--- a/skills/hyperliquid/src/main.rs
+++ b/skills/hyperliquid/src/main.rs
@@ -11,6 +11,7 @@ use commands::{
     close::CloseArgs,
     deposit::DepositArgs,
     order::OrderArgs,
+    orders::OrdersArgs,
     positions::PositionsArgs,
     prices::PricesArgs,
     register::RegisterArgs,
@@ -32,6 +33,8 @@ struct Cli {
 enum Commands {
     /// Show open perpetual positions, unrealized PnL, and margin summary
     Positions(PositionsArgs),
+    /// List open orders (limit, TP/SL); optionally filter by coin
+    Orders(OrdersArgs),
     /// Get current mid prices for all markets or a specific coin
     Prices(PricesArgs),
     /// Place a market or limit order; optionally attach TP/SL bracket (requires --confirm)
@@ -53,6 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Positions(args) => commands::positions::run(args).await,
+        Commands::Orders(args) => commands::orders::run(args).await,
         Commands::Prices(args) => commands::prices::run(args).await,
         Commands::Order(args) => commands::order::run(args).await,
         Commands::Close(args) => commands::close::run(args).await,

--- a/skills/hyperliquid/src/main.rs
+++ b/skills/hyperliquid/src/main.rs
@@ -13,6 +13,7 @@ use commands::{
     order::OrderArgs,
     positions::PositionsArgs,
     prices::PricesArgs,
+    register::RegisterArgs,
     tpsl::TpslArgs,
 };
 
@@ -43,6 +44,8 @@ enum Commands {
     Cancel(CancelArgs),
     /// Deposit USDC from Arbitrum to Hyperliquid via the official bridge
     Deposit(DepositArgs),
+    /// Detect your onchainos signing address on Hyperliquid and show setup instructions
+    Register(RegisterArgs),
 }
 
 #[tokio::main]
@@ -56,5 +59,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Tpsl(args) => commands::tpsl::run(args).await,
         Commands::Cancel(args) => commands::cancel::run(args).await,
         Commands::Deposit(args) => commands::deposit::run(args).await,
+        Commands::Register(args) => commands::register::run(args).await,
     }
 }

--- a/skills/hyperliquid/src/onchainos.rs
+++ b/skills/hyperliquid/src/onchainos.rs
@@ -128,6 +128,8 @@ pub fn onchainos_sign_eip712(typed_data: &serde_json::Value, wallet: &str) -> an
 /// Uses `onchainos wallet sign-message --type eip712` with the Hyperliquid
 /// EIP-712 typed data structure for L1 action signing.
 ///
+/// wallet_chain_id: the EVM chain ID used to resolve the wallet (passed to --chain so
+///                  onchainos selects the same key it resolved the wallet with).
 /// dry_run: if true, returns the unsigned preview payload without submitting.
 /// confirm: if false (no --confirm flag), returns the preview payload for review.
 ///          if true, proceeds to sign and submit.
@@ -135,6 +137,7 @@ pub fn onchainos_hl_sign(
     action: &Value,
     nonce: u64,
     wallet: &str,
+    wallet_chain_id: u64,
     confirm: bool,
     dry_run: bool,
 ) -> anyhow::Result<Value> {
@@ -173,23 +176,28 @@ pub fn onchainos_hl_sign(
     hasher.update(&hash_input);
     let digest = hasher.finalize();
     let connection_id = format!("0x{}", hex::encode(digest));
+
+
+    // EIP-712 typed data — field order matches HL Python SDK exactly:
+    // domain: chainId, name, verifyingContract, version
+    // types: Agent first, EIP712Domain second (required by onchainos for correct hash)
     let eip712_message = serde_json::json!({
         "domain": {
-            "name": "Exchange",
-            "version": "1",
             "chainId": 1337,
-            "verifyingContract": "0x0000000000000000000000000000000000000000"
+            "name": "Exchange",
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+            "version": "1"
         },
         "types": {
+            "Agent": [
+                { "name": "source",       "type": "string"  },
+                { "name": "connectionId", "type": "bytes32" }
+            ],
             "EIP712Domain": [
                 { "name": "name",              "type": "string"  },
                 { "name": "version",           "type": "string"  },
                 { "name": "chainId",           "type": "uint256" },
                 { "name": "verifyingContract", "type": "address" }
-            ],
-            "Agent": [
-                { "name": "source",       "type": "string"  },
-                { "name": "connectionId", "type": "bytes32" }
             ]
         },
         "primaryType": "Agent",
@@ -201,6 +209,7 @@ pub fn onchainos_hl_sign(
 
     let eip712_str = serde_json::to_string(&eip712_message)?;
 
+    let wallet_chain_str = wallet_chain_id.to_string();
     let output = Command::new("onchainos")
         .args([
             "wallet",
@@ -210,7 +219,7 @@ pub fn onchainos_hl_sign(
             "--message",
             &eip712_str,
             "--chain",
-            "1",
+            &wallet_chain_str,
             "--from",
             wallet,
         ])

--- a/skills/hyperliquid/src/signing.rs
+++ b/skills/hyperliquid/src/signing.rs
@@ -15,6 +15,48 @@ pub fn format_px(px: f64) -> String {
     s.to_string()
 }
 
+/// Round a price to the correct number of decimal places for a given coin,
+/// matching the Python SDK's round_to_sz_decimals(px, sz_decimals) logic.
+/// This rounds to `sz_decimals` significant figures.
+///
+/// Example: ETH sz_decimals=4, price=2098.4 → 4 sig figs → round to 0 dp → "2098"
+pub fn round_px(px: f64, sz_decimals: u32) -> String {
+    if px == 0.0 {
+        return "0".to_string();
+    }
+    if sz_decimals == 0 {
+        return format!("{}", px.round() as i64);
+    }
+    let mag = px.abs().log10().floor() as i32;
+    let decimal_places = (sz_decimals as i32) - mag - 1;
+    let rounded = if decimal_places <= 0 {
+        let factor = 10_f64.powi(-decimal_places);
+        (px / factor).round() * factor
+    } else {
+        let factor = 10_f64.powi(decimal_places);
+        (px * factor).round() / factor
+    };
+    // For integer results (decimal_places ≤ 0), return as-is — no trimming to avoid
+    // stripping significant zeros (e.g. "2100" → "21" if trimmed).
+    // For decimal results, trim trailing zeros after the decimal point.
+    if decimal_places <= 0 {
+        format!("{:.0}", rounded)
+    } else {
+        let s = format!("{:.prec$}", rounded, prec = decimal_places as usize);
+        let s = s.trim_end_matches('0').trim_end_matches('.');
+        s.to_string()
+    }
+}
+
+/// Compute slippage-protected price for a market order.
+/// is_buy=true → price * 1.05 (pay up to 5% above mid)
+/// is_buy=false → price * 0.95 (accept down to 5% below mid)
+/// Rounds to sz_decimals significant figures to match HL's validation.
+pub fn market_slippage_px(mid_px: f64, is_buy: bool, sz_decimals: u32) -> String {
+    let px = if is_buy { mid_px * 1.05 } else { mid_px * 0.95 };
+    round_px(px, sz_decimals)
+}
+
 /// Slippage-protected limit price for market trigger orders.
 /// When a trigger fires as "market", HL still needs a worst-acceptable-price.
 /// Convention: 10% slippage tolerance (same as HL web UI default).
@@ -30,25 +72,26 @@ fn trigger_limit_px(trigger_px: f64, is_buy: bool) -> String {
 // ─── Entry orders ────────────────────────────────────────────────────────────
 
 /// Build the order action payload for a market order.
+/// Uses IOC (Immediate-or-Cancel) limit at slippage price — HL's standard market order format.
+/// slippage_px_str: worst-acceptable price (mid × 1.05 for buy, mid × 0.95 for sell).
 pub fn build_market_order_action(
     asset: usize,
     is_buy: bool,
     size_str: &str,
     reduce_only: bool,
+    slippage_px_str: &str,
 ) -> Value {
     json!({
         "type": "order",
         "orders": [{
             "a": asset,
             "b": is_buy,
-            "p": "0",
+            "p": slippage_px_str,
             "s": size_str,
             "r": reduce_only,
             "t": {
-                "trigger": {
-                    "isMarket": true,
-                    "tpsl": "tp",
-                    "triggerPx": "0"
+                "limit": {
+                    "tif": "Ioc"
                 }
             }
         }],
@@ -84,23 +127,22 @@ pub fn build_limit_order_action(
 
 // ─── Close ───────────────────────────────────────────────────────────────────
 
-/// Market close: reduce-only market order in the opposite direction.
+/// Market close: reduce-only IOC limit at slippage price in the opposite direction.
 /// position_is_long: true → sell to close; false → buy to close.
-pub fn build_close_action(asset: usize, position_is_long: bool, size_str: &str) -> Value {
+/// slippage_px_str: worst-acceptable price (mid × 1.05 for buy, mid × 0.95 for sell).
+pub fn build_close_action(asset: usize, position_is_long: bool, size_str: &str, slippage_px_str: &str) -> Value {
     let is_buy = !position_is_long;
     json!({
         "type": "order",
         "orders": [{
             "a": asset,
             "b": is_buy,
-            "p": "0",
+            "p": slippage_px_str,
             "s": size_str,
             "r": true,
             "t": {
-                "trigger": {
-                    "isMarket": true,
-                    "tpsl": "tp",
-                    "triggerPx": "0"
+                "limit": {
+                    "tif": "Ioc"
                 }
             }
         }],
@@ -148,8 +190,8 @@ pub fn build_trigger_order_element(
         "t": {
             "trigger": {
                 "isMarket": is_market,
-                "tpsl": tpsl,
-                "triggerPx": trigger_px_str
+                "triggerPx": trigger_px_str,
+                "tpsl": tpsl
             }
         }
     })
@@ -227,6 +269,19 @@ pub fn build_cancel_action(asset: usize, oid: u64) -> Value {
             "a": asset,
             "o": oid
         }]
+    })
+}
+
+/// Build cancel action for multiple orders in one request.
+/// Each element of `orders` is (asset_index, oid).
+pub fn build_batch_cancel_action(orders: &[(usize, u64)]) -> Value {
+    let cancels: Vec<Value> = orders
+        .iter()
+        .map(|(a, o)| json!({"a": a, "o": o}))
+        .collect();
+    json!({
+        "type": "cancel",
+        "cancels": cancels
     })
 }
 


### PR DESCRIPTION
## Summary

- **Fix EIP-712 signing** — HL now correctly recovers the wallet address from all submitted signatures
- **Add `orders` command** — list open orders with optional `--coin` filter
- **Improve `cancel`** — supports single OID, batch by coin (`--coin ETH`), and cancel-all (`--all`)
- **Fix market order format** — switch from trigger type to IOC limit at 5% slippage price
- **Fix price rounding** — implement Python SDK's `round_to_sz_decimals` (significant figures); fixes integer price corruption bug
- **Rename `prices --market` → `--coin`** for consistency

## Signing fixes (root causes)

1. Trigger order field ordering must be `{isMarket, triggerPx, tpsl}` to match Python SDK msgpack output
2. Market/close orders use `{"limit": {"tif": "Ioc"}}` with slippage price — not trigger type
3. Price rounding: `round_px(px, sz_decimals)` rounds to `sz_decimals` significant figures (e.g. ETH szDecimals=4 → integer prices)
4. `ARBITRUM_CHAIN_ID` (42161) used consistently for all signing calls

## Commands verified on Hyperliquid mainnet

| Command | Status |
|---------|--------|
| `prices` | ✅ |
| `positions` | ✅ |
| `order --type market` | ✅ real TX |
| `order --type limit` | ✅ real TX |
| `tpsl` | ✅ real TX |
| `orders` | ✅ |
| `cancel` (single) | ✅ real TX |
| `cancel --coin` (batch) | ✅ |
| `close` | ✅ real TX |
| `deposit` | ✅ real TX |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)