### PR TITLE
fix(curve): v0.2.0 — fix wallet resolution, approve race condition, add wait_for_tx

### DIFF
--- a/skills/curve/.claude-plugin/plugin.json
+++ b/skills/curve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve/Cargo.lock
+++ b/skills/curve/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "curve"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/curve/Cargo.toml
+++ b/skills/curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve/SKILL.md
+++ b/skills/curve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.1.0"
+version: "0.2.0"
 author: "GeoGu360"
 tags:
   - dex

--- a/skills/curve/SKILL.md
+++ b/skills/curve/SKILL.md
@@ -335,7 +335,7 @@ curve --chain <chain_id> [--dry-run] remove-liquidity --pool <pool_address> [--l
 - `--pool` — Pool contract address
 - `--lp-amount` — LP tokens to redeem (default: full wallet balance)
 - `--coin-index` — Coin index for single-coin withdrawal (omit for proportional)
-- `--min-amounts` — Minimum amounts to receive (default: 0)
+- `--min-amounts` — Minimum amounts to receive (default: 0); pass as many values as pool coins (2, 3, or 4)
 - `--wallet` — Sender address
 
 **Execution flow:**
@@ -368,10 +368,14 @@ curve --chain 42161 remove-liquidity --pool <2pool_addr> --min-amounts "0,0"
 | `No LP token balance` | Wallet has no LP in that pool | Check `get-balances` first |
 | `Cannot determine wallet address` | Not logged in to onchainos | Run `onchainos wallet login` |
 | `txHash: pending` | Transaction not broadcast | `--force` flag is applied automatically for write ops |
+| `execution reverted` on quote/swap | Wrong pool selected (duplicate low-TVL pool) | Fixed in v0.2.0: pools are now sorted by TVL so the deepest pool is always selected |
+| `Unsupported pool coin count: 4` | 4-coin pool used with remove-liquidity | Fixed in v0.2.0: 4-coin proportional withdrawal now supported |
+| `transferFrom reverted` on approve | Approval broadcast before prior tx confirmed | Fixed in v0.2.0: `wait_for_tx` polls receipt before main op |
 
 ## Security Notes
 
 - Pool addresses are fetched from the official Curve API (`api.curve.finance`) only — never from user input
 - ERC-20 allowance is checked before each approve to avoid duplicate transactions
+- ⚠️ ERC-20 approvals use `--force` and broadcast immediately without an onchainos confirmation prompt — this is required so the main swap/liquidity op simulation sees the updated allowance
 - Price impact > 5% triggers a warning; handle in agent before calling `swap`
 - Use `--dry-run` to preview all write operations before execution

--- a/skills/curve/plugin.yaml
+++ b/skills/curve/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve
-version: "0.1.0"
+version: "0.2.0"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve/src/api.rs
+++ b/skills/curve/src/api.rs
@@ -109,7 +109,7 @@ pub fn find_pool_by_address<'a>(pools: &'a [PoolData], address: &str) -> Option<
     pools.iter().find(|p| p.address.to_lowercase() == addr_lower)
 }
 
-/// Find pools that contain both token_in and token_out
+/// Find pools that contain both token_in and token_out, sorted by TVL descending.
 pub fn find_pools_for_pair<'a>(
     pools: &'a [PoolData],
     token_in: &str,
@@ -117,14 +117,22 @@ pub fn find_pools_for_pair<'a>(
 ) -> Vec<&'a PoolData> {
     let tin = token_in.to_lowercase();
     let tout = token_out.to_lowercase();
-    pools
+    let mut matched: Vec<&'a PoolData> = pools
         .iter()
         .filter(|p| {
             let has_in = p.coins.iter().any(|c| c.address.to_lowercase() == tin);
             let has_out = p.coins.iter().any(|c| c.address.to_lowercase() == tout);
             has_in && has_out
         })
