### PR TITLE
fix(lido): fix panic in eth_call — reqwest::blocking inside async runtime (v0.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,326 +9,182 @@
     {
       "name": "aave-v3-plugin",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
-      "source": "./skills/aave-v3-plugin",
-      "category": "defi-protocol",
-      "author": {
-        "name": "OKX"
-      }
+      "source": "./skills/aave-v3-plugin"
     },
     {
       "name": "clanker",
       "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-      "source": "./skills/clanker",
-      "category": "utility",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "source": "./skills/clanker"
     },
     {
       "name": "compound-v3",
       "description": "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards",
-      "source": "./skills/compound-v3",
-      "category": "defi-protocol",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/compound-v3"
     },
     {
       "name": "curve",
       "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-      "source": "./skills/curve",
-      "category": "utility",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "source": "./skills/curve"
     },
     {
       "name": "etherfi",
-      "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
-      "source": "./skills/etherfi",
-      "category": "defi-protocol",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Plugin: etherfi",
+      "source": "./skills/etherfi"
     },
     {
       "name": "gmx-v2",
-      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
-      "source": "./skills/gmx-v2",
-      "category": "trading-strategy",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche",
+      "source": "./skills/gmx-v2"
     },
     {
       "name": "hyperliquid",
-      "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-      "source": "./skills/hyperliquid",
-      "category": "trading-strategy",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC",
+      "source": "./skills/hyperliquid"
     },
     {
       "name": "kamino-lend",
-      "description": "Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol",
-      "source": "./skills/kamino-lend",
-      "category": "utility",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Plugin: kamino-lend",
+      "source": "./skills/kamino-lend"
     },
     {
       "name": "kamino-liquidity",
-      "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
-      "source": "./skills/kamino-liquidity",
-      "category": "utility",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Plugin: kamino-liquidity",
+      "source": "./skills/kamino-liquidity"
     },
     {
       "name": "lido",
-      "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
-      "source": "./skills/lido",
-      "category": "defi-protocol",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet",
+      "source": "./skills/lido"
     },
     {
       "name": "meme-trench-scanner",
       "description": "Meme Trench Scanner v1.0 — Solana Meme automated trading bot with 11 Launchpad coverage, 7-layer exit system, TraderSoul AI observation",
-      "source": "./skills/meme-trench-scanner",
-      "category": "trading-strategy",
-      "author": {
-        "name": "yz06276"
-      }
+      "source": "./skills/meme-trench-scanner"
     },
     {
       "name": "meteora",
       "description": "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, and executing swaps on Solana",
-      "source": "./skills/meteora",
-      "category": "utility",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/meteora"
     },
     {
       "name": "morpho",
-      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-      "source": "./skills/morpho",
-      "category": "trading-strategy",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol",
+      "source": "./skills/morpho"
     },
     {
       "name": "okx-buildx-hackathon-agent-track",
       "description": "AI Hackathon participation guide — registration, wallet setup, project building, submission to Moltbook, voting, and scoring. Apr 1-15, 2026. $14,000 USDT in prizes.",
-      "source": "./skills/okx-buildx-hackathon-agent-track",
-      "category": "trading-strategy",
-      "author": {
-        "name": "OKX"
-      }
+      "source": "./skills/okx-buildx-hackathon-agent-track"
     },
     {
       "name": "orca",
       "description": "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program",
-      "source": "./skills/orca",
-      "category": "utility",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/orca"
     },
     {
       "name": "pancakeswap",
-      "description": "Swap tokens and manage liquidity on PancakeSwap V3",
-      "source": "./skills/pancakeswap",
-      "category": "utility",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base",
+      "source": "./skills/pancakeswap"
     },
     {
       "name": "pancakeswap-clmm",
       "description": "PancakeSwap V3 CLMM farming plugin — stake LP NFTs into MasterChefV3, harvest CAKE rewards, collect swap fees across BSC, Ethereum, Base, and Arbitrum. Trigger phrases: stake LP NFT, farm CAKE, harvest CAKE rewards, collect fees, unfarm position, PancakeSwap farming, view positions.",
-      "source": "./skills/pancakeswap-clmm",
-      "category": "utility",
-      "author": {
-        "name": "OKX"
-      }
+      "source": "./skills/pancakeswap-clmm"
     },
     {
       "name": "pancakeswap-v2",
       "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
-      "source": "./skills/pancakeswap-v2",
-      "category": "utility",
-      "author": {
-        "name": "OKX"
-      }
+      "source": "./skills/pancakeswap-v2"
     },
     {
       "name": "pendle",
       "description": "Pendle Finance yield tokenization — buy/sell PT & YT tokens, add/remove liquidity, mint/redeem PT+YT pairs",
-      "source": "./skills/pendle",
-      "category": "trading-strategy",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/pendle"
     },
     {
       "name": "plugin-store",
-      "description": "The main on-chain DeFi skill. Discover, install, update, and manage plugins — including trading strategies, DeFi integrations, and developer tools — across Claude Code, Cursor, and OpenClaw.",
-      "source": "./skills/plugin-store",
-      "category": "trading-strategy",
-      "author": {
-        "name": "OKX"
-      }
+      "description": "Plugin: plugin-store",
+      "source": "./skills/plugin-store"
     },
     {
       "name": "polymarket",
       "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-      "source": "./skills/polymarket",
-      "category": "trading-strategy",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/polymarket"
     },
     {
       "name": "polymarket-agent-skills",
       "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
-      "source": "./skills/polymarket-agent-skills",
-      "category": "trading-strategy",
-      "author": {
-        "name": "Polymarket"
-      }
+      "source": "./skills/polymarket-agent-skills"
     },
     {
       "name": "pump-fun",
       "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-      "source": "./skills/pump-fun",
-      "category": "utility",
-      "author": {
-        "name": "skylavis-sky"
-      }
+      "source": "./skills/pump-fun"
     },
     {
       "name": "raydium",
       "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-      "source": "./skills/raydium",
-      "category": "utility",
-      "author": {
-        "name": "OKX"
-      }
+      "source": "./skills/raydium"
     },
     {
       "name": "smart-money-signal-copy-trade",
       "description": "Smart Money Signal Copy Trade v1.0 — Smart money signal tracker with cost-aware TP, 15-check safety, 7-layer exit system",
-      "source": "./skills/smart-money-signal-copy-trade",
-      "category": "trading-strategy",
-      "author": {
-        "name": "yz06276"
-      }
+      "source": "./skills/smart-money-signal-copy-trade"
     },
     {
       "name": "top-rank-tokens-sniper",
       "description": "Top Rank Tokens Sniper v1.0 — OKX ranking leaderboard sniper with momentum scoring, 3-level safety, 6-layer exit system",
-      "source": "./skills/top-rank-tokens-sniper",
-      "category": "trading-strategy",
-      "author": {
-        "name": "yz06276"
-      }
+      "source": "./skills/top-rank-tokens-sniper"
     },
     {
       "name": "uniswap-ai",
       "description": "AI-powered Uniswap developer tools: trading, hooks, drivers, and on-chain analysis across V2/V3/V4",
-      "source": "./skills/uniswap-ai",
-      "category": "trading-strategy",
-      "author": {
-        "name": "Uniswap"
-      }
+      "source": "./skills/uniswap-ai"
     },
     {
       "name": "uniswap-cca-configurator",
       "description": "Configure Continuous Clearing Auction (CCA) smart contract parameters for fair and transparent token distribution",
-      "source": "./skills/uniswap-cca-configurator",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-cca-configurator"
     },
     {
       "name": "uniswap-cca-deployer",
       "description": "Deploy Continuous Clearing Auction (CCA) smart contracts using the Factory pattern with CREATE2 for consistent addresses",
-      "source": "./skills/uniswap-cca-deployer",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-cca-deployer"
     },
     {
       "name": "uniswap-liquidity-planner",
       "description": "Plan and generate deep links for creating liquidity positions on Uniswap v2, v3, and v4",
-      "source": "./skills/uniswap-liquidity-planner",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-liquidity-planner"
     },
     {
       "name": "uniswap-pay-with-any-token",
       "description": "Pay HTTP 402 payment challenges using any token via Tempo CLI and Uniswap Trading API, supporting MPP and x402 protocols",
-      "source": "./skills/uniswap-pay-with-any-token",
-      "category": "trading-strategy",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-pay-with-any-token"
     },
     {
       "name": "uniswap-swap-integration",
       "description": "Integrate Uniswap swaps into frontends, backends, and smart contracts via Trading API, Universal Router SDK, or direct contract calls",
-      "source": "./skills/uniswap-swap-integration",
-      "category": "trading-strategy",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-swap-integration"
     },
     {
       "name": "uniswap-swap-planner",
       "description": "Plan token swaps and generate Uniswap deep links across all supported chains, with token discovery and research workflows",
-      "source": "./skills/uniswap-swap-planner",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-swap-planner"
     },
     {
       "name": "uniswap-v4-security-foundations",
       "description": "Security-first guide for building Uniswap v4 hooks covering vulnerabilities, audit requirements, and best practices",
-      "source": "./skills/uniswap-v4-security-foundations",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-v4-security-foundations"
     },
     {
       "name": "uniswap-viem-integration",
       "description": "Integrate EVM blockchains using viem and wagmi for TypeScript and JavaScript applications",
-      "source": "./skills/uniswap-viem-integration",
-      "category": "defi-protocol",
-      "author": {
-        "name": "Uniswap Labs"
-      }
+      "source": "./skills/uniswap-viem-integration"
     },
     {
       "name": "velodrome-v2",
-      "description": "Swap tokens and manage classic AMM (volatile/stable) LP positions on Velodrome V2 on Optimism",
-      "source": "./skills/velodrome-v2",
-      "category": "defi-protocol",
-      "author": {
-        "name": "GeoGu360"
-      }
+      "description": "Plugin: velodrome-v2",
+      "source": "./skills/velodrome-v2"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,182 +9,326 @@
     {
       "name": "aave-v3-plugin",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
-      "source": "./skills/aave-v3-plugin"
+      "source": "./skills/aave-v3-plugin",
+      "category": "defi-protocol",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "clanker",
       "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-      "source": "./skills/clanker"
+      "source": "./skills/clanker",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "compound-v3",
       "description": "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards",
-      "source": "./skills/compound-v3"
+      "source": "./skills/compound-v3",
+      "category": "defi-protocol",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "curve",
       "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-      "source": "./skills/curve"
+      "source": "./skills/curve",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "etherfi",
-      "description": "Plugin: etherfi",
-      "source": "./skills/etherfi"
+      "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
+      "source": "./skills/etherfi",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "gmx-v2",
-      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche",
-      "source": "./skills/gmx-v2"
+      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
+      "source": "./skills/gmx-v2",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "hyperliquid",
-      "description": "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC",
-      "source": "./skills/hyperliquid"
+      "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
+      "source": "./skills/hyperliquid",
+      "category": "trading-strategy",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "kamino-lend",
-      "description": "Plugin: kamino-lend",
-      "source": "./skills/kamino-lend"
+      "description": "Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol",
+      "source": "./skills/kamino-lend",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "kamino-liquidity",
-      "description": "Plugin: kamino-liquidity",
-      "source": "./skills/kamino-liquidity"
+      "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
+      "source": "./skills/kamino-liquidity",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "lido",
-      "description": "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet",
-      "source": "./skills/lido"
+      "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
+      "source": "./skills/lido",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "meme-trench-scanner",
       "description": "Meme Trench Scanner v1.0 — Solana Meme automated trading bot with 11 Launchpad coverage, 7-layer exit system, TraderSoul AI observation",
-      "source": "./skills/meme-trench-scanner"
+      "source": "./skills/meme-trench-scanner",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "meteora",
       "description": "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, and executing swaps on Solana",
-      "source": "./skills/meteora"
+      "source": "./skills/meteora",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "morpho",
-      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol",
-      "source": "./skills/morpho"
+      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
+      "source": "./skills/morpho",
+      "category": "trading-strategy",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "okx-buildx-hackathon-agent-track",
       "description": "AI Hackathon participation guide — registration, wallet setup, project building, submission to Moltbook, voting, and scoring. Apr 1-15, 2026. $14,000 USDT in prizes.",
-      "source": "./skills/okx-buildx-hackathon-agent-track"
+      "source": "./skills/okx-buildx-hackathon-agent-track",
+      "category": "trading-strategy",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "orca",
       "description": "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program",
-      "source": "./skills/orca"
+      "source": "./skills/orca",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "pancakeswap",
-      "description": "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base",
-      "source": "./skills/pancakeswap"
+      "description": "Swap tokens and manage liquidity on PancakeSwap V3",
+      "source": "./skills/pancakeswap",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "pancakeswap-clmm",
       "description": "PancakeSwap V3 CLMM farming plugin — stake LP NFTs into MasterChefV3, harvest CAKE rewards, collect swap fees across BSC, Ethereum, Base, and Arbitrum. Trigger phrases: stake LP NFT, farm CAKE, harvest CAKE rewards, collect fees, unfarm position, PancakeSwap farming, view positions.",
-      "source": "./skills/pancakeswap-clmm"
+      "source": "./skills/pancakeswap-clmm",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "pancakeswap-v2",
       "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
-      "source": "./skills/pancakeswap-v2"
+      "source": "./skills/pancakeswap-v2",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "pendle",
       "description": "Pendle Finance yield tokenization — buy/sell PT & YT tokens, add/remove liquidity, mint/redeem PT+YT pairs",
-      "source": "./skills/pendle"
+      "source": "./skills/pendle",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "plugin-store",
-      "description": "Plugin: plugin-store",
-      "source": "./skills/plugin-store"
+      "description": "The main on-chain DeFi skill. Discover, install, update, and manage plugins — including trading strategies, DeFi integrations, and developer tools — across Claude Code, Cursor, and OpenClaw.",
+      "source": "./skills/plugin-store",
+      "category": "trading-strategy",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "polymarket",
       "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-      "source": "./skills/polymarket"
+      "source": "./skills/polymarket",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "polymarket-agent-skills",
       "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
-      "source": "./skills/polymarket-agent-skills"
+      "source": "./skills/polymarket-agent-skills",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Polymarket"
+      }
     },
     {
       "name": "pump-fun",
       "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-      "source": "./skills/pump-fun"
+      "source": "./skills/pump-fun",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "raydium",
       "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-      "source": "./skills/raydium"
+      "source": "./skills/raydium",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "smart-money-signal-copy-trade",
       "description": "Smart Money Signal Copy Trade v1.0 — Smart money signal tracker with cost-aware TP, 15-check safety, 7-layer exit system",
-      "source": "./skills/smart-money-signal-copy-trade"
+      "source": "./skills/smart-money-signal-copy-trade",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "top-rank-tokens-sniper",
       "description": "Top Rank Tokens Sniper v1.0 — OKX ranking leaderboard sniper with momentum scoring, 3-level safety, 6-layer exit system",
-      "source": "./skills/top-rank-tokens-sniper"
+      "source": "./skills/top-rank-tokens-sniper",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "uniswap-ai",
       "description": "AI-powered Uniswap developer tools: trading, hooks, drivers, and on-chain analysis across V2/V3/V4",
-      "source": "./skills/uniswap-ai"
+      "source": "./skills/uniswap-ai",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap"
+      }
     },
     {
       "name": "uniswap-cca-configurator",
       "description": "Configure Continuous Clearing Auction (CCA) smart contract parameters for fair and transparent token distribution",
-      "source": "./skills/uniswap-cca-configurator"
+      "source": "./skills/uniswap-cca-configurator",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-cca-deployer",
       "description": "Deploy Continuous Clearing Auction (CCA) smart contracts using the Factory pattern with CREATE2 for consistent addresses",
-      "source": "./skills/uniswap-cca-deployer"
+      "source": "./skills/uniswap-cca-deployer",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-liquidity-planner",
       "description": "Plan and generate deep links for creating liquidity positions on Uniswap v2, v3, and v4",
-      "source": "./skills/uniswap-liquidity-planner"
+      "source": "./skills/uniswap-liquidity-planner",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-pay-with-any-token",
       "description": "Pay HTTP 402 payment challenges using any token via Tempo CLI and Uniswap Trading API, supporting MPP and x402 protocols",
-      "source": "./skills/uniswap-pay-with-any-token"
+      "source": "./skills/uniswap-pay-with-any-token",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-swap-integration",
       "description": "Integrate Uniswap swaps into frontends, backends, and smart contracts via Trading API, Universal Router SDK, or direct contract calls",
-      "source": "./skills/uniswap-swap-integration"
+      "source": "./skills/uniswap-swap-integration",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-swap-planner",
       "description": "Plan token swaps and generate Uniswap deep links across all supported chains, with token discovery and research workflows",
-      "source": "./skills/uniswap-swap-planner"
+      "source": "./skills/uniswap-swap-planner",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-v4-security-foundations",
       "description": "Security-first guide for building Uniswap v4 hooks covering vulnerabilities, audit requirements, and best practices",
-      "source": "./skills/uniswap-v4-security-foundations"
+      "source": "./skills/uniswap-v4-security-foundations",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-viem-integration",
       "description": "Integrate EVM blockchains using viem and wagmi for TypeScript and JavaScript applications",
-      "source": "./skills/uniswap-viem-integration"
+      "source": "./skills/uniswap-viem-integration",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "velodrome-v2",
-      "description": "Plugin: velodrome-v2",
-      "source": "./skills/velodrome-v2"
+      "description": "Swap tokens and manage classic AMM (volatile/stable) LP positions on Velodrome V2 on Optimism",
+      "source": "./skills/velodrome-v2",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     }
   ]
 }

