### PR TITLE
chore(morpho): bump version to 0.1.1

### DIFF
--- a/skills/morpho/.claude-plugin/plugin.json
+++ b/skills/morpho/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morpho",
   "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/morpho/Cargo.lock
+++ b/skills/morpho/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "morpho"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/morpho/Cargo.toml
+++ b/skills/morpho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morpho"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/morpho/SKILL.md
+++ b/skills/morpho/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: morpho
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults."
-version: "0.1.0"
+version: "0.1.1"
 author: "GeoGu360"
 tags:
   - lending
@@ -49,7 +49,7 @@ if ! command -v morpho >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho@0.1.0/morpho-${TARGET}${EXT}" -o ~/.local/bin/morpho${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho@0.1.1/morpho-${TARGET}${EXT}" -o ~/.local/bin/morpho${EXT}
   chmod +x ~/.local/bin/morpho${EXT}
 fi
 ```
@@ -71,7 +71,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"morpho","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"morpho","version":"0.1.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

- Bump morpho plugin version from `0.1.0` to `0.1.1` across all required files
- Sync version in `Cargo.toml`, `Cargo.lock`, `SKILL.md` (frontmatter + binary download URL + install report), and `.claude-plugin/plugin.json`

## Checklist

- [x] `plugin.yaml` version: `0.1.1`
- [x] `SKILL.md` frontmatter version: `0.1.1`
- [x] `Cargo.toml` version: `0.1.1`
- [x] `.claude-plugin/plugin.json` version: `0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)