-        .collect()
+        .collect();
+    // Sort by TVL descending so matching_pools[0] is always the deepest pool
+    matched.sort_by(|a, b| {
+        b.usd_total
+            .unwrap_or(0.0)
+            .partial_cmp(&a.usd_total.unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    matched
 }
 
 /// Get coin index within a pool

--- a/skills/curve/src/commands/add_liquidity.rs
+++ b/skills/curve/src/commands/add_liquidity.rs
@@ -1,7 +1,6 @@
 // commands/add_liquidity.rs — Add liquidity to a Curve pool
 use crate::{api, config, curve_abi, onchainos, rpc};
 use anyhow::Result;
-use tokio::time::{sleep, Duration};
 
 pub async fn run(
     chain_id: u64,
@@ -72,9 +71,8 @@ pub async fn run(
         return Ok(());
     }
 
-    // Approve each token with a non-zero amount
+    // Approve each token with a non-zero amount, waiting for each to confirm on-chain
     if let Some(p) = pool {
-        let mut approved_any = false;
         for (i, coin) in p.coins.iter().enumerate() {
             let amount = amounts[i];
             if amount == 0 {
@@ -96,12 +94,9 @@ pub async fn run(
                 .await?;
                 let ah = onchainos::extract_tx_hash_or_err(&approve_result)?;
                 eprintln!("Approve {} tx: {}", coin.symbol, ah);
-                approved_any = true;
+                // Wait for approve to confirm before proceeding (prevents simulation race condition)
+                onchainos::wait_for_tx(&ah, rpc_url).await?;
             }
-        }
-        if approved_any {
-            // Wait for approvals to confirm before adding liquidity
-            sleep(Duration::from_secs(5)).await;
         }
     }
 

--- a/skills/curve/src/commands/remove_liquidity.rs
+++ b/skills/curve/src/commands/remove_liquidity.rs
@@ -89,6 +89,15 @@ pub async fn run(
                 ];
                 curve_abi::encode_remove_liquidity_3(actual_lp_amount, mins)
             }
+            4 => {
+                let mins = [
+                    min_amounts.first().copied().unwrap_or(0),
+                    min_amounts.get(1).copied().unwrap_or(0),
+                    min_amounts.get(2).copied().unwrap_or(0),
+                    min_amounts.get(3).copied().unwrap_or(0),
+                ];
+                curve_abi::encode_remove_liquidity_4(actual_lp_amount, mins)
+            }
             _ => anyhow::bail!("Unsupported pool coin count: {}", n_coins),
         }
     };

--- a/skills/curve/src/commands/swap.rs
+++ b/skills/curve/src/commands/swap.rs
@@ -1,7 +1,6 @@
 // commands/swap.rs — Execute a swap via Curve pool exchange()
 use crate::{api, config, curve_abi, onchainos, rpc};
 use anyhow::Result;
-use tokio::time::{sleep, Duration};
 
 /// Determine whether a pool uses uint256 or int128 indices.
 /// Factory v2 (CryptoSwap, tricrypto) pools use uint256; classic StableSwap pools use int128.
@@ -118,7 +117,7 @@ pub async fn run(
             .await?;
             let approve_hash = onchainos::extract_tx_hash_or_err(&approve_result)?;
             eprintln!("Approve tx: {}", approve_hash);
-            sleep(Duration::from_secs(3)).await;
+            onchainos::wait_for_tx(&approve_hash, rpc_url).await?;
         }
     }
 

--- a/skills/curve/src/curve_abi.rs
+++ b/skills/curve/src/curve_abi.rs
@@ -126,6 +126,17 @@ pub fn encode_remove_liquidity_2(lp_amount: u128, min_amounts: [u128; 2]) -> Str
     s
 }
 
+/// Build calldata for remove_liquidity(uint256,uint256[4]) — 4-coin
+/// Selector: keccak256("remove_liquidity(uint256,uint256[4])") = 0x7d49d875
+pub fn encode_remove_liquidity_4(lp_amount: u128, min_amounts: [u128; 4]) -> String {
+    let mut s = String::from("0x7d49d875");
+    s.push_str(&encode_uint256_u128(lp_amount));
+    for &a in &min_amounts {
+        s.push_str(&encode_uint256_u128(a));
+    }
+    s
+}
+
 /// Build calldata for remove_liquidity(uint256,uint256[3]) — 3-coin
 /// Selector: keccak256("remove_liquidity(uint256,uint256[3])") = 0xecb586a5
 pub fn encode_remove_liquidity_3(lp_amount: u128, min_amounts: [u128; 3]) -> String {

--- a/skills/curve/src/onchainos.rs
+++ b/skills/curve/src/onchainos.rs
@@ -2,13 +2,43 @@
 use std::process::Command;
 use serde_json::Value;
 
-/// Resolve active wallet EVM address via `onchainos wallet addresses`.
-pub fn resolve_wallet(_chain_id: u64) -> anyhow::Result<String> {
+/// Resolve active wallet EVM address via `onchainos wallet addresses --chain <id>`.
+pub fn resolve_wallet(chain_id: u64) -> anyhow::Result<String> {
+    let chain_str = chain_id.to_string();
     let output = Command::new("onchainos")
-        .args(["wallet", "addresses"])
+        .args(["wallet", "addresses", "--chain", &chain_str])
         .output()?;
-    let json: Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))?;
-    Ok(json["data"]["evmAddress"].as_str().unwrap_or("").to_string())
+    let json: Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))
+        .map_err(|e| anyhow::anyhow!("wallet addresses parse error: {}", e))?;
+    let addr = json["data"]["evm"][0]["address"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine active EVM wallet address. Ensure onchainos is logged in."))?
+        .to_string();
+    Ok(addr)
+}
+
+/// Poll until a transaction is confirmed on-chain (up to ~24 seconds).
+/// Called after approve --force so the main op simulation sees the updated allowance.
+pub async fn wait_for_tx(tx_hash: &str, rpc_url: &str) -> anyhow::Result<()> {
+    if tx_hash == "0x0000000000000000000000000000000000000000000000000000000000000000" {
+        return Ok(()); // dry-run stub hash — nothing to wait for
+    }
+    let client = reqwest::Client::new();
+    for _ in 0..12 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let body = serde_json::json!({
+            "jsonrpc": "2.0", "method": "eth_getTransactionReceipt",
+            "params": [tx_hash], "id": 1
+        });
+        if let Ok(resp) = client.post(rpc_url).json(&body).send().await {
+            if let Ok(v) = resp.json::<Value>().await {
+                if !v["result"].is_null() {
+                    return Ok(());
+                }
+            }
+        }
+    }
+    Ok(()) // proceed anyway after timeout (~24s)
 }
 
 /// Call onchainos wallet contract-call.