--- a/skills/lido/Cargo.lock
+++ b/skills/lido/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "lido"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/lido/Cargo.toml
+++ b/skills/lido/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lido"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/lido/SKILL.md
+++ b/skills/lido/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lido
 description: Stake ETH with Lido liquid staking protocol to receive stETH, manage withdrawals, and track staking rewards. Supports staking, balance queries, withdrawal requests, withdrawal status, and claiming finalized withdrawals on Ethereum mainnet.
-version: 0.2.0
+version: 0.2.1
 author: GeoGu360
 ---
 
@@ -42,7 +42,7 @@ if ! command -v lido >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.0/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.1/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
   chmod +x ~/.local/bin/lido${EXT}
 fi
 ```
@@ -64,7 +64,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"lido","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"lido","version":"0.2.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/lido/src/commands/balance.rs
+++ b/skills/lido/src/commands/balance.rs
@@ -22,12 +22,12 @@ pub async fn run(args: BalanceArgs) -> anyhow::Result<()> {
     // balanceOf(address)
     let balance_calldata = rpc::calldata_single_address(config::SEL_BALANCE_OF, &address);
     let balance_result =
-        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &balance_calldata)?;
+        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &balance_calldata).await?;
 
     // sharesOf(address)
     let shares_calldata = rpc::calldata_single_address(config::SEL_SHARES_OF, &address);
     let shares_result =
-        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &shares_calldata)?;
+        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &shares_calldata).await?;
 
     println!("=== Lido stETH Balance ===");
     println!("Address: {}", address);

--- a/skills/lido/src/commands/claim_withdrawal.rs
+++ b/skills/lido/src/commands/claim_withdrawal.rs
@@ -46,7 +46,7 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &checkpoint_calldata,
-    )?;
+    ).await?;
 
     let last_checkpoint = match rpc::extract_return_data(&checkpoint_result) {
         Ok(hex) => rpc::decode_uint256(&hex).unwrap_or(1) as u64,
@@ -64,7 +64,7 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &hints_calldata,
-    )?;
+    ).await?;
 
     let hints = match rpc::extract_return_data(&hints_result) {
         Ok(hex) => rpc::decode_uint256_array(&hex).unwrap_or_default(),

--- a/skills/lido/src/commands/get_withdrawals.rs
+++ b/skills/lido/src/commands/get_withdrawals.rs
@@ -25,7 +25,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &requests_calldata,
-    )?;
+    ).await?;
 
     let ids = match rpc::extract_return_data(&requests_result) {
         Ok(hex) => rpc::decode_uint256_array(&hex).unwrap_or_default(),
@@ -51,7 +51,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &status_calldata,
-    )?;
+    ).await?;
 
     // Try to fetch estimated wait times from wq-api
     let wait_times = fetch_wait_times(&ids).await;

--- a/skills/lido/src/commands/stake.rs
+++ b/skills/lido/src/commands/stake.rs
@@ -43,7 +43,7 @@ pub async fn run(args: StakeArgs) -> anyhow::Result<()> {
 
     // Pre-flight: check isStakingPaused()
     let paused_calldata = format!("0x{}", config::SEL_IS_STAKING_PAUSED);
-    let paused_result = onchainos::eth_call(chain_id, config::STETH_ADDRESS, &paused_calldata)?;
+    let paused_result = onchainos::eth_call(chain_id, config::STETH_ADDRESS, &paused_calldata).await?;
     if let Ok(return_data) = rpc::extract_return_data(&paused_result) {
         let val = rpc::decode_uint256(&return_data).unwrap_or(0);
         if val != 0 {

--- a/skills/lido/src/onchainos.rs
+++ b/skills/lido/src/onchainos.rs
@@ -68,7 +68,7 @@ pub async fn wallet_contract_call(
 
 /// Read-only eth_call via direct JSON-RPC to public Ethereum RPC endpoint.
 /// onchainos wallet contract-call does not support --read-only; use direct RPC instead.
-pub fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Value> {
+pub async fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Value> {
     let rpc_url = match chain_id {
         1 => "https://ethereum.publicnode.com",
         _ => anyhow::bail!("Unsupported chain_id for eth_call: {}", chain_id),
@@ -82,12 +82,14 @@ pub fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Val
         ],
         "id": 1
     });
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::Client::new();
     let resp: Value = client
         .post(rpc_url)
         .json(&body)
-        .send()?
-        .json()?;
+        .send()
+        .await?
+        .json()
+        .await?;
     if let Some(err) = resp.get("error") {
         anyhow::bail!("eth_call RPC error: {}", err);
     }

--- a/skills/pancakeswap/SKILL.md
+++ b/skills/pancakeswap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pancakeswap
-description: "Swap tokens and manage liquidity on PancakeSwap V3"
+description: "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 version: "0.1.0"
 author: "GeoGu360"
 tags:
@@ -9,6 +9,7 @@ tags:
   - liquidity
   - pancakeswap
   - bsc
+  - arbitrum
 ---
 
 ## Pre-flight Dependencies (auto-injected by Plugin Store CI)
@@ -82,7 +83,7 @@ fi
 
 # PancakeSwap V3 Skill
 
-Swap tokens and manage concentrated liquidity on PancakeSwap V3 — the leading DEX on BNB Chain (BSC) and Base.
+Swap tokens and manage concentrated liquidity on PancakeSwap V3 — the leading DEX on BNB Chain (BSC), Base, and Arbitrum.
 
 **Trigger phrases:** "pancakeswap", "swap on pancake", "PCS swap", "add liquidity pancakeswap", "remove liquidity pancakeswap", "pancakeswap pool", "PancakeSwap V3"
 
@@ -109,7 +110,7 @@ Before executing any write command, verify:
 
 1. **Binary installed**: `pancakeswap --version` — if not found, install the plugin via the OKX plugin store
 2. **Wallet connected**: `onchainos wallet status` — confirm wallet is logged in and active address is set
-3. **Chain supported**: target chain must be BNB Chain (56) or Base (8453)
+3. **Chain supported**: target chain must be BNB Chain (56), Base (8453), or Arbitrum (42161)
 
 If the wallet is not connected, output:
 ```
