### PR TITLE
fix(pancakeswap-v2): fix remove-liquidity dry-run & u128 overflow, add Arbitrum, bump v0.2.0

### DIFF
--- a/skills/pancakeswap-v2/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "pancakeswap-v2",
   "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/skills/pancakeswap-v2/Cargo.toml
+++ b/skills/pancakeswap-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v2"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v2/SKILL.md
+++ b/skills/pancakeswap-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v2
 description: "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair."
-version: "0.1.0"
+version: "0.2.0"
 author: "skylavis-sky"
 tags:
   - dex
@@ -52,7 +52,7 @@ if ! command -v pancakeswap-v2 >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2@0.1.0/pancakeswap-v2-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap-v2${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2@0.2.0/pancakeswap-v2-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap-v2${EXT}
   chmod +x ~/.local/bin/pancakeswap-v2${EXT}
 fi
 ```
@@ -74,7 +74,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v2","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v2","version":"0.2.0"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pancakeswap-v2/plugin.yaml
+++ b/skills/pancakeswap-v2/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v2
-version: "0.1.0"
+version: "0.2.0"
 description: "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair."
 author:
   name: skylavis-sky

--- a/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
@@ -85,8 +85,11 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
     };
 
     let liq_u128 = if liquidity == 0 { 1u128 } else { liquidity };
-    let amount_a_expected = reserve_a * liq_u128 / total_supply;
-    let amount_b_expected = reserve_b * liq_u128 / total_supply;
+    // Use f64 to avoid u128 overflow: reserve (up to ~10^28) * lp (up to ~10^18)
+    // overflows u128 max (~3.4×10^38) for large pools. f64 gives sufficient
+    // precision for a withdrawal preview.
+    let amount_a_expected = ((reserve_a as f64) * (liq_u128 as f64) / (total_supply as f64)) as u128;
+    let amount_b_expected = ((reserve_b as f64) * (liq_u128 as f64) / (total_supply as f64)) as u128;
     let amount_a_min = amount_a_expected * (10000 - args.slippage_bps) as u128 / 10000;
     let amount_b_min = amount_b_expected * (10000 - args.slippage_bps) as u128 / 10000;
 

--- a/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
@@ -26,16 +26,23 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
     let native_b = is_native(&args.token_b);
     let native_a = is_native(&args.token_a);
 
-    // Resolve wallet
-    let wallet = if args.dry_run {
-        "0x0000000000000000000000000000000000000000".to_string()
-    } else {
+    // Resolve wallet — always use the real address so LP balance / expected amounts
+    // are accurate in dry-run too. Only signing/broadcast is skipped in dry-run mode.
+    let wallet = {
         let w = args.from.clone()
             .unwrap_or_else(|| onchainos::resolve_wallet(args.chain_id).unwrap_or_default());
         if w.is_empty() {
-            anyhow::bail!("Cannot resolve wallet address. Pass --from or ensure onchainos is logged in.");
+            if args.dry_run {
+                // No wallet available but dry-run: use zero address as fallback,
+                // and note the estimates will be unreliable.
+                eprintln!("Warning: cannot resolve wallet for dry-run; LP balance will show 0. Pass --from for accurate estimates.");
+                "0x0000000000000000000000000000000000000000".to_string()
+            } else {
+                anyhow::bail!("Cannot resolve wallet address. Pass --from or ensure onchainos is logged in.");
+            }
+        } else {
+            w
         }
-        w
     };
 
     let token_a_addr = if native_a {

--- a/skills/pancakeswap-v2/src/config.rs
+++ b/skills/pancakeswap-v2/src/config.rs
@@ -24,7 +24,14 @@ pub fn chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
             rpc_url: "https://base-rpc.publicnode.com",
             explorer: "https://basescan.org",
         }),
-        _ => anyhow::bail!("Unsupported chain ID {}. Supported: 56 (BSC), 8453 (Base)", chain_id),
+        42161 => Ok(ChainConfig {
+            router02: "0x8cFe327CEc66d1C090Dd72bd0FF11d690C33a2Eb",
+            factory: "0x02a84c1b3BBD7401a5f7fa98a384EBC70bB5749E",
+            weth: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+            rpc_url: "https://arb1.arbitrum.io/rpc",
+            explorer: "https://arbiscan.io",
+        }),
+        _ => anyhow::bail!("Unsupported chain ID {}. Supported: 56 (BSC), 8453 (Base), 42161 (Arbitrum)", chain_id),
     }
 }
 
@@ -42,6 +49,10 @@ pub fn resolve_token_address(symbol: &str, chain_id: u64) -> String {
         // Base (8453)
         ("WETH", 8453) | ("ETH", 8453) => "0x4200000000000000000000000000000000000006".to_string(),
         ("USDC", 8453) => "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+        // Arbitrum One (42161)
+        ("WETH", 42161) | ("ETH", 42161) => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1".to_string(),
+        ("USDC", 42161) => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831".to_string(),
+        ("USDT", 42161) => "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9".to_string(),
         _ => symbol.to_string(), // assume it's already a hex address
     }
 }


### PR DESCRIPTION
## Summary

### Bug Fixes
- **dry-run wallet bug**: `remove-liquidity --dry-run` was hardcoding wallet to `0x0000...0000`, causing `erc20_balance_of` to return 0, making `expectedTokenA/B` meaningless. Fix: always resolve the real wallet first; only signing/broadcast is skipped in dry-run mode.
- **u128 overflow**: `reserve * liquidity / totalSupply` silently wraps in release mode for large pools (product can reach ~4.5×10³⁸, exceeding u128 max ~3.4×10³⁸). Fix: use f64 arithmetic for the withdrawal preview.

### New Feature
- **Arbitrum One (chain 42161)** support — Router/Factory addresses verified on-chain (`factory()` call confirmed), WETH `0x82aF49...`, token map for USDC/USDT.

### Version Bump
- `0.1.0` → `0.2.0` across `plugin.yaml`, `Cargo.toml`, `SKILL.md`, `.claude-plugin/plugin.json`

## On-chain Verification

All chains tested with real transactions (add + remove liquidity):

| Chain | add-liquidity TX | remove-liquidity TX |
|-------|-----------------|---------------------|
| BSC (56) | `0xafa069bd...` | `0x96602f25...` |
| Arbitrum (42161) | `0x25aa835e...` | `0x0a1900b3...` |

dry-run predicted amounts matched actual on-chain returned amounts in all cases.

## Checklist
- [x] `cargo build --release` passes
- [x] dry-run returns correct expected amounts (uses real wallet)
- [x] remove-liquidity verified on BSC mainnet
- [x] remove-liquidity verified on Arbitrum mainnet
- [x] version bumped in all 4 files (plugin.yaml, Cargo.toml, SKILL.md, .claude-plugin/plugin.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)