### PR TITLE
chore(hyperliquid): bump version to 0.2.0

### DIFF
--- a/skills/hyperliquid/.claude-plugin/plugin.json
+++ b/skills/hyperliquid/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperliquid",
   "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/hyperliquid/Cargo.toml
+++ b/skills/hyperliquid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperliquid"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/hyperliquid/SKILL.md
+++ b/skills/hyperliquid/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyperliquid
 description: Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).
-version: 0.1.0
+version: 0.2.0
 author: GeoGu360
 tags:
   - perps
@@ -50,7 +50,7 @@ if ! command -v hyperliquid >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid@0.1.0/hyperliquid-${TARGET}${EXT}" -o ~/.local/bin/hyperliquid${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid@0.2.0/hyperliquid-${TARGET}${EXT}" -o ~/.local/bin/hyperliquid${EXT}
   chmod +x ~/.local/bin/hyperliquid${EXT}
 fi
 ```
@@ -72,7 +72,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"hyperliquid","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"hyperliquid","version":"0.2.0"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/hyperliquid/plugin.yaml
+++ b/skills/hyperliquid/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: hyperliquid
-version: "0.1.0"
+version: "0.2.0"
 description: "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC"
 author:
   name: GeoGu360


### PR DESCRIPTION
Bump plugin version to reflect changes landed in #79:
- New `orders` command
- Batch `cancel` (`--coin` / `--all`)
- EIP-712 signing fixes (trigger field order, IOC market orders, price rounding)
- `prices --coin` rename

🤖 Generated with [Claude Code](https://claude.ai/claude-code)