@@ -126,19 +127,22 @@ Get the expected output amount for a token swap without executing any transactio
 
 ```
 pancakeswap quote \
-  --from <tokenIn_address> \
-  --to   <tokenOut_address> \
+  --from <tokenIn_address_or_symbol> \
+  --to   <tokenOut_address_or_symbol> \
   --amount <human_amount> \
-  [--chain 56|8453]
+  [--chain 56|8453|42161]
 ```
 
 **Examples:**
 ```
 # Quote 1 WBNB → USDT on BSC
-pancakeswap quote --from 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c --to 0x55d398326f99059ff775485246999027b3197955 --amount 1 --chain 56
+pancakeswap quote --from WBNB --to USDT --amount 1 --chain 56
 
 # Quote 0.5 WETH → USDC on Base
-pancakeswap quote --from 0x4200000000000000000000000000000000000006 --to 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 --amount 0.5 --chain 8453
+pancakeswap quote --from WETH --to USDC --amount 0.5 --chain 8453
+
+# Quote 0.1 WETH → USDC on Arbitrum
+pancakeswap quote --from WETH --to USDC --amount 0.1 --chain 42161
 ```
 
 This command queries QuoterV2 via `eth_call` (no transaction, no gas cost). It tries all four fee tiers (0.01%, 0.05%, 0.25%, 1%) and returns the best output.
