### PR TITLE
fix(morpho): bump to v0.1.1 — fix wallet address resolution and Ethereum RPC

### DIFF
--- a/skills/morpho/plugin.yaml
+++ b/skills/morpho/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: morpho
-version: "0.1.0"
+version: "0.1.1"
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol"
 author:
   name: GeoGu360
@@ -25,6 +25,6 @@ build:
 
 api_calls:
   - "https://blue-api.morpho.org/graphql"
-  - "https://eth.llamarpc.com"
+  - "https://ethereum-rpc.publicnode.com"
   - "https://base-rpc.publicnode.com"
   - "https://api.merkl.xyz"

--- a/skills/morpho/src/config.rs
+++ b/skills/morpho/src/config.rs
@@ -36,6 +36,6 @@ pub fn chain_name(chain_id: u64) -> &'static str {
     match chain_id {
         1 => "Ethereum Mainnet",
         8453 => "Base",
-        _ => "Unknown",
+        _ => "Unknown Chain",
     }
 }

--- a/skills/morpho/src/config.rs
+++ b/skills/morpho/src/config.rs
@@ -9,7 +9,7 @@ pub struct ChainConfig {
 
 pub const CHAIN_ETHEREUM: ChainConfig = ChainConfig {
     chain_id: 1,
-    rpc_url: "https://eth.llamarpc.com",
+    rpc_url: "https://ethereum-rpc.publicnode.com",
     morpho_blue: "0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
     merkl_distributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",
 };

--- a/skills/morpho/src/onchainos.rs
+++ b/skills/morpho/src/onchainos.rs
@@ -123,7 +123,7 @@ pub async fn resolve_wallet(from: Option<&str>, _chain_id: u64) -> anyhow::Resul
         .await?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let v: Value = serde_json::from_str(&stdout)?;
-    let addr = v["data"]["evmAddress"]
+    let addr = v["data"]["evm"][0]["address"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Could not determine active EVM wallet address. Ensure onchainos is logged in."))?
         .to_string();


### PR DESCRIPTION
## Summary

- Fix `resolve_wallet()` JSON path: `data.evmAddress` → `data.evm[0].address`，该字段不存在导致所有写操作（supply/withdraw/borrow）均报错 "Could not determine active EVM wallet address"
- Replace `eth.llamarpc.com` → `ethereum-rpc.publicnode.com`，旧 RPC 在部分网络环境下 SSL 失败，导致 `erc20_decimals()` 静默回退到 18 位小数，造成 USDC（6位）金额计算错误（5 USDC 被算成 5×10¹⁸）
- Bump version `0.1.0` → `0.1.1`，同步更新 `plugin.yaml` 中 `api_calls` 列表

## Test plan

- [x] `morpho supply --vault 0xdd0f28e19C1780eb6396170735D45153D261490d --asset USDC --amount 5 --chain 1` 成功存入 5 USDC，TX: `0x8c220339ab782cdbd82a42d213b6902f7256e23adc3ba2b9d7346ce374ca025b`
- [x] `morpho withdraw --vault ... --all --chain 1` 成功取回 5 USDC，TX: `0x81c9616c77015b98d508a643ac421fbf706b728c7ff8532619a70476cadc43d8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)