@@ -90,6 +120,6 @@ pub async fn erc20_approve(
     let spender_padded = format!("{:0>64}", spender_clean);
     let amount_hex = format!("{:064x}", amount);
     let calldata = format!("0x095ea7b3{}{}", spender_padded, amount_hex);
-    // approve does not need --force (only swap/exchange does)
-    wallet_contract_call(chain_id, token_addr, &calldata, from, None, false, dry_run).await
+    // Approvals use --force: they must broadcast immediately as prerequisite steps
+    wallet_contract_call(chain_id, token_addr, &calldata, from, None, true, dry_run).await
 }


### PR DESCRIPTION
## Summary

Three live-tested bug fixes for the Curve plugin:

- **Fix wallet resolution** (`onchainos.rs`): `resolve_wallet` was missing `--chain <id>` flag and used wrong JSON path `data.evmAddress` (non-existent) → now uses `data.evm[0].address`. Affected all write commands on non-default chains.

- **Fix approve → main-op race condition** (`onchainos.rs`, `swap.rs`, `add_liquidity.rs`): ERC-20 approve used `--force false` and a fixed `sleep(3s)` / `sleep(5s)` before the main op. On fast-block chains (Base, Arbitrum) the approval may not be mined yet when `eth_estimateGas` runs, causing the simulation to revert. Fixed by: (a) using `force=true` on approvals so they broadcast immediately, (b) replacing sleeps with `wait_for_tx` — polls `eth_getTransactionReceipt` every 2s up to 12 attempts (~24s) before proceeding.

- **Fix pool selection for duplicate token pairs** (`api.rs`): `find_pools_for_pair` returned pools in API insertion order. When two pools share the same token pair (one active, one near-zero TVL), the dead pool was picked first, causing `execution reverted` on quote/swap. Fixed by sorting matching pools by `usd_total` descending.

- **Add 4-coin remove_liquidity support** (`curve_abi.rs`, `remove_liquidity.rs`): `remove-liquidity` failed with "Unsupported pool coin count: 4" on 4-asset StableSwap pools (e.g. Base 4pool: USDC/USDbC/axlUSDC/crvUSD). Added `encode_remove_liquidity_4` (selector `0x7d49d875`) and a `n_coins=4` match arm.

## Live Test Results (Base, chain 8453)

| Test | Command | Result |
|------|---------|--------|
| T1 | `get-pools --limit 5` | ✅ 5 pools |
| T2 | `get-pool-info --pool <weth-cbeth>` | ✅ fee, TVL, coins |
| T3 | `quote WETH→cbETH 0.0001 WETH` | ✅ ~0.0000887 cbETH |
| T4 | `get-balances` | ✅ 4pool LP position |
| T5 | `swap --dry-run WETH→cbETH` | ✅ calldata preview |
| T6 | `swap WETH→cbETH 0.0001 WETH` | ✅ [0x579ecb09...](https://basescan.org/tx/0x579ecb09618e0f062c361d2a194ff63b8020d08eb9113341f5ca78fa4f9568e0) |
| T7 | `add-liquidity --dry-run 4pool` | ✅ calldata preview |
| T8 | `add-liquidity 0.04 USDC → 4pool` | ✅ [0x350c7818...](https://basescan.org/tx/0x350c78188dbc412d488df0879e466c519713ff9544dcb5d413d200538d10a097) |
| T9 | `remove-liquidity --dry-run 4pool proportional` | ✅ calldata preview |
| T10 | `remove-liquidity 4pool proportional live` | ✅ [0x8f0cc1e2...](https://basescan.org/tx/0x8f0cc1e22364bab896345a9d570242962121511b26c9c33b0e07472edf66e003) |
| T11 | `remove-liquidity --dry-run --coin-index 0` | ✅ estimated output |

## Test plan
- [x] Read ops verified (get-pools, get-pool-info, get-balances, quote)
- [x] Write ops verified live (swap, add-liquidity, remove-liquidity proportional)
- [x] Dry-run previews verified for all write ops
- [x] 4-coin pool add and remove liquidity confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)