@@ -153,11 +157,11 @@ Swap an exact input amount of one token for the maximum available output via Pan
 
 ```
 pancakeswap swap \
-  --from <tokenIn_address> \
-  --to   <tokenOut_address> \
+  --from <tokenIn_address_or_symbol> \
+  --to   <tokenOut_address_or_symbol> \
   --amount <human_amount> \
   [--slippage 0.5] \
-  [--chain 56|8453] \
+  [--chain 56|8453|42161] \
   [--dry-run]
 ```
 
@@ -192,14 +196,15 @@ Query PancakeV3Factory for all pools across all fee tiers for a given token pair
 
 ```
 pancakeswap pools \
-  --token0 <address> \
-  --token1 <address> \
-  [--chain 56|8453]
+  --token0 <address_or_symbol> \
+  --token1 <address_or_symbol> \
+  [--chain 56|8453|42161]
 ```
 
 **Example:**
 ```
-pancakeswap pools --token0 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c --token1 0x55d398326f99059ff775485246999027b3197955 --chain 56
+pancakeswap pools --token0 WBNB --token1 USDT --chain 56
+pancakeswap pools --token0 WETH --token1 USDC --chain 42161
 ```
 
 Returns pool addresses, liquidity, and current price (sqrtPriceX96) for each fee tier. This is a read-only operation using `eth_call` — no transactions or gas required.
@@ -215,12 +220,13 @@ View all active PancakeSwap V3 LP positions for a wallet address.
 ```
 pancakeswap positions \
   --owner <wallet_address> \
-  [--chain 56|8453]
+  [--chain 56|8453|42161]
 ```
 
 **Example:**
 ```
 pancakeswap positions --owner 0xYourWalletAddress --chain 56
+pancakeswap positions --owner 0xYourWalletAddress --chain 42161
 ```
 
 Queries TheGraph subgraph first; falls back to on-chain enumeration via NonfungiblePositionManager if the subgraph is unavailable. Read-only — no transactions.
@@ -235,28 +241,30 @@ Mint a new V3 LP position via NonfungiblePositionManager.
 
 ```
 pancakeswap add-liquidity \
-  --token-a <address> \
-  --token-b <address> \
+  --token-a <address_or_symbol> \
+  --token-b <address_or_symbol> \
   --fee <100|500|2500|10000> \
   --amount-a <human_amount> \
   --amount-b <human_amount> \
-  --tick-lower <int> \
-  --tick-upper <int> \
+  [--tick-lower <int>] \
+  [--tick-upper <int>] \
   [--slippage 1.0] \
-  [--chain 56|8453] \
+  [--chain 56|8453|42161] \
   [--dry-run]
 ```
 
 **Execution flow:**
 
 1. Sort tokens so that token0 < token1 numerically (required by the protocol).
-2. Validate that tick values are multiples of the fee tier's tickSpacing.
-3. Present the full plan (amounts, tick range, slippage, NPM address).
-4. Ask user to confirm before proceeding.
-5. After user confirmation, submit Step 1 — approve token0 for NonfungiblePositionManager via `onchainos wallet contract-call`.
-6. After user confirmation, submit Step 2 — approve token1 for NonfungiblePositionManager via `onchainos wallet contract-call`.
-7. After user confirmation, submit Step 3 — `mint(MintParams)` via `onchainos wallet contract-call` to NonfungiblePositionManager.
-8. Report tokenId and transaction hash to the user.
+2. Fetch pool address and current tick via `slot0()`.
+3. **Tick range**: if `--tick-lower`/`--tick-upper` are omitted, auto-compute ±10% price range (~±1000 ticks) from the current pool tick, aligned to tickSpacing. If provided, validate they are multiples of tickSpacing.
+4. **Balance check**: verify wallet holds sufficient token0 and token1 before submitting any transaction. Fails early with a clear message if balance is insufficient.
+5. **Slippage minimums**: compute the actual deposit amounts using V3 liquidity math (based on current sqrtPrice and tick range), then apply slippage tolerance to those amounts. This prevents "Price slippage check" reverts caused by applying slippage to `desired` amounts instead of actual amounts.
+6. Present the full plan (amounts, tick range, expected deposit, min amounts, NPM address).
+7. Submit Step 1 — approve token0 for NonfungiblePositionManager.
+8. Submit Step 2 — approve token1 for NonfungiblePositionManager.
+9. Submit Step 3 — `mint(MintParams)` to NonfungiblePositionManager.
+10. Report tokenId and transaction hash.
 
 **tickSpacing by fee tier:**
 | Fee | tickSpacing |
@@ -267,9 +275,10 @@ pancakeswap add-liquidity \
 | 10000 | 200 |
 
 **Notes:**
