### PR TITLE
fix(lido): fix panic in eth_call — reqwest::blocking inside async runtime (v0.2.1)

### DIFF
--- a/skills/lido/.claude-plugin/plugin.json
+++ b/skills/lido/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lido",
   "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/lido/Cargo.lock
+++ b/skills/lido/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "lido"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/lido/Cargo.toml
+++ b/skills/lido/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lido"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/lido/SKILL.md
+++ b/skills/lido/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lido
 description: Stake ETH with Lido liquid staking protocol to receive stETH, manage withdrawals, and track staking rewards. Supports staking, balance queries, withdrawal requests, withdrawal status, and claiming finalized withdrawals on Ethereum mainnet.
-version: 0.2.0
+version: 0.2.1
 author: GeoGu360
 ---
 
@@ -42,7 +42,7 @@ if ! command -v lido >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.0/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.1/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
   chmod +x ~/.local/bin/lido${EXT}
 fi
 ```
@@ -64,7 +64,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"lido","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"lido","version":"0.2.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/lido/plugin.yaml
+++ b/skills/lido/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: lido
-version: "0.2.0"
+version: "0.2.1"
 description: "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet"
 author:
   name: GeoGu360

--- a/skills/lido/src/commands/balance.rs
+++ b/skills/lido/src/commands/balance.rs
@@ -22,12 +22,12 @@ pub async fn run(args: BalanceArgs) -> anyhow::Result<()> {
     // balanceOf(address)
     let balance_calldata = rpc::calldata_single_address(config::SEL_BALANCE_OF, &address);
     let balance_result =
-        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &balance_calldata)?;
+        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &balance_calldata).await?;
 
     // sharesOf(address)
     let shares_calldata = rpc::calldata_single_address(config::SEL_SHARES_OF, &address);
     let shares_result =
-        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &shares_calldata)?;
+        onchainos::eth_call(chain_id, config::STETH_ADDRESS, &shares_calldata).await?;
 
     println!("=== Lido stETH Balance ===");
     println!("Address: {}", address);

--- a/skills/lido/src/commands/claim_withdrawal.rs
+++ b/skills/lido/src/commands/claim_withdrawal.rs
@@ -46,7 +46,7 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &checkpoint_calldata,
-    )?;
+    ).await?;
 
     let last_checkpoint = match rpc::extract_return_data(&checkpoint_result) {
         Ok(hex) => rpc::decode_uint256(&hex).unwrap_or(1) as u64,
@@ -64,7 +64,7 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &hints_calldata,
-    )?;
+    ).await?;
 
     let hints = match rpc::extract_return_data(&hints_result) {
         Ok(hex) => rpc::decode_uint256_array(&hex).unwrap_or_default(),

--- a/skills/lido/src/commands/get_withdrawals.rs
+++ b/skills/lido/src/commands/get_withdrawals.rs
@@ -25,7 +25,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &requests_calldata,
-    )?;
+    ).await?;
 
     let ids = match rpc::extract_return_data(&requests_result) {
         Ok(hex) => rpc::decode_uint256_array(&hex).unwrap_or_default(),
@@ -51,7 +51,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
         &status_calldata,
-    )?;
+    ).await?;
 
     // Try to fetch estimated wait times from wq-api
     let wait_times = fetch_wait_times(&ids).await;

--- a/skills/lido/src/commands/stake.rs
+++ b/skills/lido/src/commands/stake.rs
@@ -43,7 +43,7 @@ pub async fn run(args: StakeArgs) -> anyhow::Result<()> {
 
     // Pre-flight: check isStakingPaused()
     let paused_calldata = format!("0x{}", config::SEL_IS_STAKING_PAUSED);
-    let paused_result = onchainos::eth_call(chain_id, config::STETH_ADDRESS, &paused_calldata)?;
+    let paused_result = onchainos::eth_call(chain_id, config::STETH_ADDRESS, &paused_calldata).await?;
     if let Ok(return_data) = rpc::extract_return_data(&paused_result) {
         let val = rpc::decode_uint256(&return_data).unwrap_or(0);
         if val != 0 {

--- a/skills/lido/src/onchainos.rs
+++ b/skills/lido/src/onchainos.rs
@@ -68,7 +68,7 @@ pub async fn wallet_contract_call(
 
 /// Read-only eth_call via direct JSON-RPC to public Ethereum RPC endpoint.
 /// onchainos wallet contract-call does not support --read-only; use direct RPC instead.
-pub fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Value> {
+pub async fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Value> {
     let rpc_url = match chain_id {
         1 => "https://ethereum.publicnode.com",
         _ => anyhow::bail!("Unsupported chain_id for eth_call: {}", chain_id),
@@ -82,12 +82,14 @@ pub fn eth_call(chain_id: u64, to: &str, input_data: &str) -> anyhow::Result<Val
         ],
         "id": 1
     });
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::Client::new();
     let resp: Value = client
         .post(rpc_url)
         .json(&body)
-        .send()?
-        .json()?;
+        .send()
+        .await?
+        .json()
+        .await?;
     if let Some(err) = resp.get("error") {
         anyhow::bail!("eth_call RPC error: {}", err);
     }


### PR DESCRIPTION
## Problem

`eth_call` used `reqwest::blocking::Client`, which internally creates its own tokio runtime. Calling it from within a `#[tokio::main]` async context causes an immediate panic:

```
thread 'main' panicked: Cannot drop a runtime in a context where blocking is not allowed.
This happens when a runtime is dropped from within an asynchronous context.
```

Affected commands (all call `eth_call` from async context):
| Command | Call sites |
|---|---|
| `balance` | 2 (`balanceOf`, `sharesOf`) |
| `stake` | 1 (`isStakingPaused` pre-flight check) |
| `get-withdrawals` | 2 (`getWithdrawalRequests`, `getWithdrawalStatus`) |
| `claim-withdrawal` | 2 (`getLastCheckpointIndex`, `findCheckpointHints`) |

## Fix

- Convert `eth_call` to `async fn` in `onchainos.rs`
- Replace `reqwest::blocking::Client` with async `reqwest::Client`
- Add `.await` to all 7 call sites across `balance.rs`, `stake.rs`, `get_withdrawals.rs`, `claim_withdrawal.rs`
- Bump version to `0.2.1` in `Cargo.toml`, `SKILL.md`, `plugin.yaml`, `.claude-plugin/plugin.json`

## Test plan

- [x] `lido get-apy` — APR query (unaffected, returns 2.39%)
- [x] `lido balance` — on-chain stETH balance query, no panic
- [x] `lido get-withdrawals` — lists withdrawal requests from chain, no panic
- [x] `lido request-withdrawal --amount-eth 0.00001 --confirm` — 2-step tx (approve + requestWithdrawals), both confirmed on-chain
- [x] `lido claim-withdrawal --ids <ID>` — reaches chain correctly (returns expected `RequestNotFoundOrNotFinalized` for PENDING requests, confirming RPC call succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)