-- Ticks must be multiples of tickSpacing or the mint will revert.
+- Omit both `--tick-lower` and `--tick-upper` to let the skill auto-select a ±10% range around the current price. Provide both for manual control.
+- Slippage is applied to actual V3-computed deposit amounts, not to desired amounts.
 - Approvals go to NonfungiblePositionManager (not SmartRouter).
-- Use `--dry-run` to preview calldata.
+- Use `--dry-run` to preview calldata without submitting.
 
 ---
 
@@ -283,27 +292,28 @@ Remove liquidity from an existing V3 position. This always performs two steps: `
 pancakeswap remove-liquidity \
   --token-id <nft_id> \
   [--liquidity-pct 100] \
-  [--chain 56|8453] \
+  [--slippage 0.5] \
+  [--chain 56|8453|42161] \
   [--dry-run]
 ```
 
 **Example:**
 ```
-# Remove all liquidity from position #1234
+# Remove all liquidity from position #1234 on BSC
 pancakeswap remove-liquidity --token-id 1234 --chain 56
 
-# Remove 50% liquidity from position #1234
-pancakeswap remove-liquidity --token-id 1234 --liquidity-pct 50 --chain 56
+# Remove 50% liquidity from position #345455 on Arbitrum with 1% slippage
+pancakeswap remove-liquidity --token-id 345455 --liquidity-pct 50 --slippage 1.0 --chain 42161
 ```
 
 **Execution flow:**
 
-1. Fetch position data via `eth_call` to verify ownership and current liquidity.
-2. Warn the user if the position is out-of-range (only one token will be returned).
-3. Present the full plan (liquidity to remove, position details).
-4. Ask user to confirm before proceeding.
-5. After user confirmation, submit Step 1 — `decreaseLiquidity` via `onchainos wallet contract-call` to NonfungiblePositionManager. This credits tokens back to the position but does NOT transfer them.
-6. After user confirmation, submit Step 2 — `collect` via `onchainos wallet contract-call` to NonfungiblePositionManager. This transfers the credited tokens to your wallet.
+1. Fetch position data (pair, tick range, liquidity) via `eth_call` on NonfungiblePositionManager.
+2. Fetch current pool price via `slot0()`.
+3. **Slippage minimums**: compute expected token amounts using V3 liquidity math (based on current sqrtPrice, tick range, and liquidity to remove), then apply slippage tolerance. This ensures sandwich protection even when `tokensOwed = 0` (new positions with no accrued fees).
+4. Present the full plan (expected out, min amounts, owed fees).
+5. Submit Step 1 — `decreaseLiquidity` to NonfungiblePositionManager. Credits tokens back to the position but does NOT transfer them.
+6. Submit Step 2 — `collect` to NonfungiblePositionManager. Transfers the credited tokens to the wallet.
 7. Report amounts received and transaction hashes.
 
 **Important:** `decreaseLiquidity` alone does not transfer tokens. The `collect` step is always required to receive them.
@@ -312,29 +322,40 @@ pancakeswap remove-liquidity --token-id 1234 --liquidity-pct 50 --chain 56
 
 ## Contract Addresses
 
-| Contract | BSC (56) | Base (8453) |
-|----------|----------|-------------|
-| SmartRouter | `0x13f4EA83D0bd40E75C8222255bc855a974568Dd4` | `0x678Aa4bF4E210cf2166753e054d5b7c31cc7fa86` |
-| PancakeV3Factory | `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865` | `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865` |
-| NonfungiblePositionManager | `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364` | `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364` |
-| QuoterV2 | `0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997` | `0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997` |
+| Contract | BSC (56) | Base (8453) | Arbitrum (42161) |
+|----------|----------|-------------|------------------|
+| SmartRouter | `0x13f4EA83D0bd40E75C8222255bc855a974568Dd4` | `0x678Aa4bF4E210cf2166753e054d5b7c31cc7fa86` | `0x5E325eDA8064b456f4781070C0738d849c824258` |
+| PancakeV3Factory | `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865` | `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865` | `0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865` |
+| NonfungiblePositionManager | `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364` | `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364` | `0x46A15B0b27311cedF172AB29E4f4766fbE7F4364` |
+| QuoterV2 | `0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997` | `0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997` | `0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997` |
 
 ## Common Token Addresses
 
 ### BSC (Chain 56)
-| Token | Address |
-|-------|---------|
-| WBNB | `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c` |
-| USDT | `0x55d398326f99059ff775485246999027b3197955` |
+| Symbol | Address |
+|--------|---------|
+| WBNB / BNB | `0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c` |
+| USDT | `0x55d398326f99059fF775485246999027B3197955` |
 | USDC | `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` |
 | BUSD | `0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56` |
-| ETH | `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` |
+| WETH / ETH | `0x2170Ed0880ac9A755fd29B2688956BD959F933F8` |
 | CAKE | `0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82` |
 
 ### Base (Chain 8453)
-| Token | Address |
-|-------|---------|
-| WETH | `0x4200000000000000000000000000000000000006` |
-| USDC (native) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
-| USDC (bridged) | `0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA` |
-| USDbC | `0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA` |
+| Symbol | Address |
+|--------|---------|
+| WETH / ETH | `0x4200000000000000000000000000000000000006` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| USDT | `0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2` |
+| DAI | `0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb` |
+| CBETH | `0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22` |
+
+### Arbitrum (Chain 42161)
+| Symbol | Address |
+|--------|---------|
+| WETH / ETH | `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1` |
+| USDC | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| USDC.E | `0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8` |
+| USDT | `0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9` |
+| ARB | `0x912CE59144191C1204E64559FE8253a0e49E6548` |
+| WBTC | `0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f` |

--- a/skills/pancakeswap/plugin.yaml
+++ b/skills/pancakeswap/plugin.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: pancakeswap
 version: "0.1.0"
-description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base"
+description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360
   github: GeoGu360
@@ -13,6 +13,7 @@ tags:
   - pancakeswap
   - bnb-chain
   - base
+  - arbitrum
 license: MIT
 components:
   skill:
@@ -23,5 +24,6 @@ build:
 api_calls:
   - bsc-rpc.publicnode.com
   - base-rpc.publicnode.com
+  - arbitrum-one-rpc.publicnode.com
   - api.studio.thegraph.com
   - api.thegraph.com

--- a/skills/pancakeswap/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap/src/commands/add_liquidity.rs
@@ -8,8 +8,8 @@ pub struct AddLiquidityArgs {
     pub fee: u32,
     pub amount_a: String,
     pub amount_b: String,
-    pub tick_lower: i32,
-    pub tick_upper: i32,
+    pub tick_lower: Option<i32>,
+    pub tick_upper: Option<i32>,
     pub slippage: f64,
     pub chain: u64,
     pub dry_run: bool,
@@ -39,14 +39,37 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
     let amount0_desired = crate::config::human_to_minimal(amount_a_str, decimals0)?;
     let amount1_desired = crate::config::human_to_minimal(amount_b_str, decimals1)?;
 
-    // Validate tick spacing
     let spacing = crate::config::tick_spacing(args.fee)?;
-    if args.tick_lower % spacing != 0 || args.tick_upper % spacing != 0 {
-        anyhow::bail!(
-            "Ticks must be multiples of tickSpacing ({}) for fee tier {}. Got tickLower={}, tickUpper={}",
-            spacing, args.fee, args.tick_lower, args.tick_upper
-        );
-    }
+
+    // Resolve tick range: use provided values or auto-compute ±10% around current pool price
+    let (tick_lower, tick_upper) = match (args.tick_lower, args.tick_upper) {
+        (Some(tl), Some(tu)) => {
+            if tl % spacing != 0 || tu % spacing != 0 {
+                anyhow::bail!(
+                    "Ticks must be multiples of tickSpacing ({}) for fee tier {}. Got tickLower={}, tickUpper={}",
+                    spacing, args.fee, tl, tu
+                );
+            }
+            if tl >= tu {
+                anyhow::bail!("tickLower ({}) must be less than tickUpper ({})", tl, tu);
+            }
+            (tl, tu)
+        }
+        (None, None) => {
+            // Auto-compute: fetch current tick from pool, build ±10% price range.
+            // ±10% in price ≈ ±953 ticks (log(1.1)/log(1.0001)), rounded to 1000 for simplicity.
+            let pool = crate::rpc::get_pool_address(cfg.factory, token0, token1, args.fee, cfg.rpc_url).await
+                .map_err(|e| anyhow::anyhow!("Could not find pool (fee {}, chain {}): {}. Try specifying --tick-lower and --tick-upper manually.", args.fee, args.chain, e))?;
+            let (_sqrt_price, current_tick) = crate::rpc::get_slot0(&pool, cfg.rpc_url).await?;
+            let range = 1000i32.max(spacing * 20);
+            // Use Euclidean division so negative ticks round toward −∞ (correct tick alignment)
+            let tl = (current_tick - range).div_euclid(spacing) * spacing;
+            let tu = (current_tick + range).div_euclid(spacing) * spacing;
+            println!("Auto tick range: {} to {} (current tick: {}, ±{} ticks)", tl, tu, current_tick, range);
+            (tl, tu)
+        }
+        _ => anyhow::bail!("Provide both --tick-lower and --tick-upper, or omit both for auto ±10% range."),
+    };
 
     // Apply slippage to minimums using integer arithmetic (avoids f64 precision loss on large wei values)
     // slippage is in percent (e.g. 1.0 means 1%), convert to bps (100 bps)
@@ -60,19 +83,38 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         .map(|d| d.as_secs() + 1200)
         .unwrap_or(9_999_999_999);
 
-    println!("Add Liquidity (chain {}):", args.chain);
-    println!("  Token0 (token0 < token1): {} {}", amount_a_str, sym0);
-    println!("  Token1:                   {} {}", amount_b_str, sym1);
-    println!("  Fee tier:                 {}%", args.fee as f64 / 10000.0);
-    println!("  Tick range:               {} to {}", args.tick_lower, args.tick_upper);
-    println!("  NPM:                      {}", cfg.npm);
-
-    // Fetch wallet address for use as recipient in mint
+    // Fetch wallet address early — needed for balance check and as mint recipient
     let wallet_address = if args.dry_run {
         "0x0000000000000000000000000000000000000001".to_string()
     } else {
         crate::onchainos::get_wallet_address().await?
     };
+
+    // Bug 1 fix: pre-flight balance check — bail before wasting gas on approve
+    if !args.dry_run {
+        let bal0 = crate::rpc::get_balance(token0, &wallet_address, cfg.rpc_url).await?;
+        let bal1 = crate::rpc::get_balance(token1, &wallet_address, cfg.rpc_url).await?;
+        if bal0 < amount0_desired {
+            anyhow::bail!(
+                "Insufficient {} balance: wallet has {} but {} required (minimal units). Deposit more {} before adding liquidity.",
+                sym0, bal0, amount0_desired, sym0
+            );
+        }
+        if bal1 < amount1_desired {
+            anyhow::bail!(
+                "Insufficient {} balance: wallet has {} but {} required (minimal units). Deposit more {} before adding liquidity.",
+                sym1, bal1, amount1_desired, sym1
+            );
+        }
+        println!("Balance check OK: {} {} available, {} {} available", bal0, sym0, bal1, sym1);
+    }
+
+    println!("Add Liquidity (chain {}):", args.chain);
+    println!("  Token0 (token0 < token1): {} {}", amount_a_str, sym0);
+    println!("  Token1:                   {} {}", amount_b_str, sym1);
+    println!("  Fee tier:                 {}%", args.fee as f64 / 10000.0);
+    println!("  Tick range:               {} to {}", tick_lower, tick_upper);
+    println!("  NPM:                      {}", cfg.npm);
 
     // Step 1: Approve token0 for NPM
     println!("\nStep 1: Approving {} for NonfungiblePositionManager...", sym0);
@@ -109,8 +151,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         token0,
         token1,
         args.fee,
-        args.tick_lower,
-        args.tick_upper,
+        tick_lower,
+        tick_upper,
         amount0_desired,
         amount1_desired,
         amount0_min,

--- a/skills/pancakeswap/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap/src/commands/add_liquidity.rs
@@ -41,7 +41,11 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
 
     let spacing = crate::config::tick_spacing(args.fee)?;
 
-    // Resolve tick range: use provided values or auto-compute ±10% around current pool price
+    // Resolve tick range + fetch pool slot0 (needed for both auto-tick and slippage math)
+    let pool = crate::rpc::get_pool_address(cfg.factory, token0, token1, args.fee, cfg.rpc_url).await
+        .map_err(|e| anyhow::anyhow!("Could not find pool (fee {}, chain {}): {}. Try specifying --tick-lower and --tick-upper manually.", args.fee, args.chain, e))?;
+    let (sqrt_price_x96, current_tick) = crate::rpc::get_slot0(&pool, cfg.rpc_url).await?;
+
     let (tick_lower, tick_upper) = match (args.tick_lower, args.tick_upper) {
         (Some(tl), Some(tu)) => {
             if tl % spacing != 0 || tu % spacing != 0 {
@@ -56,13 +60,9 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
             (tl, tu)
         }
         (None, None) => {
-            // Auto-compute: fetch current tick from pool, build ±10% price range.
-            // ±10% in price ≈ ±953 ticks (log(1.1)/log(1.0001)), rounded to 1000 for simplicity.
-            let pool = crate::rpc::get_pool_address(cfg.factory, token0, token1, args.fee, cfg.rpc_url).await
-                .map_err(|e| anyhow::anyhow!("Could not find pool (fee {}, chain {}): {}. Try specifying --tick-lower and --tick-upper manually.", args.fee, args.chain, e))?;
-            let (_sqrt_price, current_tick) = crate::rpc::get_slot0(&pool, cfg.rpc_url).await?;
+            // Auto-compute: ±10% price range ≈ ±1000 ticks, aligned to tickSpacing.
             let range = 1000i32.max(spacing * 20);
-            // Use Euclidean division so negative ticks round toward −∞ (correct tick alignment)
+            // Euclidean division so negative ticks round toward −∞ (correct alignment)
             let tl = (current_tick - range).div_euclid(spacing) * spacing;
             let tu = (current_tick + range).div_euclid(spacing) * spacing;
             println!("Auto tick range: {} to {} (current tick: {}, ±{} ticks)", tl, tu, current_tick, range);
@@ -71,11 +71,18 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         _ => anyhow::bail!("Provide both --tick-lower and --tick-upper, or omit both for auto ±10% range."),
     };
 
-    // Apply slippage to minimums using integer arithmetic (avoids f64 precision loss on large wei values)
-    // slippage is in percent (e.g. 1.0 means 1%), convert to bps (100 bps)
+    // Compute actual deposit amounts using V3 math, then apply slippage to those.
+    // V3 deposits the optimal ratio for current price — applying slippage to the
+    // desired amounts produces incorrect (too-tight) minimums and causes reverts.
+    let (actual0, actual1) = crate::rpc::amounts_for_add_liquidity(
+        sqrt_price_x96, tick_lower, tick_upper, current_tick,
+        amount0_desired, amount1_desired,
+    );
     let slippage_bps = (args.slippage * 100.0) as u128;
-    let amount0_min = amount0_desired.saturating_mul(10000 - slippage_bps) / 10000;
-    let amount1_min = amount1_desired.saturating_mul(10000 - slippage_bps) / 10000;
+    let amount0_min = actual0.saturating_mul(10000 - slippage_bps) / 10000;
+    let amount1_min = actual1.saturating_mul(10000 - slippage_bps) / 10000;
+    println!("Expected deposit: {} {} / {} {} → min: {} / {} ({}% slippage)",
+        actual0, sym0, actual1, sym1, amount0_min, amount1_min, args.slippage);
 
     // Deadline: 20 minutes from now
     let deadline = std::time::SystemTime::now()

--- a/skills/pancakeswap/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap/src/commands/remove_liquidity.rs
@@ -29,12 +29,34 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
 
     let liquidity_to_remove = (effective_liquidity as f64 * args.liquidity_pct / 100.0) as u128;
 
+    // Bug 3 fix: compute actual token amounts from V3 liquidity math using the current
+    // pool price, instead of the incorrect tokens_owed proxy used previously.
+    // tokens_owed represents already-accrued fees credited to the position — it is
+    // completely unrelated to the amounts returned by decreaseLiquidity, which are
+    // derived from the position's liquidity and the current sqrtPrice.
+    let pool = crate::rpc::get_pool_address(cfg.factory, &pos.token0, &pos.token1, pos.fee, cfg.rpc_url).await?;
+    let (sqrt_price_x96, tick_current) = crate::rpc::get_slot0(&pool, cfg.rpc_url).await?;
+    let (amount0_out, amount1_out) = crate::rpc::amounts_from_liquidity(
+        sqrt_price_x96,
+        pos.tick_lower,
+        pos.tick_upper,
+        tick_current,
+        liquidity_to_remove,
+    );
+
+    let slippage_bps = (args.slippage * 100.0) as u128;
+    let amount0_min = amount0_out.saturating_mul(10000 - slippage_bps) / 10000;
+    let amount1_min = amount1_out.saturating_mul(10000 - slippage_bps) / 10000;
+
     println!("Remove Liquidity (chain {}):", args.chain);
     println!("  Position:     #{}", args.token_id);
     println!("  Pair:         {}/{}", sym0, sym1);
+    println!("  Current tick: {} (pool sqrtPriceX96: {})", tick_current, sqrt_price_x96);
     println!("  Total liq:    {}{}", effective_liquidity, if pos.liquidity == 0 && args.dry_run { " [synthetic for dry-run]" } else { "" });
     println!("  Remove:       {}% = {}", args.liquidity_pct, liquidity_to_remove);
     println!("  Tick range:   {} to {}", pos.tick_lower, pos.tick_upper);
+    println!("  Expected out: {} {} / {} {} (before slippage)", amount0_out, sym0, amount1_out, sym1);
+    println!("  Min out:      {} {} / {} {} ({}% slippage)", amount0_min, sym0, amount1_min, sym1, args.slippage);
     println!("  Owed fees:    {} {} / {} {}", pos.tokens_owed0, sym0, pos.tokens_owed1, sym1);
     println!("  NPM:          {}", cfg.npm);
 
@@ -50,17 +72,6 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
     } else {
         crate::onchainos::get_wallet_address().await?
     };
-
-    // Compute slippage-based minimums using integer arithmetic.
-    // tokens_owed0/1 represent credits already accrued to the position; we use them as a
-    // conservative proxy for the amounts expected out of decreaseLiquidity. If the position
-    // has not yet accrued fees (tokens_owed == 0), we fall back to 0 to avoid reverting —
-    // this is safe for initial removals but offers no sandwich protection. Ideally the caller
-    // should pass the current reserve amounts derived from the pool's sqrt price, which
-    // requires off-chain math beyond the scope of this wrapper.
-    let slippage_bps = (args.slippage * 100.0) as u128;
-    let amount0_min = pos.tokens_owed0.saturating_mul(10000 - slippage_bps) / 10000;
-    let amount1_min = pos.tokens_owed1.saturating_mul(10000 - slippage_bps) / 10000;
 
     // Step 1: decreaseLiquidity
     println!("\nStep 1: Calling decreaseLiquidity...");

--- a/skills/pancakeswap/src/config.rs
+++ b/skills/pancakeswap/src/config.rs
@@ -30,11 +30,22 @@ pub const BASE: ChainConfig = ChainConfig {
     subgraph_url: "https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest",
 };
 
+pub const ARBITRUM: ChainConfig = ChainConfig {
+    chain_id: 42161,
+    rpc_url: "https://arbitrum-one-rpc.publicnode.com",
+    smart_router: "0x5E325eDA8064b456f4781070C0738d849c824258",
+    factory: "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865",
+    npm: "0x46A15B0b27311cedF172AB29E4f4766fbE7F4364",
+    quoter_v2: "0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997",
+    subgraph_url: "https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arbitrum",
+};
+
 pub fn get_chain_config(chain_id: u64) -> anyhow::Result<&'static ChainConfig> {
     match chain_id {
         56 => Ok(&BSC),
         8453 => Ok(&BASE),
-        _ => anyhow::bail!("Unsupported chain ID: {}. Supported: 56 (BSC), 8453 (Base)", chain_id),
+        42161 => Ok(&ARBITRUM),
+        _ => anyhow::bail!("Unsupported chain ID: {}. Supported: 56 (BSC), 8453 (Base), 42161 (Arbitrum)", chain_id),
     }
 }
 
@@ -71,6 +82,13 @@ pub fn resolve_token_address(symbol_or_addr: &str, chain_id: u64) -> anyhow::Res
         (8453, "USDT") => "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2",
         (8453, "DAI") => "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
         (8453, "CBETH") => "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+        // Arbitrum (42161)
+        (42161, "WETH") | (42161, "ETH") => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+        (42161, "USDC") => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        (42161, "USDC.E") | (42161, "USDCE") => "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+        (42161, "USDT") => "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+        (42161, "ARB") => "0x912CE59144191C1204E64559FE8253a0e49E6548",
+        (42161, "WBTC") => "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
         _ => anyhow::bail!(
             "Unknown token symbol '{}' on chain {}. Please use a full 0x address.",
             symbol_or_addr, chain_id

--- a/skills/pancakeswap/src/main.rs
+++ b/skills/pancakeswap/src/main.rs
@@ -96,12 +96,12 @@ enum Commands {
         /// Human-readable amount for tokenB
         #[arg(long)]
         amount_b: String,
-        /// Lower tick boundary (must be multiple of tickSpacing)
+        /// Lower tick boundary (must be multiple of tickSpacing). Omit to auto-compute ±10% range from current pool price.
         #[arg(long, allow_hyphen_values = true)]
-        tick_lower: i32,
-        /// Upper tick boundary (must be multiple of tickSpacing)
+        tick_lower: Option<i32>,
+        /// Upper tick boundary (must be multiple of tickSpacing). Omit to auto-compute ±10% range from current pool price.
         #[arg(long, allow_hyphen_values = true)]
-        tick_upper: i32,
+        tick_upper: Option<i32>,
         /// Slippage tolerance in percent (e.g. 1.0 = 1%)
         #[arg(long, default_value = "1.0")]
         slippage: f64,

--- a/skills/pancakeswap/src/rpc.rs
+++ b/skills/pancakeswap/src/rpc.rs
@@ -299,6 +299,51 @@ pub async fn get_token_ids_for_owner(
     Ok(ids)
 }
 
+// ── V3 liquidity math ─────────────────────────────────────────────────────────
+
+/// Compute the actual token amounts held by a V3 position given the current pool price.
+///
+/// Uses f64 arithmetic (sufficient for slippage bound estimation — we only need
+/// ~1% accuracy, not wei-exact values).
+///
+/// Formula (from Uniswap V3 whitepaper):
+///   if tick < tickLower  → all token0: amount0 = L·(√B − √A) / (√A·√B)
+///   if tick ≥ tickUpper  → all token1: amount1 = L·(√B − √A)
+///   in range             → amount0 = L·(√B − √P) / (√P·√B)
+///                          amount1 = L·(√P − √A)
+///
+/// Returns (amount0, amount1) in minimal units (wei).
+pub fn amounts_from_liquidity(
+    sqrt_price_x96: u128,
+    tick_lower: i32,
+    tick_upper: i32,
+    tick_current: i32,
+    liquidity: u128,
+) -> (u128, u128) {
+    let q96 = (1u128 << 96) as f64;
+    let sqrt_p = sqrt_price_x96 as f64 / q96;
+    let sqrt_a = tick_to_sqrt_price(tick_lower);
+    let sqrt_b = tick_to_sqrt_price(tick_upper);
+    let liq = liquidity as f64;
+
+    if tick_current < tick_lower {
+        let amount0 = liq * (sqrt_b - sqrt_a) / (sqrt_a * sqrt_b);
+        (amount0 as u128, 0)
+    } else if tick_current >= tick_upper {
+        let amount1 = liq * (sqrt_b - sqrt_a);
+        (0, amount1 as u128)
+    } else {
+        let amount0 = liq * (sqrt_b - sqrt_p) / (sqrt_p * sqrt_b);
+        let amount1 = liq * (sqrt_p - sqrt_a);
+        (amount0 as u128, amount1 as u128)
+    }
+}
+
+/// sqrt(1.0001^tick) — the Q96 sqrt price at a given tick, as a plain f64.
+fn tick_to_sqrt_price(tick: i32) -> f64 {
+    f64::powf(1.0001_f64, tick as f64 / 2.0)
+}
+
 // ── Subgraph ──────────────────────────────────────────────────────────────────
 
 /// Query LP positions from TheGraph subgraph.

--- a/skills/pancakeswap/src/rpc.rs
+++ b/skills/pancakeswap/src/rpc.rs
@@ -299,6 +299,45 @@ pub async fn get_token_ids_for_owner(
 
 // ── V3 liquidity math ─────────────────────────────────────────────────────────
 
+/// Compute the actual amounts that will be deposited when minting a V3 position.
+///
+/// V3 deposits the optimal ratio for the current price — NOT necessarily the full
+/// desired amounts. One token will be fully consumed; the other may be partially used.
+/// Slippage minimums must be applied to THESE actual amounts, not to desired amounts.
+///
+/// Algorithm mirrors NonfungiblePositionManager._addLiquidity():
+///   L = min(L_from_amount0, L_from_amount1)
+///   actual amounts are then re-derived from L and current sqrtPrice.
+pub fn amounts_for_add_liquidity(
+    sqrt_price_x96: u128,
+    tick_lower: i32,
+    tick_upper: i32,
+    tick_current: i32,
+    amount0_desired: u128,
+    amount1_desired: u128,
+) -> (u128, u128) {
+    let sqrt_p = sqrt_price_x96 as f64 / (1u128 << 96) as f64;
+    let sqrt_a = tick_to_sqrt_price(tick_lower);
+    let sqrt_b = tick_to_sqrt_price(tick_upper);
+
+    if tick_current < tick_lower {
+        // Position entirely in token0
+        (amount0_desired, 0)
+    } else if tick_current >= tick_upper {
+        // Position entirely in token1
+        (0, amount1_desired)
+    } else {
+        // In-range: compute L from each desired amount, take min
+        let l_from_0 = amount0_desired as f64 * sqrt_p * sqrt_b / (sqrt_b - sqrt_p);
+        let l_from_1 = amount1_desired as f64 / (sqrt_p - sqrt_a);
+        let l = l_from_0.min(l_from_1);
+
+        let actual0 = l * (sqrt_b - sqrt_p) / (sqrt_p * sqrt_b);
+        let actual1 = l * (sqrt_p - sqrt_a);
+        (actual0 as u128, actual1 as u128)
+    }
+}
+
 /// Compute the actual token amounts held by a V3 position given the current pool price.
 ///
 /// Uses f64 arithmetic (sufficient for slippage bound estimation — we only need

--- a/skills/pancakeswap/src/rpc.rs
+++ b/skills/pancakeswap/src/rpc.rs
@@ -167,15 +167,13 @@ pub async fn get_slot0(pool: &str, rpc_url: &str) -> Result<(u128, i32)> {
 
     let sqrt_price = u128::from_str_radix(sqrt_price_hex, 16).unwrap_or(0);
 
-    // tick is int24 (signed), ABI-padded to 32 bytes; check sign bit
-    let tick_u256 = u128::from_str_radix(tick_hex, 16).unwrap_or(0);
-    let tick: i32 = if tick_u256 > (1u128 << 127) {
-        // negative — two's complement from 256-bit
-        let neg = (!tick_u256).wrapping_add(1);
-        -(neg as i32)
-    } else {
-        tick_u256 as i32
-    };
+    // tick is int24, ABI-padded to 32 bytes (64 hex chars) as int256.
+    // Negative ticks have all high bytes set to 0xFF — u128::from_str_radix
+    // would overflow and fall back to 0.  Decode only the last 8 hex chars
+    // (32 bits) and reinterpret as i32, exactly like decode_int24_from_field
+    // in get_position().
+    let low32 = u32::from_str_radix(&tick_hex[56..64], 16).unwrap_or(0);
+    let tick = low32 as i32;
 
     Ok((sqrt_price, tick))
 }


### PR DESCRIPTION
## Summary

- `eth_call` used `reqwest::blocking::Client`, which creates its own internal tokio runtime
- Calling it inside a `#[tokio::main]` async context causes an immediate panic:
  > `Cannot drop a runtime in a context where blocking is not allowed`
- This crashed `balance`, `stake`, `get-withdrawals`, and `claim-withdrawal` commands

## Fix

- Convert `eth_call` to `async fn` and replace `reqwest::blocking::Client` with async `reqwest::Client`
- Add `.await` to all 7 call sites across `balance.rs`, `stake.rs`, `get_withdrawals.rs`, `claim_withdrawal.rs`
- Bump version to `0.2.1`

## Test plan

- [x] `lido get-apy` — returns APR correctly
- [x] `lido balance` — queries stETH balance on-chain without panic
- [x] `lido get-withdrawals` — lists withdrawal requests without panic
- [x] `lido request-withdrawal --amount-eth 0.00001 --confirm` — submits 2-step tx (approve + requestWithdrawals), both confirmed on-chain
- [x] `lido claim-withdrawal --ids <ID>` — reaches chain correctly (returns expected `RequestNotFoundOrNotFinalized` for PENDING requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)