### PR TITLE
feat(gmx-v2): v0.2.0 — fix acceptable price, SHORT close, place-order BTC precision, get-positions PnL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,182 +9,326 @@
     {
       "name": "aave-v3-plugin",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
-      "source": "./skills/aave-v3-plugin"
+      "source": "./skills/aave-v3-plugin",
+      "category": "defi-protocol",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "clanker",
       "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-      "source": "./skills/clanker"
+      "source": "./skills/clanker",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "compound-v3",
       "description": "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards",
-      "source": "./skills/compound-v3"
+      "source": "./skills/compound-v3",
+      "category": "defi-protocol",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "curve",
       "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-      "source": "./skills/curve"
+      "source": "./skills/curve",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "etherfi",
-      "description": "Plugin: etherfi",
-      "source": "./skills/etherfi"
+      "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
+      "source": "./skills/etherfi",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "gmx-v2",
-      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche",
-      "source": "./skills/gmx-v2"
+      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
+      "source": "./skills/gmx-v2",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "hyperliquid",
-      "description": "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC",
-      "source": "./skills/hyperliquid"
+      "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
+      "source": "./skills/hyperliquid",
+      "category": "trading-strategy",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "kamino-lend",
-      "description": "Plugin: kamino-lend",
-      "source": "./skills/kamino-lend"
+      "description": "Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol",
+      "source": "./skills/kamino-lend",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "kamino-liquidity",
-      "description": "Plugin: kamino-liquidity",
-      "source": "./skills/kamino-liquidity"
+      "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
+      "source": "./skills/kamino-liquidity",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "lido",
-      "description": "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet",
-      "source": "./skills/lido"
+      "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
+      "source": "./skills/lido",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "meme-trench-scanner",
       "description": "Meme Trench Scanner v1.0 — Solana Meme automated trading bot with 11 Launchpad coverage, 7-layer exit system, TraderSoul AI observation",
-      "source": "./skills/meme-trench-scanner"
+      "source": "./skills/meme-trench-scanner",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "meteora",
       "description": "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, and executing swaps on Solana",
-      "source": "./skills/meteora"
+      "source": "./skills/meteora",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "morpho",
-      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol",
-      "source": "./skills/morpho"
+      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
+      "source": "./skills/morpho",
+      "category": "trading-strategy",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "okx-buildx-hackathon-agent-track",
       "description": "AI Hackathon participation guide — registration, wallet setup, project building, submission to Moltbook, voting, and scoring. Apr 1-15, 2026. $14,000 USDT in prizes.",
-      "source": "./skills/okx-buildx-hackathon-agent-track"
+      "source": "./skills/okx-buildx-hackathon-agent-track",
+      "category": "trading-strategy",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "orca",
       "description": "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program",
-      "source": "./skills/orca"
+      "source": "./skills/orca",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "pancakeswap",
-      "description": "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base",
-      "source": "./skills/pancakeswap"
+      "description": "Swap tokens and manage liquidity on PancakeSwap V3",
+      "source": "./skills/pancakeswap",
+      "category": "utility",
+      "author": {
+        "name": "GeoGu360"
+      }
     },
     {
       "name": "pancakeswap-clmm",
       "description": "PancakeSwap V3 CLMM farming plugin — stake LP NFTs into MasterChefV3, harvest CAKE rewards, collect swap fees across BSC, Ethereum, Base, and Arbitrum. Trigger phrases: stake LP NFT, farm CAKE, harvest CAKE rewards, collect fees, unfarm position, PancakeSwap farming, view positions.",
-      "source": "./skills/pancakeswap-clmm"
+      "source": "./skills/pancakeswap-clmm",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "pancakeswap-v2",
       "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
-      "source": "./skills/pancakeswap-v2"
+      "source": "./skills/pancakeswap-v2",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "pendle",
       "description": "Pendle Finance yield tokenization — buy/sell PT & YT tokens, add/remove liquidity, mint/redeem PT+YT pairs",
-      "source": "./skills/pendle"
+      "source": "./skills/pendle",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "plugin-store",
-      "description": "Plugin: plugin-store",
-      "source": "./skills/plugin-store"
+      "description": "The main on-chain DeFi skill. Discover, install, update, and manage plugins — including trading strategies, DeFi integrations, and developer tools — across Claude Code, Cursor, and OpenClaw.",
+      "source": "./skills/plugin-store",
+      "category": "trading-strategy",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "polymarket",
       "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-      "source": "./skills/polymarket"
+      "source": "./skills/polymarket",
+      "category": "trading-strategy",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "polymarket-agent-skills",
       "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
-      "source": "./skills/polymarket-agent-skills"
+      "source": "./skills/polymarket-agent-skills",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Polymarket"
+      }
     },
     {
       "name": "pump-fun",
       "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-      "source": "./skills/pump-fun"
+      "source": "./skills/pump-fun",
+      "category": "utility",
+      "author": {
+        "name": "skylavis-sky"
+      }
     },
     {
       "name": "raydium",
       "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-      "source": "./skills/raydium"
+      "source": "./skills/raydium",
+      "category": "utility",
+      "author": {
+        "name": "OKX"
+      }
     },
     {
       "name": "smart-money-signal-copy-trade",
       "description": "Smart Money Signal Copy Trade v1.0 — Smart money signal tracker with cost-aware TP, 15-check safety, 7-layer exit system",
-      "source": "./skills/smart-money-signal-copy-trade"
+      "source": "./skills/smart-money-signal-copy-trade",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "top-rank-tokens-sniper",
       "description": "Top Rank Tokens Sniper v1.0 — OKX ranking leaderboard sniper with momentum scoring, 3-level safety, 6-layer exit system",
-      "source": "./skills/top-rank-tokens-sniper"
+      "source": "./skills/top-rank-tokens-sniper",
+      "category": "trading-strategy",
+      "author": {
+        "name": "yz06276"
+      }
     },
     {
       "name": "uniswap-ai",
       "description": "AI-powered Uniswap developer tools: trading, hooks, drivers, and on-chain analysis across V2/V3/V4",
-      "source": "./skills/uniswap-ai"
+      "source": "./skills/uniswap-ai",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap"
+      }
     },
     {
       "name": "uniswap-cca-configurator",
       "description": "Configure Continuous Clearing Auction (CCA) smart contract parameters for fair and transparent token distribution",
-      "source": "./skills/uniswap-cca-configurator"
+      "source": "./skills/uniswap-cca-configurator",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-cca-deployer",
       "description": "Deploy Continuous Clearing Auction (CCA) smart contracts using the Factory pattern with CREATE2 for consistent addresses",
-      "source": "./skills/uniswap-cca-deployer"
+      "source": "./skills/uniswap-cca-deployer",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-liquidity-planner",
       "description": "Plan and generate deep links for creating liquidity positions on Uniswap v2, v3, and v4",
-      "source": "./skills/uniswap-liquidity-planner"
+      "source": "./skills/uniswap-liquidity-planner",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-pay-with-any-token",
       "description": "Pay HTTP 402 payment challenges using any token via Tempo CLI and Uniswap Trading API, supporting MPP and x402 protocols",
-      "source": "./skills/uniswap-pay-with-any-token"
+      "source": "./skills/uniswap-pay-with-any-token",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-swap-integration",
       "description": "Integrate Uniswap swaps into frontends, backends, and smart contracts via Trading API, Universal Router SDK, or direct contract calls",
-      "source": "./skills/uniswap-swap-integration"
+      "source": "./skills/uniswap-swap-integration",
+      "category": "trading-strategy",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-swap-planner",
       "description": "Plan token swaps and generate Uniswap deep links across all supported chains, with token discovery and research workflows",
-      "source": "./skills/uniswap-swap-planner"
+      "source": "./skills/uniswap-swap-planner",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-v4-security-foundations",
       "description": "Security-first guide for building Uniswap v4 hooks covering vulnerabilities, audit requirements, and best practices",
-      "source": "./skills/uniswap-v4-security-foundations"
+      "source": "./skills/uniswap-v4-security-foundations",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "uniswap-viem-integration",
       "description": "Integrate EVM blockchains using viem and wagmi for TypeScript and JavaScript applications",
-      "source": "./skills/uniswap-viem-integration"
+      "source": "./skills/uniswap-viem-integration",
+      "category": "defi-protocol",
+      "author": {
+        "name": "Uniswap Labs"
+      }
     },
     {
       "name": "velodrome-v2",
-      "description": "Plugin: velodrome-v2",
-      "source": "./skills/velodrome-v2"
+      "description": "Swap tokens and manage classic AMM (volatile/stable) LP positions on Velodrome V2 on Optimism",
+      "source": "./skills/velodrome-v2",
+      "category": "defi-protocol",
+      "author": {
+        "name": "GeoGu360"
+      }
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -7,20 +7,38 @@
       "version": "0.1.0",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
       "author": {
-        "name": "OKX"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum",
-        "defi"
+        "lending",
+        "borrowing",
+        "defi",
+        "earn",
+        "aave",
+        "collateral",
+        "health-factor"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/aave-v3-plugin"
+          "asset_pattern": "aave-v3-plugin-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/aave-v3-plugin@0.1.0"
         }
       },
+      "api_calls": [
+        "https://ethereum.publicnode.com",
+        "https://polygon-bor-rpc.publicnode.com",
+        "https://arbitrum-one-rpc.publicnode.com",
+        "https://base-rpc.publicnode.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -36,17 +54,36 @@
       "version": "0.1.0",
       "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
-      "tags": [],
+      "tags": [
+        "token-launch",
+        "meme",
+        "erc20",
+        "uniswap-v4",
+        "base"
+      ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/clanker"
+          "asset_pattern": "clanker-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/clanker@0.1.0"
         }
       },
+      "api_calls": [
+        "https://clanker.world/api",
+        "https://base-rpc.publicnode.com",
+        "https://arb1.arbitrum.io/rpc",
+        "https://basescan.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -61,20 +98,36 @@
       "version": "0.1.0",
       "description": "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum",
-        "defi"
+        "lending",
+        "borrowing",
+        "defi",
+        "compound",
+        "comet"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/compound-v3"
+          "asset_pattern": "compound-v3-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/compound-v3@0.1.0"
         }
       },
+      "api_calls": [
+        "https://ethereum.publicnode.com",
+        "https://base-rpc.publicnode.com",
+        "https://arbitrum-one-rpc.publicnode.com",
+        "https://polygon-rpc.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -90,19 +143,38 @@
       "version": "0.1.0",
       "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum"
+        "dex",
+        "swap",
+        "stablecoin",
+        "amm",
+        "liquidity"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/curve"
+          "asset_pattern": "curve-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/curve@0.1.0"
         }
       },
+      "api_calls": [
+        "https://api.curve.finance/api/getPools",
+        "https://ethereum.publicnode.com",
+        "https://arbitrum-one-rpc.publicnode.com",
+        "https://base-rpc.publicnode.com",
+        "https://polygon-bor-rpc.publicnode.com",
+        "https://bsc-rpc.publicnode.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -118,20 +190,37 @@
       "version": "0.1.0",
       "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
+        "liquid-staking",
+        "restaking",
+        "eigenlayer",
+        "eeth",
+        "weeth",
         "ethereum",
-        "defi"
+        "erc4626"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/etherfi"
+          "asset_pattern": "etherfi-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/etherfi@0.1.0"
         }
       },
+      "api_calls": [
+        "ethereum-rpc.publicnode.com",
+        "app.ether.fi",
+        "etherscan.io"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -145,21 +234,41 @@
     {
       "name": "gmx-v2",
       "version": "0.1.0",
-      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
+      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche",
       "author": {
-        "name": "skylavis-sky"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "trading"
+        "perpetuals",
+        "trading",
+        "leverage",
+        "arbitrum",
+        "avalanche"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/gmx-v2"
+          "asset_pattern": "gmx-v2-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/gmx-v2@0.1.0"
         }
       },
+      "api_calls": [
+        "https://arbitrum-api.gmxinfra.io",
+        "https://arbitrum-api.gmxinfra2.io",
+        "https://avalanche-api.gmxinfra.io",
+        "https://avalanche-api.gmxinfra2.io",
+        "https://gmx.squids.live",
+        "https://arbitrum.publicnode.com",
+        "https://avalanche-c-chain-rpc.publicnode.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -172,24 +281,37 @@
     {
       "name": "hyperliquid",
       "version": "0.2.0",
-      "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
+      "description": "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana",
-        "ethereum",
+        "perpetuals",
         "trading",
-        "defi"
+        "hyperliquid",
+        "derivatives"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/hyperliquid"
+          "asset_pattern": "hyperliquid-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/hyperliquid@0.2.0"
         }
       },
+      "api_calls": [
+        "https://api.hyperliquid.xyz",
+        "https://api.hyperliquid-testnet.xyz",
+        "https://arbitrum-one-rpc.publicnode.com",
+        "https://app.hyperliquid.xyz"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -206,19 +328,33 @@
       "version": "0.1.0",
       "description": "Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana"
+        "lending",
+        "borrowing",
+        "solana",
+        "kamino",
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/kamino-lend"
+          "asset_pattern": "kamino-lend-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/kamino-lend@0.1.0"
         }
       },
+      "api_calls": [
+        "api.kamino.finance"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -234,19 +370,37 @@
       "version": "0.1.0",
       "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana"
+        "solana",
+        "yield",
+        "liquidity",
+        "kamino"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/kamino-liquidity"
+          "asset_pattern": "kamino-liquidity-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/kamino-liquidity@0.1.0"
         }
       },
+      "api_calls": [
+        "api.kamino.finance/kvaults/vaults",
+        "api.kamino.finance/kvaults/users",
+        "api.kamino.finance/ktx/kvault/deposit",
+        "api.kamino.finance/ktx/kvault/withdraw",
+        "api.kamino.finance",
+        "solscan.io/tx"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -260,22 +414,37 @@
     {
       "name": "lido",
       "version": "0.2.0",
-      "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
+      "description": "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum",
-        "defi"
+        "staking",
+        "liquid-staking",
+        "lido",
+        "steth",
+        "ethereum"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/lido"
+          "asset_pattern": "lido-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/lido@0.2.0"
         }
       },
+      "api_calls": [
+        "eth-api.lido.fi",
+        "wq-api.lido.fi",
+        "ethereum.publicnode.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -288,26 +457,23 @@
     },
     {
       "name": "meme-trench-scanner",
-      "version": "1.0",
+      "version": "1.0.0",
       "description": "Meme Trench Scanner v1.0 — Solana Meme automated trading bot with 11 Launchpad coverage, 7-layer exit system, TraderSoul AI observation",
       "author": {
-        "name": "yz06276"
+        "name": "yz06276",
+        "github": "yz06276"
       },
+      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "trading",
-        "signal",
-        "scanner",
-        "sniper",
-        "defi",
-        "memepump"
+        "onchainos",
+        "trading-bot"
       ],
-      "type": "community-developer",
+      "type": "community",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/meme-trench-scanner"
+          "dir": "."
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -325,19 +491,33 @@
       "version": "0.1.0",
       "description": "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, and executing swaps on Solana",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana"
+        "solana",
+        "dex",
+        "liquidity",
+        "dlmm",
+        "swap"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/meteora"
+          "asset_pattern": "meteora-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/meteora@0.1.0"
         }
       },
+      "api_calls": [
+        "https://dlmm.datapi.meteora.ag"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -351,23 +531,39 @@
     {
       "name": "morpho",
       "version": "0.2.0",
-      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
+      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum",
-        "trading",
-        "defi"
+        "lending",
+        "borrowing",
+        "defi",
+        "earn",
+        "morpho",
+        "collateral"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/morpho"
+          "asset_pattern": "morpho-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/morpho@0.2.0"
         }
       },
+      "api_calls": [
+        "https://blue-api.morpho.org/graphql",
+        "https://ethereum-rpc.publicnode.com",
+        "https://base-rpc.publicnode.com",
+        "https://api.merkl.xyz"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -383,22 +579,29 @@
       "version": "1.0.0",
       "description": "AI Hackathon participation guide — registration, wallet setup, project building, submission to Moltbook, voting, and scoring. Apr 1-15, 2026. $14,000 USDT in prizes.",
       "author": {
-        "name": "OKX"
+        "name": "OKX",
+        "github": "MigOKG"
       },
+      "license": "MIT",
       "category": "utility",
       "tags": [
-        "trading",
-        "defi",
-        "ranking",
-        "hackathon"
+        "hackathon",
+        "xlayer",
+        "onchainos",
+        "uniswap",
+        "moltbook"
       ],
       "type": "official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/okx-buildx-hackathon-agent-track"
         }
       },
+      "api_calls": [
+        "www.moltbook.com",
+        "web3.okx.com",
+        "docs.uniswap.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -414,19 +617,35 @@
       "version": "0.1.0",
       "description": "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
-        "solana"
+        "dex",
+        "swap",
+        "clmm",
+        "concentrated-liquidity",
+        "solana",
+        "amm"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/orca"
+          "asset_pattern": "orca-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/orca@0.1.0"
         }
       },
+      "api_calls": [
+        "https://api.orca.so/v1/whirlpool/list",
+        "https://api.orca.so/v1"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -438,48 +657,41 @@
       }
     },
     {
-      "name": "pancakeswap",
-      "version": "0.1.0",
-      "description": "Swap tokens and manage liquidity on PancakeSwap V3",
-      "author": {
-        "name": "GeoGu360"
-      },
-      "category": "defi-protocol",
-      "tags": [],
-      "type": "community-developer",
-      "components": {
-        "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/pancakeswap"
-        }
-      },
-      "link": "https://github.com/okx/plugin-store",
-      "extra": {
-        "chains": [
-          "base"
-        ],
-        "protocols": [],
-        "risk_level": "medium"
-      }
-    },
-    {
       "name": "pancakeswap-clmm",
       "version": "0.1.0",
       "description": "PancakeSwap V3 CLMM farming plugin — stake LP NFTs into MasterChefV3, harvest CAKE rewards, collect swap fees across BSC, Ethereum, Base, and Arbitrum. Trigger phrases: stake LP NFT, farm CAKE, harvest CAKE rewards, collect fees, unfarm position, PancakeSwap farming, view positions.",
       "author": {
-        "name": "OKX"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum"
+        "dex",
+        "liquidity",
+        "clmm",
+        "farming",
+        "v3",
+        "pancakeswap"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/pancakeswap-clmm"
+          "asset_pattern": "pancakeswap-clmm-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/pancakeswap-clmm@0.1.0"
         }
       },
+      "api_calls": [
+        "https://bsc-rpc.publicnode.com",
+        "https://ethereum.publicnode.com",
+        "https://base-rpc.publicnode.com",
+        "https://arb1.arbitrum.io/rpc"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -495,17 +707,83 @@
       "version": "0.2.0",
       "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
       "author": {
-        "name": "OKX"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
-      "tags": [],
+      "tags": [
+        "dex",
+        "swap",
+        "liquidity",
+        "amm",
+        "pancakeswap",
+        "bsc",
+        "v2",
+        "xyk",
+        "lp"
+      ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/pancakeswap-v2"
+          "asset_pattern": "pancakeswap-v2-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/pancakeswap-v2@0.2.0"
         }
       },
+      "api_calls": [
+        "https://bsc-rpc.publicnode.com",
+        "https://base-rpc.publicnode.com"
+      ],
+      "link": "https://github.com/okx/plugin-store",
+      "extra": {
+        "chains": [
+          "base"
+        ],
+        "protocols": [],
+        "risk_level": "medium"
+      }
+    },
+    {
+      "name": "pancakeswap",
+      "version": "0.1.0",
+      "description": "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base",
+      "author": {
+        "name": "GeoGu360",
+        "github": "GeoGu360"
+      },
+      "license": "MIT",
+      "category": "defi-protocol",
+      "tags": [
+        "dex",
+        "swap",
+        "liquidity",
+        "pancakeswap",
+        "bnb-chain",
+        "base"
+      ],
+      "type": "community-developer",
+      "components": {
+        "skill": {
+          "dir": "."
+        },
+        "binary": {
+          "repo": "okx/plugin-store",
+          "asset_pattern": "pancakeswap-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/pancakeswap@0.1.0"
+        }
+      },
+      "api_calls": [
+        "bsc-rpc.publicnode.com",
+        "base-rpc.publicnode.com",
+        "api.studio.thegraph.com",
+        "api.thegraph.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -520,20 +798,37 @@
       "version": "0.1.0",
       "description": "Pendle Finance yield tokenization — buy/sell PT & YT tokens, add/remove liquidity, mint/redeem PT+YT pairs",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "ethereum",
-        "trading"
+        "yield-trading",
+        "fixed-yield",
+        "pt",
+        "yt",
+        "liquidity"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/pendle"
+          "asset_pattern": "pendle-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/pendle@0.1.0"
         }
       },
+      "api_calls": [
+        "https://api-v2.pendle.finance",
+        "https://cloudflare-eth.com",
+        "https://bsc-rpc.publicnode.com",
+        "https://base-rpc.publicnode.com",
+        "https://arb1.arbitrum.io/rpc"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -545,23 +840,27 @@
       }
     },
     {
-      "name": "plugin-store",
+      "name": "polymarket-agent-skills",
       "version": "1.0.0",
-      "description": "The main on-chain DeFi skill. Discover, install, update, and manage plugins — including trading strategies, DeFi integrations, and developer tools — across Claude Code, Cursor, and OpenClaw.",
+      "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
       "author": {
-        "name": "OKX"
+        "name": "Polymarket",
+        "github": "Polymarket"
       },
-      "category": "trading-strategy",
+      "license": "MIT",
+      "category": "defi-protocol",
       "tags": [
+        "polymarket",
+        "prediction-market",
         "trading",
-        "defi",
-        "hackathon"
+        "polygon",
+        "gasless",
+        "bridge"
       ],
-      "type": "official",
+      "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/plugin-store"
+          "dir": "skills/polymarket-agent-skills"
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -578,47 +877,36 @@
       "version": "0.2.0",
       "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
+        "prediction-market",
+        "polymarket",
+        "polygon",
         "trading",
-        "defi"
+        "defi",
+        "clob"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/polymarket"
+          "asset_pattern": "polymarket-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/polymarket@0.2.0"
         }
       },
-      "link": "https://github.com/okx/plugin-store",
-      "extra": {
-        "chains": [
-          "base"
-        ],
-        "protocols": [],
-        "risk_level": "high"
-      }
-    },
-    {
-      "name": "polymarket-agent-skills",
-      "version": "1.0.0",
-      "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
-      "author": {
-        "name": "Polymarket"
-      },
-      "category": "defi-protocol",
-      "tags": [
-        "trading"
+      "api_calls": [
+        "https://clob.polymarket.com",
+        "https://gamma-api.polymarket.com",
+        "https://data-api.polymarket.com"
       ],
-      "type": "dapp-official",
-      "components": {
-        "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/polymarket-agent-skills"
-        }
-      },
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -633,19 +921,34 @@
       "version": "0.1.0",
       "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
       "author": {
-        "name": "skylavis-sky"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana"
+        "solana",
+        "memecoins",
+        "bonding-curve",
+        "launchpad",
+        "pump-fun"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/pump-fun"
+          "asset_pattern": "pump-fun-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/pump-fun@0.1.0"
         }
       },
+      "api_calls": [
+        "https://api.mainnet-beta.solana.com",
+        "https://frontend-api.pump.fun"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -661,19 +964,34 @@
       "version": "0.1.0",
       "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
       "author": {
-        "name": "OKX"
+        "name": "skylavis-sky",
+        "github": "skylavis-sky"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana"
+        "solana",
+        "dex",
+        "amm",
+        "swap",
+        "raydium"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/raydium"
+          "asset_pattern": "raydium-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/raydium@0.1.0"
         }
       },
+      "api_calls": [
+        "https://api-v3.raydium.io",
+        "https://transaction-v1.raydium.io"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -686,24 +1004,23 @@
     },
     {
       "name": "smart-money-signal-copy-trade",
-      "version": "1.0",
+      "version": "1.0.0",
       "description": "Smart Money Signal Copy Trade v1.0 — Smart money signal tracker with cost-aware TP, 15-check safety, 7-layer exit system",
       "author": {
-        "name": "yz06276"
+        "name": "yz06276",
+        "github": "yz06276"
       },
+      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "trading",
-        "signal",
-        "sniper",
-        "defi"
+        "onchainos",
+        "trading-bot"
       ],
-      "type": "community-developer",
+      "type": "community",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/smart-money-signal-copy-trade"
+          "dir": "."
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -718,26 +1035,23 @@
     },
     {
       "name": "top-rank-tokens-sniper",
-      "version": "1.0",
+      "version": "1.0.0",
       "description": "Top Rank Tokens Sniper v1.0 — OKX ranking leaderboard sniper with momentum scoring, 3-level safety, 6-layer exit system",
       "author": {
-        "name": "yz06276"
+        "name": "yz06276",
+        "github": "yz06276"
       },
+      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "trading",
-        "signal",
-        "scanner",
-        "sniper",
-        "defi",
-        "ranking"
+        "onchainos",
+        "trading-bot"
       ],
-      "type": "community-developer",
+      "type": "community",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
-          "dir": "skills/top-rank-tokens-sniper"
+          "dir": "."
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -755,17 +1069,23 @@
       "version": "1.7.0",
       "description": "AI-powered Uniswap developer tools: trading, hooks, drivers, and on-chain analysis across V2/V3/V4",
       "author": {
-        "name": "Uniswap"
+        "name": "Uniswap",
+        "github": "Uniswap"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
+        "uniswap",
         "trading",
-        "defi"
+        "hooks",
+        "v2",
+        "v3",
+        "v4",
+        "multi-chain"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-ai"
         }
       },
@@ -783,16 +1103,22 @@
       "version": "1.0.0",
       "description": "Configure Continuous Clearing Auction (CCA) smart contract parameters for fair and transparent token distribution",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "defi"
+        "uniswap",
+        "cca",
+        "auction",
+        "token-distribution",
+        "smart-contracts",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-cca-configurator"
         }
       },
@@ -810,16 +1136,23 @@
       "version": "1.0.0",
       "description": "Deploy Continuous Clearing Auction (CCA) smart contracts using the Factory pattern with CREATE2 for consistent addresses",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "defi"
+        "uniswap",
+        "cca",
+        "auction",
+        "deployment",
+        "create2",
+        "smart-contracts",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-cca-deployer"
         }
       },
@@ -837,19 +1170,29 @@
       "version": "0.2.0",
       "description": "Plan and generate deep links for creating liquidity positions on Uniswap v2, v3, and v4",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "defi"
+        "uniswap",
+        "liquidity",
+        "defi",
+        "lp-position",
+        "concentrated-liquidity",
+        "deep-links",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-liquidity-planner"
         }
       },
+      "api_calls": [
+        "trade-api.gateway.uniswap.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -864,20 +1207,29 @@
       "version": "2.0.0",
       "description": "Pay HTTP 402 payment challenges using any token via Tempo CLI and Uniswap Trading API, supporting MPP and x402 protocols",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "trading",
-        "defi"
+        "uniswap",
+        "payments",
+        "x402",
+        "mpp",
+        "tempo",
+        "defi",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-pay-with-any-token"
         }
       },
+      "api_calls": [
+        "trade-api.gateway.uniswap.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -892,20 +1244,29 @@
       "version": "1.3.0",
       "description": "Integrate Uniswap swaps into frontends, backends, and smart contracts via Trading API, Universal Router SDK, or direct contract calls",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "trading",
-        "defi"
+        "uniswap",
+        "swap",
+        "defi",
+        "trading-api",
+        "universal-router",
+        "permit2",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-swap-integration"
         }
       },
+      "api_calls": [
+        "trade-api.gateway.uniswap.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -920,19 +1281,29 @@
       "version": "0.2.1",
       "description": "Plan token swaps and generate Uniswap deep links across all supported chains, with token discovery and research workflows",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "defi"
+        "uniswap",
+        "swap",
+        "defi",
+        "token-discovery",
+        "deep-links",
+        "ethereum",
+        "multichain"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-swap-planner"
         }
       },
+      "api_calls": [
+        "trade-api.gateway.uniswap.org"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -947,16 +1318,23 @@
       "version": "1.1.0",
       "description": "Security-first guide for building Uniswap v4 hooks covering vulnerabilities, audit requirements, and best practices",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "security",
       "tags": [
-        "defi"
+        "uniswap",
+        "v4-hooks",
+        "security",
+        "smart-contracts",
+        "audit",
+        "solidity",
+        "ethereum"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-v4-security-foundations"
         }
       },
@@ -974,16 +1352,23 @@
       "version": "1.0.0",
       "description": "Integrate EVM blockchains using viem and wagmi for TypeScript and JavaScript applications",
       "author": {
-        "name": "Uniswap Labs"
+        "name": "Uniswap Labs",
+        "github": "wkoutre"
       },
+      "license": "MIT",
       "category": "utility",
       "tags": [
-        "defi"
+        "viem",
+        "wagmi",
+        "ethereum",
+        "evm",
+        "blockchain",
+        "typescript",
+        "smart-contracts"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
-          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-viem-integration"
         }
       },
@@ -1001,19 +1386,35 @@
       "version": "0.1.0",
       "description": "Swap tokens and manage classic AMM (volatile/stable) LP positions on Velodrome V2 on Optimism",
       "author": {
-        "name": "GeoGu360"
+        "name": "GeoGu360",
+        "github": "GeoGu360"
       },
+      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "defi"
+        "dex",
+        "amm",
+        "velodrome",
+        "classic-amm",
+        "stable",
+        "volatile",
+        "optimism"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
+          "dir": "."
+        },
+        "binary": {
           "repo": "okx/plugin-store",
-          "dir": "skills/velodrome-v2"
+          "asset_pattern": "velodrome-v2-{target}",
+          "checksums_asset": "checksums.txt",
+          "release_tag": "plugins/velodrome-v2@0.1.0"
         }
       },
+      "api_calls": [
+        "optimism-rpc.publicnode.com"
+      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [

--- a/registry.json
+++ b/registry.json
@@ -7,38 +7,20 @@
       "version": "0.1.0",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "OKX"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "lending",
-        "borrowing",
-        "defi",
-        "earn",
-        "aave",
-        "collateral",
-        "health-factor"
+        "ethereum",
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "aave-v3-plugin-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/aave-v3-plugin@0.1.0"
+          "dir": "skills/aave-v3-plugin"
         }
       },
-      "api_calls": [
-        "https://ethereum.publicnode.com",
-        "https://polygon-bor-rpc.publicnode.com",
-        "https://arbitrum-one-rpc.publicnode.com",
-        "https://base-rpc.publicnode.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -54,36 +36,17 @@
       "version": "0.1.0",
       "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
-      "tags": [
-        "token-launch",
-        "meme",
-        "erc20",
-        "uniswap-v4",
-        "base"
-      ],
+      "tags": [],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "clanker-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/clanker@0.1.0"
+          "dir": "skills/clanker"
         }
       },
-      "api_calls": [
-        "https://clanker.world/api",
-        "https://base-rpc.publicnode.com",
-        "https://arb1.arbitrum.io/rpc",
-        "https://basescan.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -98,36 +61,20 @@
       "version": "0.1.0",
       "description": "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "lending",
-        "borrowing",
-        "defi",
-        "compound",
-        "comet"
+        "ethereum",
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "compound-v3-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/compound-v3@0.1.0"
+          "dir": "skills/compound-v3"
         }
       },
-      "api_calls": [
-        "https://ethereum.publicnode.com",
-        "https://base-rpc.publicnode.com",
-        "https://arbitrum-one-rpc.publicnode.com",
-        "https://polygon-rpc.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -143,38 +90,19 @@
       "version": "0.1.0",
       "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "dex",
-        "swap",
-        "stablecoin",
-        "amm",
-        "liquidity"
+        "ethereum"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "curve-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/curve@0.1.0"
+          "dir": "skills/curve"
         }
       },
-      "api_calls": [
-        "https://api.curve.finance/api/getPools",
-        "https://ethereum.publicnode.com",
-        "https://arbitrum-one-rpc.publicnode.com",
-        "https://base-rpc.publicnode.com",
-        "https://polygon-bor-rpc.publicnode.com",
-        "https://bsc-rpc.publicnode.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -190,37 +118,20 @@
       "version": "0.1.0",
       "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "liquid-staking",
-        "restaking",
-        "eigenlayer",
-        "eeth",
-        "weeth",
         "ethereum",
-        "erc4626"
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "etherfi-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/etherfi@0.1.0"
+          "dir": "skills/etherfi"
         }
       },
-      "api_calls": [
-        "ethereum-rpc.publicnode.com",
-        "app.ether.fi",
-        "etherscan.io"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -234,41 +145,21 @@
     {
       "name": "gmx-v2",
       "version": "0.1.0",
-      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche",
+      "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "perpetuals",
-        "trading",
-        "leverage",
-        "arbitrum",
-        "avalanche"
+        "trading"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "gmx-v2-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/gmx-v2@0.1.0"
+          "dir": "skills/gmx-v2"
         }
       },
-      "api_calls": [
-        "https://arbitrum-api.gmxinfra.io",
-        "https://arbitrum-api.gmxinfra2.io",
-        "https://avalanche-api.gmxinfra.io",
-        "https://avalanche-api.gmxinfra2.io",
-        "https://gmx.squids.live",
-        "https://arbitrum.publicnode.com",
-        "https://avalanche-c-chain-rpc.publicnode.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -281,37 +172,24 @@
     {
       "name": "hyperliquid",
       "version": "0.2.0",
-      "description": "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC",
+      "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "perpetuals",
+        "solana",
+        "ethereum",
         "trading",
-        "hyperliquid",
-        "derivatives"
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "hyperliquid-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/hyperliquid@0.2.0"
+          "dir": "skills/hyperliquid"
         }
       },
-      "api_calls": [
-        "https://api.hyperliquid.xyz",
-        "https://api.hyperliquid-testnet.xyz",
-        "https://arbitrum-one-rpc.publicnode.com",
-        "https://app.hyperliquid.xyz"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -328,33 +206,19 @@
       "version": "0.1.0",
       "description": "Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "lending",
-        "borrowing",
-        "solana",
-        "kamino",
-        "defi"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "kamino-lend-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/kamino-lend@0.1.0"
+          "dir": "skills/kamino-lend"
         }
       },
-      "api_calls": [
-        "api.kamino.finance"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -370,37 +234,19 @@
       "version": "0.1.0",
       "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana",
-        "yield",
-        "liquidity",
-        "kamino"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "kamino-liquidity-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/kamino-liquidity@0.1.0"
+          "dir": "skills/kamino-liquidity"
         }
       },
-      "api_calls": [
-        "api.kamino.finance/kvaults/vaults",
-        "api.kamino.finance/kvaults/users",
-        "api.kamino.finance/ktx/kvault/deposit",
-        "api.kamino.finance/ktx/kvault/withdraw",
-        "api.kamino.finance",
-        "solscan.io/tx"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -414,37 +260,22 @@
     {
       "name": "lido",
       "version": "0.2.0",
-      "description": "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet",
+      "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "staking",
-        "liquid-staking",
-        "lido",
-        "steth",
-        "ethereum"
+        "ethereum",
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "lido-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/lido@0.2.0"
+          "dir": "skills/lido"
         }
       },
-      "api_calls": [
-        "eth-api.lido.fi",
-        "wq-api.lido.fi",
-        "ethereum.publicnode.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -457,23 +288,26 @@
     },
     {
       "name": "meme-trench-scanner",
-      "version": "1.0.0",
+      "version": "1.0",
       "description": "Meme Trench Scanner v1.0 — Solana Meme automated trading bot with 11 Launchpad coverage, 7-layer exit system, TraderSoul AI observation",
       "author": {
-        "name": "yz06276",
-        "github": "yz06276"
+        "name": "yz06276"
       },
-      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "onchainos",
-        "trading-bot"
+        "trading",
+        "signal",
+        "scanner",
+        "sniper",
+        "defi",
+        "memepump"
       ],
-      "type": "community",
+      "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
+          "repo": "okx/plugin-store",
+          "dir": "skills/meme-trench-scanner"
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -491,33 +325,19 @@
       "version": "0.1.0",
       "description": "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, and executing swaps on Solana",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana",
-        "dex",
-        "liquidity",
-        "dlmm",
-        "swap"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "meteora-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/meteora@0.1.0"
+          "dir": "skills/meteora"
         }
       },
-      "api_calls": [
-        "https://dlmm.datapi.meteora.ag"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -531,39 +351,23 @@
     {
       "name": "morpho",
       "version": "0.2.0",
-      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol",
+      "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "lending",
-        "borrowing",
-        "defi",
-        "earn",
-        "morpho",
-        "collateral"
+        "ethereum",
+        "trading",
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "morpho-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/morpho@0.2.0"
+          "dir": "skills/morpho"
         }
       },
-      "api_calls": [
-        "https://blue-api.morpho.org/graphql",
-        "https://ethereum-rpc.publicnode.com",
-        "https://base-rpc.publicnode.com",
-        "https://api.merkl.xyz"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -579,29 +383,22 @@
       "version": "1.0.0",
       "description": "AI Hackathon participation guide — registration, wallet setup, project building, submission to Moltbook, voting, and scoring. Apr 1-15, 2026. $14,000 USDT in prizes.",
       "author": {
-        "name": "OKX",
-        "github": "MigOKG"
+        "name": "OKX"
       },
-      "license": "MIT",
       "category": "utility",
       "tags": [
-        "hackathon",
-        "xlayer",
-        "onchainos",
-        "uniswap",
-        "moltbook"
+        "trading",
+        "defi",
+        "ranking",
+        "hackathon"
       ],
       "type": "official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/okx-buildx-hackathon-agent-track"
         }
       },
-      "api_calls": [
-        "www.moltbook.com",
-        "web3.okx.com",
-        "docs.uniswap.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -617,35 +414,19 @@
       "version": "0.1.0",
       "description": "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
-        "dex",
-        "swap",
-        "clmm",
-        "concentrated-liquidity",
-        "solana",
-        "amm"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "orca-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/orca@0.1.0"
+          "dir": "skills/orca"
         }
       },
-      "api_calls": [
-        "https://api.orca.so/v1/whirlpool/list",
-        "https://api.orca.so/v1"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -657,41 +438,48 @@
       }
     },
     {
+      "name": "pancakeswap",
+      "version": "0.1.0",
+      "description": "Swap tokens and manage liquidity on PancakeSwap V3",
+      "author": {
+        "name": "GeoGu360"
+      },
+      "category": "defi-protocol",
+      "tags": [],
+      "type": "community-developer",
+      "components": {
+        "skill": {
+          "repo": "okx/plugin-store",
+          "dir": "skills/pancakeswap"
+        }
+      },
+      "link": "https://github.com/okx/plugin-store",
+      "extra": {
+        "chains": [
+          "base"
+        ],
+        "protocols": [],
+        "risk_level": "medium"
+      }
+    },
+    {
       "name": "pancakeswap-clmm",
       "version": "0.1.0",
       "description": "PancakeSwap V3 CLMM farming plugin — stake LP NFTs into MasterChefV3, harvest CAKE rewards, collect swap fees across BSC, Ethereum, Base, and Arbitrum. Trigger phrases: stake LP NFT, farm CAKE, harvest CAKE rewards, collect fees, unfarm position, PancakeSwap farming, view positions.",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "OKX"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "dex",
-        "liquidity",
-        "clmm",
-        "farming",
-        "v3",
-        "pancakeswap"
+        "ethereum"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "pancakeswap-clmm-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/pancakeswap-clmm@0.1.0"
+          "dir": "skills/pancakeswap-clmm"
         }
       },
-      "api_calls": [
-        "https://bsc-rpc.publicnode.com",
-        "https://ethereum.publicnode.com",
-        "https://base-rpc.publicnode.com",
-        "https://arb1.arbitrum.io/rpc"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -707,83 +495,17 @@
       "version": "0.2.0",
       "description": "Swap tokens and provide full-range liquidity on PancakeSwap V2 — the xyk AMM on BSC and Base. Trigger phrases: swap on pancakeswap v2, pancake swap, pcs v2 swap, add liquidity pancakeswap, remove liquidity pancake, pancake amm, pancakeswap v2 quote, check pancake pair.",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "OKX"
       },
-      "license": "MIT",
       "category": "defi-protocol",
-      "tags": [
-        "dex",
-        "swap",
-        "liquidity",
-        "amm",
-        "pancakeswap",
-        "bsc",
-        "v2",
-        "xyk",
-        "lp"
-      ],
+      "tags": [],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "pancakeswap-v2-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/pancakeswap-v2@0.2.0"
+          "dir": "skills/pancakeswap-v2"
         }
       },
-      "api_calls": [
-        "https://bsc-rpc.publicnode.com",
-        "https://base-rpc.publicnode.com"
-      ],
-      "link": "https://github.com/okx/plugin-store",
-      "extra": {
-        "chains": [
-          "base"
-        ],
-        "protocols": [],
-        "risk_level": "medium"
-      }
-    },
-    {
-      "name": "pancakeswap",
-      "version": "0.1.0",
-      "description": "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base",
-      "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
-      },
-      "license": "MIT",
-      "category": "defi-protocol",
-      "tags": [
-        "dex",
-        "swap",
-        "liquidity",
-        "pancakeswap",
-        "bnb-chain",
-        "base"
-      ],
-      "type": "community-developer",
-      "components": {
-        "skill": {
-          "dir": "."
-        },
-        "binary": {
-          "repo": "okx/plugin-store",
-          "asset_pattern": "pancakeswap-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/pancakeswap@0.1.0"
-        }
-      },
-      "api_calls": [
-        "bsc-rpc.publicnode.com",
-        "base-rpc.publicnode.com",
-        "api.studio.thegraph.com",
-        "api.thegraph.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -798,37 +520,20 @@
       "version": "0.1.0",
       "description": "Pendle Finance yield tokenization — buy/sell PT & YT tokens, add/remove liquidity, mint/redeem PT+YT pairs",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "yield-trading",
-        "fixed-yield",
-        "pt",
-        "yt",
-        "liquidity"
+        "ethereum",
+        "trading"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "pendle-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/pendle@0.1.0"
+          "dir": "skills/pendle"
         }
       },
-      "api_calls": [
-        "https://api-v2.pendle.finance",
-        "https://cloudflare-eth.com",
-        "https://bsc-rpc.publicnode.com",
-        "https://base-rpc.publicnode.com",
-        "https://arb1.arbitrum.io/rpc"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -840,27 +545,23 @@
       }
     },
     {
-      "name": "polymarket-agent-skills",
+      "name": "plugin-store",
       "version": "1.0.0",
-      "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
+      "description": "The main on-chain DeFi skill. Discover, install, update, and manage plugins — including trading strategies, DeFi integrations, and developer tools — across Claude Code, Cursor, and OpenClaw.",
       "author": {
-        "name": "Polymarket",
-        "github": "Polymarket"
+        "name": "OKX"
       },
-      "license": "MIT",
-      "category": "defi-protocol",
+      "category": "trading-strategy",
       "tags": [
-        "polymarket",
-        "prediction-market",
         "trading",
-        "polygon",
-        "gasless",
-        "bridge"
+        "defi",
+        "hackathon"
       ],
-      "type": "dapp-official",
+      "type": "official",
       "components": {
         "skill": {
-          "dir": "skills/polymarket-agent-skills"
+          "repo": "okx/plugin-store",
+          "dir": "skills/plugin-store"
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -877,36 +578,47 @@
       "version": "0.2.0",
       "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "prediction-market",
-        "polymarket",
-        "polygon",
         "trading",
-        "defi",
-        "clob"
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "polymarket-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/polymarket@0.2.0"
+          "dir": "skills/polymarket"
         }
       },
-      "api_calls": [
-        "https://clob.polymarket.com",
-        "https://gamma-api.polymarket.com",
-        "https://data-api.polymarket.com"
+      "link": "https://github.com/okx/plugin-store",
+      "extra": {
+        "chains": [
+          "base"
+        ],
+        "protocols": [],
+        "risk_level": "high"
+      }
+    },
+    {
+      "name": "polymarket-agent-skills",
+      "version": "1.0.0",
+      "description": "Polymarket prediction market integration: trading, market data, WebSocket streaming, cross-chain bridge, and gasless transactions",
+      "author": {
+        "name": "Polymarket"
+      },
+      "category": "defi-protocol",
+      "tags": [
+        "trading"
       ],
+      "type": "dapp-official",
+      "components": {
+        "skill": {
+          "repo": "okx/plugin-store",
+          "dir": "skills/polymarket-agent-skills"
+        }
+      },
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -921,34 +633,19 @@
       "version": "0.1.0",
       "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "skylavis-sky"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana",
-        "memecoins",
-        "bonding-curve",
-        "launchpad",
-        "pump-fun"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "pump-fun-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/pump-fun@0.1.0"
+          "dir": "skills/pump-fun"
         }
       },
-      "api_calls": [
-        "https://api.mainnet-beta.solana.com",
-        "https://frontend-api.pump.fun"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -964,34 +661,19 @@
       "version": "0.1.0",
       "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
       "author": {
-        "name": "skylavis-sky",
-        "github": "skylavis-sky"
+        "name": "OKX"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "solana",
-        "dex",
-        "amm",
-        "swap",
-        "raydium"
+        "solana"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "raydium-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/raydium@0.1.0"
+          "dir": "skills/raydium"
         }
       },
-      "api_calls": [
-        "https://api-v3.raydium.io",
-        "https://transaction-v1.raydium.io"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -1004,23 +686,24 @@
     },
     {
       "name": "smart-money-signal-copy-trade",
-      "version": "1.0.0",
+      "version": "1.0",
       "description": "Smart Money Signal Copy Trade v1.0 — Smart money signal tracker with cost-aware TP, 15-check safety, 7-layer exit system",
       "author": {
-        "name": "yz06276",
-        "github": "yz06276"
+        "name": "yz06276"
       },
-      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "onchainos",
-        "trading-bot"
+        "trading",
+        "signal",
+        "sniper",
+        "defi"
       ],
-      "type": "community",
+      "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
+          "repo": "okx/plugin-store",
+          "dir": "skills/smart-money-signal-copy-trade"
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -1035,23 +718,26 @@
     },
     {
       "name": "top-rank-tokens-sniper",
-      "version": "1.0.0",
+      "version": "1.0",
       "description": "Top Rank Tokens Sniper v1.0 — OKX ranking leaderboard sniper with momentum scoring, 3-level safety, 6-layer exit system",
       "author": {
-        "name": "yz06276",
-        "github": "yz06276"
+        "name": "yz06276"
       },
-      "license": "MIT",
       "category": "trading-strategy",
       "tags": [
         "solana",
-        "onchainos",
-        "trading-bot"
+        "trading",
+        "signal",
+        "scanner",
+        "sniper",
+        "defi",
+        "ranking"
       ],
-      "type": "community",
+      "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
+          "repo": "okx/plugin-store",
+          "dir": "skills/top-rank-tokens-sniper"
         }
       },
       "link": "https://github.com/okx/plugin-store",
@@ -1069,23 +755,17 @@
       "version": "1.7.0",
       "description": "AI-powered Uniswap developer tools: trading, hooks, drivers, and on-chain analysis across V2/V3/V4",
       "author": {
-        "name": "Uniswap",
-        "github": "Uniswap"
+        "name": "Uniswap"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
         "trading",
-        "hooks",
-        "v2",
-        "v3",
-        "v4",
-        "multi-chain"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-ai"
         }
       },
@@ -1103,22 +783,16 @@
       "version": "1.0.0",
       "description": "Configure Continuous Clearing Auction (CCA) smart contract parameters for fair and transparent token distribution",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "cca",
-        "auction",
-        "token-distribution",
-        "smart-contracts",
-        "ethereum"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-cca-configurator"
         }
       },
@@ -1136,23 +810,16 @@
       "version": "1.0.0",
       "description": "Deploy Continuous Clearing Auction (CCA) smart contracts using the Factory pattern with CREATE2 for consistent addresses",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "cca",
-        "auction",
-        "deployment",
-        "create2",
-        "smart-contracts",
-        "ethereum"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-cca-deployer"
         }
       },
@@ -1170,29 +837,19 @@
       "version": "0.2.0",
       "description": "Plan and generate deep links for creating liquidity positions on Uniswap v2, v3, and v4",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "liquidity",
-        "defi",
-        "lp-position",
-        "concentrated-liquidity",
-        "deep-links",
-        "ethereum"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-liquidity-planner"
         }
       },
-      "api_calls": [
-        "trade-api.gateway.uniswap.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -1207,29 +864,20 @@
       "version": "2.0.0",
       "description": "Pay HTTP 402 payment challenges using any token via Tempo CLI and Uniswap Trading API, supporting MPP and x402 protocols",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "payments",
-        "x402",
-        "mpp",
-        "tempo",
-        "defi",
-        "ethereum"
+        "trading",
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-pay-with-any-token"
         }
       },
-      "api_calls": [
-        "trade-api.gateway.uniswap.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -1244,29 +892,20 @@
       "version": "1.3.0",
       "description": "Integrate Uniswap swaps into frontends, backends, and smart contracts via Trading API, Universal Router SDK, or direct contract calls",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "swap",
-        "defi",
-        "trading-api",
-        "universal-router",
-        "permit2",
-        "ethereum"
+        "trading",
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-swap-integration"
         }
       },
-      "api_calls": [
-        "trade-api.gateway.uniswap.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -1281,29 +920,19 @@
       "version": "0.2.1",
       "description": "Plan token swaps and generate Uniswap deep links across all supported chains, with token discovery and research workflows",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "uniswap",
-        "swap",
-        "defi",
-        "token-discovery",
-        "deep-links",
-        "ethereum",
-        "multichain"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-swap-planner"
         }
       },
-      "api_calls": [
-        "trade-api.gateway.uniswap.org"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [
@@ -1318,23 +947,16 @@
       "version": "1.1.0",
       "description": "Security-first guide for building Uniswap v4 hooks covering vulnerabilities, audit requirements, and best practices",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "security",
       "tags": [
-        "uniswap",
-        "v4-hooks",
-        "security",
-        "smart-contracts",
-        "audit",
-        "solidity",
-        "ethereum"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-v4-security-foundations"
         }
       },
@@ -1352,23 +974,16 @@
       "version": "1.0.0",
       "description": "Integrate EVM blockchains using viem and wagmi for TypeScript and JavaScript applications",
       "author": {
-        "name": "Uniswap Labs",
-        "github": "wkoutre"
+        "name": "Uniswap Labs"
       },
-      "license": "MIT",
       "category": "utility",
       "tags": [
-        "viem",
-        "wagmi",
-        "ethereum",
-        "evm",
-        "blockchain",
-        "typescript",
-        "smart-contracts"
+        "defi"
       ],
       "type": "dapp-official",
       "components": {
         "skill": {
+          "repo": "okx/plugin-store",
           "dir": "skills/uniswap-viem-integration"
         }
       },
@@ -1386,35 +1001,19 @@
       "version": "0.1.0",
       "description": "Swap tokens and manage classic AMM (volatile/stable) LP positions on Velodrome V2 on Optimism",
       "author": {
-        "name": "GeoGu360",
-        "github": "GeoGu360"
+        "name": "GeoGu360"
       },
-      "license": "MIT",
       "category": "defi-protocol",
       "tags": [
-        "dex",
-        "amm",
-        "velodrome",
-        "classic-amm",
-        "stable",
-        "volatile",
-        "optimism"
+        "defi"
       ],
       "type": "community-developer",
       "components": {
         "skill": {
-          "dir": "."
-        },
-        "binary": {
           "repo": "okx/plugin-store",
-          "asset_pattern": "velodrome-v2-{target}",
-          "checksums_asset": "checksums.txt",
-          "release_tag": "plugins/velodrome-v2@0.1.0"
+          "dir": "skills/velodrome-v2"
         }
       },
-      "api_calls": [
-        "optimism-rpc.publicnode.com"
-      ],
       "link": "https://github.com/okx/plugin-store",
       "extra": {
         "chains": [

--- a/skills/gmx-v2/.claude-plugin/plugin.json
+++ b/skills/gmx-v2/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "gmx-v2",
   "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
-  "version": "1.0.0",
-  "author": {"name": "skylavis-sky", "github": "skylavis-sky"},
-  "homepage": "https://github.com/skylavis-sky/onchainos-plugins/tree/main/gmx-v2",
-  "repository": "https://github.com/skylavis-sky/onchainos-plugins",
+  "version": "0.2.0",
+  "author": {"name": "GeoGu360", "github": "GeoGu360"},
+  "homepage": "https://github.com/GeoGu360/plugin-store/tree/main/skills/gmx-v2",
+  "repository": "https://github.com/GeoGu360/plugin-store",
   "license": "MIT",
   "keywords": ["perpetuals", "spot", "trading", "arbitrum", "avalanche", "leverage"]
 }

--- a/skills/gmx-v2/Cargo.lock
+++ b/skills/gmx-v2/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "gmx-v2"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/gmx-v2/Cargo.toml
+++ b/skills/gmx-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmx-v2"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/gmx-v2/SKILL.md
+++ b/skills/gmx-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmx-v2
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions. Trigger phrases: open position GMX, close position GMX, GMX trade, GMX leverage, GMX liquidity, deposit GM pool, withdraw GM pool, GMX stop loss, GMX take profit, cancel order GMX, claim funding fees GMX."
-version: "0.1.0"
+version: 0.2.0
 author: "GeoGu360"
 tags:
   - perpetuals
@@ -49,7 +49,7 @@ if ! command -v gmx-v2 >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.1.0/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.2.0/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
   chmod +x ~/.local/bin/gmx-v2${EXT}
 fi
 ```
@@ -71,7 +71,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"gmx-v2","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"gmx-v2","version":"0.2.0"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -101,7 +101,7 @@ fi
 
 ## Architecture
 
-**Source code**: https://github.com/skylavis-sky/onchainos-plugins/tree/main/gmx-v2 (binary built from commit `6882d08d`)
+**Source code**: https://github.com/GeoGu360/plugin-store/tree/main/skills/gmx-v2
 
 - Read ops (list-markets, get-prices, get-positions, get-orders) → direct `eth_call` via public RPC or GMX REST API; no confirmation needed
 - Write ops (open-position, close-position, place-order, cancel-order, deposit-liquidity, withdraw-liquidity, claim-funding-fees) → after user confirmation, submits via `onchainos wallet contract-call`
@@ -121,7 +121,7 @@ Default: `--chain arbitrum`
 
 - **Keeper model**: Orders are NOT executed immediately. A keeper bot executes them 1–30 seconds after the creation transaction lands. The `txHash` returned is the *creation* tx, not the execution.
 - **Execution fee**: Native token (ETH/AVAX) sent as value with multicall. Surplus is auto-refunded.
-- **Price precision**: All GMX prices use 30-decimal precision (1 USD = 10^30 in contract units).
+- **Price precision**: Token prices use `price_usd × 10^(30 − token_decimals)` — e.g. ETH (18 dec) → `× 10^12`, BTC (8 dec) → `× 10^22`. Position size (`size_delta_usd`) always uses `× 10^30`.
 - **Market addresses**: Fetched dynamically from GMX API at runtime — never hardcoded.
 
 ## Execution Flow for Write Operations
@@ -191,6 +191,10 @@ gmx-v2 --chain arbitrum get-positions
 gmx-v2 --chain arbitrum get-positions --address 0xYourWallet
 ```
 
+**Output fields per position:** index, account, market (address), marketName, collateralToken, direction (LONG/SHORT), sizeUsd, collateralUsd, leverage (e.g. "2.50x"), entryPrice_usd, currentPrice_usd, unrealizedPnl_usd
+
+> Use `market` (address) and `collateralToken` directly as `--market-token` and `--collateral-token` when calling `close-position` or `place-order`.
+
 No confirmation needed (read-only).
 
 ---
@@ -203,6 +207,10 @@ Queries pending orders (limit, stop-loss, take-profit) for a wallet address.
 gmx-v2 --chain arbitrum get-orders
 gmx-v2 --chain arbitrum get-orders --address 0xYourWallet
 ```
+
+**Output fields per order:** index, orderKey (bytes32), market (address), marketName, orderType (e.g. "LimitIncrease", "StopLossDecrease")
+
+> Use `orderKey` directly as `--key` when calling `cancel-order`.
 
 No confirmation needed (read-only).
 
@@ -243,7 +251,7 @@ gmx-v2 --chain arbitrum open-position \
 **Flow:**
 1. Run `--dry-run` to preview calldata and estimated leverage
 2. **Ask user to confirm** market, direction, size, slippage, and execution fee
-3. Plugin auto-approves collateral token if allowance is insufficient
+3. If collateral allowance is insufficient, the binary prints a NOTE — re-run with `--confirm` flag to approve and open in one step
 4. Submits multicall via `onchainos wallet contract-call`
 5. Keeper executes position within 1–30 seconds
 
@@ -276,6 +284,7 @@ gmx-v2 --chain arbitrum close-position \
 - `--size-usd`: Size to close in USD (use full position size for full close)
 - `--collateral-amount`: Collateral to withdraw
 - `--long`: presence flag — include for long positions, omit for short
+- `--slippage-bps`: Acceptable slippage in basis points (default: 100 = 1%)
 
 **Flow:**
 1. Run `--dry-run` to preview

--- a/skills/gmx-v2/plugin.yaml
+++ b/skills/gmx-v2/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: gmx-v2
-version: "0.1.0"
+version: "0.2.0"
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche"
 author:
   name: GeoGu360

--- a/skills/gmx-v2/src/abi.rs
+++ b/skills/gmx-v2/src/abi.rs
@@ -95,12 +95,20 @@ pub fn encode_claim_funding_fees(markets: &[&str], tokens: &[&str], receiver: &s
 }
 
 /// Encode `createOrder(CreateOrderParams)` calldata for GMX V2
-/// Selector: 0x97aedce2
+/// Selector: 0xf59c48eb
 ///
-/// CreateOrderParams:
-///   Addresses: (account, receiver, cancellationReceiver, callbackContract, uiFeeReceiver, market, initialCollateralToken, swapPath[])
-///   Numbers:   (orderType, decreasePositionSwapType, sizeDeltaUsd, initialCollateralDeltaAmount, triggerPrice, acceptablePrice, executionFee, callbackGasLimit, minOutputAmount, updatedAtTime, validFromTime, srcChainId)
-///   Flags:     (isLong, shouldUnwrapNativeToken, isFrozen, autoCancel)
+/// CreateOrderParams (actual deployed struct):
+///   addresses: (receiver, cancellationReceiver, callbackContract, uiFeeReceiver, market, initialCollateralToken, swapPath[])
+///   numbers:   (sizeDeltaUsd, initialCollateralDeltaAmount, triggerPrice, acceptablePrice, executionFee, callbackGasLimit, minOutputAmount, validFromTime)
+///   orderType:                  uint8
+///   decreasePositionSwapType:   uint8
+///   isLong:                     bool
+///   shouldUnwrapNativeToken:    bool
+///   autoCancel:                 bool
+///   referralCode:               bytes32
+///   dataList:                   bytes32[]  (empty)
+///
+/// ABI sig: createOrder(((address,address,address,address,address,address,address[]),(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256),uint8,uint8,bool,bool,bool,bytes32,bytes32[]))
 #[allow(clippy::too_many_arguments)]
 pub fn encode_create_order(
     account: &str,
@@ -114,126 +122,77 @@ pub fn encode_create_order(
     acceptable_price: u128,
     execution_fee: u128,
     is_long: bool,
-    src_chain_id: u64,
+    _src_chain_id: u64,
 ) -> String {
-    // The createOrder function takes a single struct param.
-    // ABI-encode as tuple:
-    // - Addresses tuple (8 slots: 8 addresses, last is dynamic array swapPath=[])
-    // - Numbers tuple (12 slots)
-    // - Flags tuple (4 bools)
-    //
-    // The full ABI for the struct has dynamic elements (swapPath array in Addresses).
-    // We encode the struct as a tuple with dynamic tail.
-    //
-    // Selector: 0x97aedce2
-    // ABI: createOrder((address,address,address,address,address,address,address,address[]),(uint8,uint8,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256),(bool,bool,bool,bool))
-    //
-    // The outer tuple is the single function argument.
-    // Top-level: 3 tuple components -> head has 3 offsets (each 32 bytes), then data.
-    // But since the top-level is a single struct, the function arg IS the struct.
-    // Let's use manual ABI encoding:
+    // ── Addresses tuple ──────────────────────────────────────────────────────
+    // (receiver, cancellationReceiver, callbackContract, uiFeeReceiver, market, initialCollateralToken, swapPath[])
+    // 6 static addresses + 1 offset for swapPath (dynamic array, length=0)
+    // Head: 7 words (6 addrs + swapPath offset), Tail: swapPath length word (=0)
+    // swapPath offset = 7*32 = 224 (relative to start of addresses tuple head[0])
+    let swap_path_offset: usize = 7 * 32;
+    let mut addr_enc = String::new();
+    addr_enc.push_str(&encode_address(receiver));         // receiver
+    addr_enc.push_str(&encode_address(account));          // cancellationReceiver = account
+    addr_enc.push_str(&zero_address());                   // callbackContract = 0x0
+    addr_enc.push_str(&zero_address());                   // uiFeeReceiver = 0x0
+    addr_enc.push_str(&encode_address(market));           // market
+    addr_enc.push_str(&encode_address(collateral_token)); // initialCollateralToken
+    addr_enc.push_str(&encode_u256(swap_path_offset as u128)); // offset to swapPath[]
+    addr_enc.push_str(&encode_u256(0));                   // swapPath length = 0
+    // addr_enc = 8 words = 256 bytes
 
-    // The createOrder function takes one argument of struct type.
-    // We encode it as a tuple (addresses_tuple, numbers_tuple, flags_tuple).
-    // Since addresses_tuple contains a dynamic array (swapPath), addresses_tuple is dynamic.
-    // numbers_tuple and flags_tuple are static.
+    // ── Numbers tuple (8 static uint256 fields, encoded inline) ─────────────
+    let mut num_enc = String::new();
+    num_enc.push_str(&encode_u256(size_delta_usd));           // sizeDeltaUsd
+    num_enc.push_str(&encode_u256(collateral_delta_amount));  // initialCollateralDeltaAmount
+    num_enc.push_str(&encode_u256(trigger_price));            // triggerPrice
+    num_enc.push_str(&encode_u256(acceptable_price));         // acceptablePrice
+    num_enc.push_str(&encode_u256(execution_fee));            // executionFee
+    num_enc.push_str(&encode_u256(0));                        // callbackGasLimit = 0
+    num_enc.push_str(&encode_u256(0));                        // minOutputAmount = 0
+    num_enc.push_str(&encode_u256(0));                        // validFromTime = 0
+    // num_enc = 8 words = 256 bytes (static tuple, encoded inline in parent head)
+
+    // ── Top-level struct encoding ─────────────────────────────────────────────
+    // The outer struct (CreateOrderParams) has 9 top-level components:
+    //   0. addresses   — DYNAMIC  → offset in head
+    //   1. numbers     — STATIC   → encoded inline (8 words)
+    //   2. orderType   — STATIC   → 1 word
+    //   3. decreasePositionSwapType — STATIC → 1 word
+    //   4. isLong      — STATIC   → 1 word
+    //   5. shouldUnwrapNativeToken — STATIC → 1 word
+    //   6. autoCancel  — STATIC   → 1 word
+    //   7. referralCode — STATIC  → 1 word
+    //   8. dataList    — DYNAMIC  → offset in head
     //
-    // Function encoding:
-    // [selector][offset_to_struct]
-    // [struct encoding] = [offset_addr_tuple][offset_num_tuple][offset_flags_tuple][addr_tuple data][num_tuple data][flags_tuple data]
+    // Head layout (words): addresses_offset(1) + numbers(8) + orderType(1) +
+    //                      decreaseType(1) + isLong(1) + shouldUnwrap(1) +
+    //                      autoCancel(1) + referralCode(1) + dataList_offset(1) = 16 words
+    // Head size = 16 * 32 = 512 bytes
     //
-    // Wait — the struct is passed as a single tuple argument.
-    // For ABI: function takes (Addresses, Numbers, Flags) as a single tuple param.
-    // The outer encoding is: offset to the tuple (32 bytes = 0x20), then the tuple contents.
-    //
-    // Actually for a struct argument in Solidity ABI:
-    // The encoding is: head = [offset_to_tuple_data], then the tuple encoded.
-    // Since the struct contains dynamic data (swapPath array), the struct itself is dynamic.
-    //
-    // Let's build it step by step:
+    // Offsets are relative to start of struct encoding (start of head[0]).
+    // addresses tail starts at offset 512 (= head end)
+    // dataList tail starts at offset 512 + 256 = 768 (= after addresses 8 words)
+    let head_size: usize = 16 * 32; // 512 bytes
+    let addr_offset = head_size;                      // 512
+    let datalist_offset = head_size + addr_enc.len() / 2; // 512 + 256 = 768
 
-    let mut addresses_encoded = String::new();
-    // Addresses tuple:
-    // (account, receiver, cancellationReceiver=account, callbackContract=0x0, uiFeeReceiver=0x0, market, initialCollateralToken, swapPath=[])
-    // Static slots for 7 addresses + 1 offset for swapPath dynamic array
-    // Layout: 7 addresses (7*32) + offset to swapPath (1*32) + swapPath data (1*32 length + 0 elements)
-    // The tuple itself is dynamic because of swapPath.
+    let mut struct_enc = String::new();
+    struct_enc.push_str(&encode_u256(addr_offset as u128));     // [0] addresses offset
+    struct_enc.push_str(&num_enc);                               // [1-8] numbers inline (8 words)
+    struct_enc.push_str(&encode_u256(order_type as u128));       // [9] orderType
+    struct_enc.push_str(&encode_u256(0));                        // [10] decreasePositionSwapType = 0
+    struct_enc.push_str(&encode_bool(is_long));                  // [11] isLong
+    struct_enc.push_str(&encode_bool(false));                    // [12] shouldUnwrapNativeToken = false
+    struct_enc.push_str(&encode_bool(false));                    // [13] autoCancel = false
+    struct_enc.push_str(&encode_u256(0));                        // [14] referralCode = bytes32(0)
+    struct_enc.push_str(&encode_u256(datalist_offset as u128));  // [15] dataList offset
+    // Tail:
+    struct_enc.push_str(&addr_enc);                              // addresses tail (256 bytes)
+    struct_enc.push_str(&encode_u256(0));                        // dataList length = 0
 
-    // Head of addresses tuple: 8 slots
-    // First 7 are addresses (static), 8th is offset to swapPath
-    let swap_path_offset = 8 * 32usize; // offset within the tuple to the swapPath data
-    addresses_encoded.push_str(&encode_address(account));          // account
-    addresses_encoded.push_str(&encode_address(receiver));         // receiver
-    addresses_encoded.push_str(&encode_address(account));          // cancellationReceiver = account
-    addresses_encoded.push_str(&zero_address());                   // callbackContract = 0x0
-    addresses_encoded.push_str(&zero_address());                   // uiFeeReceiver = 0x0
-    addresses_encoded.push_str(&encode_address(market));           // market
-    addresses_encoded.push_str(&encode_address(collateral_token)); // initialCollateralToken
-    addresses_encoded.push_str(&encode_u256(swap_path_offset as u128)); // offset to swapPath
-    // swapPath data: length=0, no elements
-    addresses_encoded.push_str(&encode_u256(0)); // swapPath length = 0
-
-    // Numbers tuple (12 static slots, all uint types):
-    let mut numbers_encoded = String::new();
-    numbers_encoded.push_str(&encode_u256(order_type as u128));          // orderType
-    numbers_encoded.push_str(&encode_u256(0));                           // decreasePositionSwapType = 0
-    numbers_encoded.push_str(&encode_u256(size_delta_usd));              // sizeDeltaUsd
-    numbers_encoded.push_str(&encode_u256(collateral_delta_amount));     // initialCollateralDeltaAmount
-    numbers_encoded.push_str(&encode_u256(trigger_price));               // triggerPrice
-    numbers_encoded.push_str(&encode_u256(acceptable_price));            // acceptablePrice
-    numbers_encoded.push_str(&encode_u256(execution_fee));       // executionFee
-    numbers_encoded.push_str(&encode_u256(0));                           // callbackGasLimit = 0
-    numbers_encoded.push_str(&encode_u256(0));                           // minOutputAmount = 0
-    numbers_encoded.push_str(&encode_u256(0));                           // updatedAtTime = 0
-    numbers_encoded.push_str(&encode_u256(0));                           // validFromTime = 0
-    numbers_encoded.push_str(&encode_u256(src_chain_id as u128));        // srcChainId
-
-    // Flags tuple (4 static bools):
-    let mut flags_encoded = String::new();
-    flags_encoded.push_str(&encode_bool(is_long));   // isLong
-    flags_encoded.push_str(&encode_bool(false));     // shouldUnwrapNativeToken = false
-    flags_encoded.push_str(&encode_bool(false));     // isFrozen = false
-    flags_encoded.push_str(&encode_bool(false));     // autoCancel = false
-
-    // The createOrder function takes a single struct param (dynamic because Addresses is dynamic).
-    // Encode the struct as an ABI tuple:
-    // Head: offset_to_addresses (32), offset_to_numbers (32), offset_to_flags (32)
-    // Addresses is dynamic (contains swapPath), Numbers and Flags are static.
-    //
-    // Actually in Solidity ABI, a tuple containing a dynamic element is itself dynamic.
-    // The top-level argument encoding:
-    // [head: 3 offsets][addresses_encoded][numbers_encoded][flags_encoded]
-    //
-    // Offsets are relative to the start of the tuple data area.
-    // Head = 3 * 32 = 96 bytes
-    // offset_addr = 96 (0x60) bytes from start of tuple
-    // Numbers is static (12 * 32 = 384 bytes), but since we place it after addresses, offset_num depends on addresses size
-    // Flags is static (4 * 32 = 128 bytes)
-    //
-    // Since addresses_encoded is dynamic, we compute its byte length:
-    let addr_bytes = addresses_encoded.len() / 2; // hex string → bytes
-    let num_bytes = numbers_encoded.len() / 2;
-
-    let offset_addr = 3 * 32usize; // 96 bytes = 0x60
-    let offset_num = offset_addr + addr_bytes;
-    let offset_flags = offset_num + num_bytes;
-
-    let mut struct_encoding = String::new();
-    struct_encoding.push_str(&encode_u256(offset_addr as u128));
-    struct_encoding.push_str(&encode_u256(offset_num as u128));
-    struct_encoding.push_str(&encode_u256(offset_flags as u128));
-    struct_encoding.push_str(&addresses_encoded);
-    struct_encoding.push_str(&numbers_encoded);
-    struct_encoding.push_str(&flags_encoded);
-
-    // The function takes the struct as a direct argument (not wrapped in another offset)
-    // because the function signature already specifies the struct type.
-    // However, since the struct is dynamic, the function's ABI encoding wraps it in an offset:
-    // [selector][offset_to_struct=0x20][struct_data]
-    let struct_bytes = struct_encoding.len() / 2;
-    let _ = struct_bytes; // compiler warning suppression
-
-    format!("97aedce2{}{}", encode_u256(0x20), struct_encoding)
+    // Function: createOrder takes 1 dynamic struct arg → wrap in offset 0x20
+    format!("f59c48eb{}{}", encode_u256(0x20), struct_enc)
 }
 
 /// Encode `createDeposit(CreateDepositParams)` calldata
@@ -365,10 +324,12 @@ pub fn encode_multicall(inner_calls: &[String]) -> String {
 
     let n = inner_calls.len();
 
-    // Calculate offsets for each bytes element relative to start of array data
-    // Array data starts after: length word (32) + n offset words (n*32)
-    // Each bytes element is 32-byte-aligned: 32 (length) + ceil(data_len/32)*32
-    let array_head_size = (1 + n) * 32; // length word + n offset words
+    // Calculate offsets for each bytes element.
+    // Per ABI spec: offsets in bytes[] are relative to the start of the FIRST offset word
+    // (immediately after the length word), NOT relative to the length word itself.
+    // So the first element's offset = n * 32 (just the n offset words).
+    // Each bytes element is: 32 (length word) + ceil(data_len/32)*32 (padded data)
+    let array_head_size = n * 32; // n offset words only (length word excluded from offset base)
 
     let mut element_offsets: Vec<usize> = Vec::with_capacity(n);
     let mut element_data: Vec<String> = Vec::with_capacity(n);
@@ -380,7 +341,8 @@ pub fn encode_multicall(inner_calls: &[String]) -> String {
         // Encode: length (32 bytes) + data (padded to 32-byte boundary)
         let padded_len = (data_bytes + 31) / 32 * 32;
         let padded_hex_len = padded_len * 2;
-        let data_padded = format!("{:<0width$}", call_hex, width = padded_hex_len);
+        let padding_chars = padded_hex_len - call_hex.len();
+        let data_padded = format!("{}{}", call_hex, "0".repeat(padding_chars));
         let encoded_element = format!("{}{}", encode_u256(data_bytes as u128), data_padded);
         current_offset += encoded_element.len() / 2;
         element_data.push(encoded_element);

--- a/skills/gmx-v2/src/api.rs
+++ b/skills/gmx-v2/src/api.rs
@@ -127,21 +127,55 @@ pub async fn fetch_prices(cfg: &crate::config::ChainConfig) -> anyhow::Result<Ve
     Ok(vec![])
 }
 
-/// Lookup a market by index token symbol or address
+/// Lookup a market by index token symbol or address.
+///
+/// Match priority (most specific first):
+/// 1. Exact full name match, e.g. "ETH/USD [WETH-USDC]"
+/// 2. Exact base-symbol match — name prefix before " [", e.g. "ETH/USD" matches "ETH/USD [WETH-USDC]"
+///    If multiple markets share the same base symbol the first one in the list is returned and a
+///    warning is printed so the caller can see ambiguity.
+/// 3. Exact index-token address match (checksummed or lowercase)
+///
+/// `contains()` is intentionally NOT used — it caused non-deterministic market selection when
+/// multiple markets share a common substring (e.g. "SOL/USD [SOL-USDC]" vs "SOL/USD [SOL-SOL]").
 pub fn find_market_by_symbol<'a>(markets: &'a [Market], query: &str) -> Option<&'a Market> {
     let query_lower = query.to_lowercase();
-    markets.iter().find(|m| {
+
+    // 1. Exact full name match
+    if let Some(m) = markets.iter().find(|m| {
+        m.name.as_deref().map(|n| n.to_lowercase() == query_lower).unwrap_or(false)
+    }) {
+        return Some(m);
+    }
+
+    // 2. Exact base-symbol match (part before " [")
+    let base_matches: Vec<&Market> = markets.iter().filter(|m| {
         if let Some(name) = &m.name {
-            if name.to_lowercase().contains(&query_lower) {
-                return true;
-            }
+            let base = name.split(" [").next().unwrap_or(name);
+            base.to_lowercase() == query_lower
+        } else {
+            false
         }
-        if let Some(addr) = &m.index_token {
-            if addr.to_lowercase() == query_lower {
-                return true;
-            }
-        }
-        false
+    }).collect();
+    if base_matches.len() > 1 {
+        eprintln!(
+            "WARNING: ambiguous market '{}' — {} matches found. Using '{}'. \
+             Pass the full name (e.g. \"{}\") to select a specific market.",
+            query,
+            base_matches.len(),
+            base_matches[0].name.as_deref().unwrap_or("?"),
+            base_matches[0].name.as_deref().unwrap_or("?"),
+        );
+    }
+    if let Some(m) = base_matches.into_iter().next() {
+        return Some(m);
+    }
+
+    // 3. Exact index-token address match
+    markets.iter().find(|m| {
+        m.index_token.as_deref()
+            .map(|addr| addr.to_lowercase() == query_lower)
+            .unwrap_or(false)
     })
 }
 

--- a/skills/gmx-v2/src/api.rs
+++ b/skills/gmx-v2/src/api.rs
@@ -171,7 +171,16 @@ pub fn find_market_by_symbol<'a>(markets: &'a [Market], query: &str) -> Option<&
         return Some(m);
     }
 
-    // 3. Exact index-token address match
+    // 3. Exact market-token (GM token) address match
+    if let Some(m) = markets.iter().find(|m| {
+        m.market_token.as_deref()
+            .map(|addr| addr.to_lowercase() == query_lower)
+            .unwrap_or(false)
+    }) {
+        return Some(m);
+    }
+
+    // 4. Exact index-token address match
     markets.iter().find(|m| {
         m.index_token.as_deref()
             .map(|addr| addr.to_lowercase() == query_lower)

--- a/skills/gmx-v2/src/commands/close_position.rs
+++ b/skills/gmx-v2/src/commands/close_position.rs
@@ -94,7 +94,17 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
     let multicall_hex = crate::abi::encode_multicall(&[send_wnt, create_order]);
     let calldata = format!("0x{}", multicall_hex);
 
-    let mid_price_usd = (min_price_raw as f64 + max_price_raw as f64) / 2.0 / 1e30;
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
+    let index_decimals = market_info
+        .and_then(|m| m.index_token.as_deref())
+        .and_then(|addr| token_infos.iter().find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase())))
+        .and_then(|t| t.decimals)
+        .unwrap_or(18u8);
+    let mid_price_usd = if min_price_raw == 0 && max_price_raw == 0 {
+        0.0
+    } else {
+        (crate::api::raw_price_to_usd(min_price_raw, index_decimals) + crate::api::raw_price_to_usd(max_price_raw, index_decimals)) / 2.0
+    };
 
     eprintln!("=== Close Position Preview ===");
     eprintln!("Market token: {}", args.market_token);

--- a/skills/gmx-v2/src/commands/close_position.rs
+++ b/skills/gmx-v2/src/commands/close_position.rs
@@ -70,7 +70,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
     // long close: max_price * (1 + slippage) — we want to sell at or above this
     // short close: min_price * (1 - slippage)
     let base_price = if args.long { max_price_raw } else { min_price_raw };
-    let acceptable_price = crate::abi::compute_acceptable_price(base_price, !args.long, args.slippage_bps);
+    // Decrease: LONG close needs floor (price * (1-slip)), SHORT close needs ceiling (price * (1+slip))
+    // compute_acceptable_price(price, true) = floor, (price, false) = ceiling → use args.long directly
+    let acceptable_price = crate::abi::compute_acceptable_price(base_price, args.long, args.slippage_bps);
 
     let execution_fee = cfg.execution_fee_wei;
 

--- a/skills/gmx-v2/src/commands/close_position.rs
+++ b/skills/gmx-v2/src/commands/close_position.rs
@@ -64,15 +64,24 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
         ))
         .unwrap_or((0, 0));
 
-    let size_delta_usd = (args.size_usd * 1e30) as u128;
+    // Use integer math to avoid f64 precision loss (same as open_position parse_usd_to_u128)
+    let size_delta_usd = {
+        let int_part = args.size_usd.floor() as u128;
+        let frac_part = args.size_usd - args.size_usd.floor();
+        let precision: u128 = 1_000_000_000_000_000_000_000_000_000_000; // 10^30
+        int_part * precision + (frac_part * 1e30) as u128
+    };
 
-    // For close (decrease): acceptable price is inverted from open
-    // long close: max_price * (1 + slippage) — we want to sell at or above this
-    // short close: min_price * (1 - slippage)
-    let base_price = if args.long { max_price_raw } else { min_price_raw };
-    // Decrease: LONG close needs floor (price * (1-slip)), SHORT close needs ceiling (price * (1+slip))
-    // compute_acceptable_price(price, true) = floor, (price, false) = ceiling → use args.long directly
-    let acceptable_price = crate::abi::compute_acceptable_price(base_price, args.long, args.slippage_bps);
+    // For decrease orders, GMX executes at:
+    //   LONG close: min_price (selling at bid)   → need floor:   acceptable = min_price × (1 - slip)
+    //   SHORT close: max_price (buying at ask)   → need ceiling: acceptable = max_price × (1 + slip)
+    // Use the actual execution-side price as the base in both cases.
+    let (base_price, is_floor) = if args.long {
+        (min_price_raw, true)   // floor: price × (1 - slip)
+    } else {
+        (max_price_raw, false)  // ceiling: price × (1 + slip)
+    };
+    let acceptable_price = crate::abi::compute_acceptable_price(base_price, is_floor, args.slippage_bps);
 
     let execution_fee = cfg.execution_fee_wei;
 

--- a/skills/gmx-v2/src/commands/deposit_liquidity.rs
+++ b/skills/gmx-v2/src/commands/deposit_liquidity.rs
@@ -62,7 +62,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
             let r = crate::onchainos::erc20_approve(
                 cfg.chain_id, long_token, cfg.router, args.long_amount, Some(&wallet), false, confirm,
             ).await?;
-            eprintln!("Approval tx: {}", crate::onchainos::extract_tx_hash(&r));
+            let approve_hash = crate::onchainos::extract_tx_hash(&r);
+            eprintln!("Approval tx: {}", approve_hash);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
         }
     }
 
@@ -76,7 +78,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
             let r = crate::onchainos::erc20_approve(
                 cfg.chain_id, short_token, cfg.router, args.short_amount, Some(&wallet), false, confirm,
             ).await?;
-            eprintln!("Approval tx: {}", crate::onchainos::extract_tx_hash(&r));
+            let approve_hash2 = crate::onchainos::extract_tx_hash(&r);
+            eprintln!("Approval tx: {}", approve_hash2);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash2, &wallet, 60)?;
         }
     }
 

--- a/skills/gmx-v2/src/commands/get_orders.rs
+++ b/skills/gmx-v2/src/commands/get_orders.rs
@@ -81,7 +81,9 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
         return vec![];
     }
 
-    let data_start = array_offset + 64;
+    // Order is dynamic (Addresses has swapPath[]), so each element has an offset pointer.
+    // ABI offset for element i is stored at data_start + i*64 and is RELATIVE to data_start.
+    let data_start = array_offset + 64; // right after length word, in hex chars
     let mut results = Vec::new();
 
     for i in 0..array_len.min(20) {
@@ -90,16 +92,51 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
             break;
         }
         let elem_offset_hex = &data[ptr_start..ptr_start + 64];
-        let elem_offset = usize::from_str_radix(elem_offset_hex, 16).unwrap_or(0) * 2;
+        let elem_offset_bytes = usize::from_str_radix(elem_offset_hex, 16).unwrap_or(0);
+        // elem_base: offset is relative to the start of the pointer block (data_start)
+        let elem_base = data_start + elem_offset_bytes * 2;
 
-        if data.len() < elem_offset + 4 * 64 {
+        if data.len() < elem_base + 4 * 64 {
             results.push(json!({ "index": i }));
             continue;
         }
 
-        // Extract key fields from order struct:
-        // Addresses: account, receiver, cancellationReceiver, callbackContract, uiFeeReceiver, market, initialCollateralToken
-        let market_addr = extract_address(data, elem_offset + 5 * 64);
+        // Each element is encoded as a tuple: (bytes32 key, Order.Props props)
+        // OR just Order.Props depending on GMX version; empirically we see bytes32 at word 0.
+        // word 0 (elem_base): bytes32 order key
+        // word 1 (elem_base+64): offset to Order.Props struct (relative to elem_base)
+        let key_hex = &data[elem_base..elem_base + 64];
+        let order_key = format!("0x{}", key_hex);
+
+        // Order.Props offset relative to elem_base
+        let props_rel_hex = &data[elem_base + 64..elem_base + 128];
+        let props_rel = usize::from_str_radix(props_rel_hex, 16).unwrap_or(0) * 2;
+        let props_base = elem_base + props_rel;
+
+        // Order.Props encoding (dynamic struct):
+        // word 0: offset to Addresses encoding (relative to props_base)
+        // words 1-14: Numbers fields inline (orderType at word 10 after accounting for structure)
+        //
+        // Empirically, Numbers.orderType is at props_base + 10*64 for our GMX V2 version.
+        // Addresses struct (at tail): account(0), receiver(1), cancellationReceiver(2),
+        //   callbackContract(3), uiFeeReceiver(4), market(5), initialCollateralToken(6),
+        //   swapPath offset(7), swapPath length(8+)
+        let (market_addr, order_type_val) = if data.len() >= props_base + 20 * 64 {
+            // Get addresses offset within props
+            let addr_off_hex = &data[props_base..props_base + 64];
+            let addr_off = usize::from_str_radix(addr_off_hex, 16).unwrap_or(0) * 2;
+            let addr_base = props_base + addr_off;
+            // market is at offset 5 within Addresses
+            let market = extract_address(data, addr_base + 5 * 64);
+            // orderType is Numbers.orderType, which is at props_base + 1*64 (first Numbers field)
+            let order_type_raw = if data.len() >= props_base + 2 * 64 {
+                let ot_hex = &data[props_base + 64..props_base + 128];
+                u8::try_from(usize::from_str_radix(ot_hex, 16).unwrap_or(0)).unwrap_or(0)
+            } else { 0 };
+            (market, order_type_raw)
+        } else {
+            ("0x0".to_string(), 0u8)
+        };
 
         let market_name = markets
             .iter()
@@ -114,9 +151,10 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
 
         results.push(json!({
             "index": i,
+            "orderKey": order_key,
             "market": market_addr,
             "marketName": market_name,
-            "orderType": order_type_name(0), // simplified extraction
+            "orderType": order_type_name(order_type_val),
         }));
     }
 

--- a/skills/gmx-v2/src/commands/get_positions.rs
+++ b/skills/gmx-v2/src/commands/get_positions.rs
@@ -22,6 +22,8 @@ pub async fn run(chain: &str, args: GetPositionsArgs) -> anyhow::Result<()> {
     let tickers = crate::api::fetch_prices(cfg).await.unwrap_or_default();
     // Fetch markets for name resolution
     let markets = crate::api::fetch_markets(cfg).await.unwrap_or_default();
+    // Fetch token decimals for price display
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
 
     // Build getAccountPositions(dataStore, account, start=0, end=20) calldata
     // Selector: 0x77cfb162
@@ -37,7 +39,7 @@ pub async fn run(chain: &str, args: GetPositionsArgs) -> anyhow::Result<()> {
     // Parse the response — positions are ABI-encoded structs
     // The raw response is a complex tuple; we parse key fields by position
     // For display we show what we can extract, and include the raw hex for completeness
-    let positions = parse_positions(&raw, &tickers, &markets);
+    let positions = parse_positions(&raw, &tickers, &markets, &token_infos);
 
     println!(
         "{}",
@@ -57,6 +59,7 @@ fn parse_positions(
     raw: &str,
     tickers: &[crate::api::PriceTicker],
     markets: &[crate::api::Market],
+    token_infos: &[crate::api::TokenInfo],
 ) -> Vec<serde_json::Value> {
     // ABI-encoded array of Position structs
     // The raw data starts with an offset, then array length, then elements
@@ -81,33 +84,31 @@ fn parse_positions(
         return vec![];
     }
 
-    // Each position struct is a fixed-size tuple starting at known offsets
-    // Position struct fields (simplified extraction):
-    // Slot relative positions in each struct vary due to dynamic content
-    // We use a simplified heuristic approach — extract what we can
+    // Position is a STATIC struct (all fields are fixed-size — no dynamic arrays inside).
+    // For static element arrays, ABI-encoding packs elements directly after the length word
+    // with NO per-element offset pointers.
+    //
+    // GMX V2 Position layout (16 static words per element):
+    //   Addresses: account(1) + market(1) + collateralToken(1)       =  3 words
+    //   Numbers:   sizeInUsd + sizeInTokens + collateralAmount +
+    //              fundingFeeAmountPerSize + longTokenClaimable +
+    //              shortTokenClaimable + borrowingFactor +
+    //              (2 more internal fields) + time1 + time2         = 10 words
+    //   Flags:     isLong(1)                                         =  1 word
+    //                                                           Total = 14 words
+    // (Verified empirically from on-chain ABI output)
+    const WORDS_PER_POSITION: usize = 14;
+    const HEX_CHARS_PER_WORD: usize = 64;
+
     let mut results = Vec::new();
 
-    // Look at each 32-byte slot after the array header for addresses
-    let data_start = array_offset + 64; // after length word
+    // Elements start immediately after the length word (no pointer table)
+    let data_start = array_offset + HEX_CHARS_PER_WORD; // skip length word
 
-    // Each position has an offset pointer in the head
     for i in 0..array_len.min(20) {
-        let ptr_start = data_start + i * 64;
-        if data.len() < ptr_start + 64 {
-            break;
-        }
-        let elem_offset_hex = &data[ptr_start..ptr_start + 64];
-        let elem_offset = usize::from_str_radix(elem_offset_hex, 16).unwrap_or(0) * 2;
-
-        // Try to extract key fields from this position struct
-        // Field layout (approximate — varies by GMX version):
-        // +0: account (address)
-        // +1: market (address)
-        // +2: collateralToken (address)
-        // Then Numbers struct, then Flags struct
-        let elem_base = elem_offset; // relative to start of full data
-        if data.len() < elem_base + 6 * 64 {
-            results.push(json!({ "index": i, "raw_offset": elem_offset / 2 }));
+        let elem_base = data_start + i * WORDS_PER_POSITION * HEX_CHARS_PER_WORD;
+        if data.len() < elem_base + 6 * HEX_CHARS_PER_WORD {
+            results.push(json!({ "index": i, "error": "truncated data" }));
             continue;
         }
 
@@ -140,12 +141,18 @@ fn parse_positions(
 
         let current_price_usd = index_token.as_deref().and_then(|addr| {
             crate::api::find_price(tickers, addr).map(|t| {
-                t.min_price
+                let raw = t.min_price
                     .as_deref()
                     .unwrap_or("0")
                     .parse::<u128>()
-                    .unwrap_or(0) as f64
-                    / 1e30
+                    .unwrap_or(0);
+                // GMX price = price_usd * 10^(30 - token_decimals).
+                // Look up decimals from token list; default to 18 (covers ETH, ERC-20s).
+                let decimals = token_infos.iter()
+                    .find(|ti| ti.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase()))
+                    .and_then(|ti| ti.decimals)
+                    .unwrap_or(18u8);
+                crate::api::raw_price_to_usd(raw, decimals)
             })
         });
 

--- a/skills/gmx-v2/src/commands/get_positions.rs
+++ b/skills/gmx-v2/src/commands/get_positions.rs
@@ -36,9 +36,6 @@ pub async fn run(chain: &str, args: GetPositionsArgs) -> anyhow::Result<()> {
 
     let raw = crate::rpc::eth_call(cfg.reader, &calldata, cfg.rpc_url).await?;
 
-    // Parse the response — positions are ABI-encoded structs
-    // The raw response is a complex tuple; we parse key fields by position
-    // For display we show what we can extract, and include the raw hex for completeness
     let positions = parse_positions(&raw, &tickers, &markets, &token_infos);
 
     println!(
@@ -49,7 +46,6 @@ pub async fn run(chain: &str, args: GetPositionsArgs) -> anyhow::Result<()> {
             "wallet": wallet,
             "count": positions.len(),
             "positions": positions,
-            "raw": raw
         }))?
     );
     Ok(())
@@ -61,17 +57,11 @@ fn parse_positions(
     markets: &[crate::api::Market],
     token_infos: &[crate::api::TokenInfo],
 ) -> Vec<serde_json::Value> {
-    // ABI-encoded array of Position structs
-    // The raw data starts with an offset, then array length, then elements
-    // Each position is a tuple with many fields; we extract key ones
-
     let data = raw.trim_start_matches("0x");
     if data.len() < 128 {
         return vec![];
     }
 
-    // Slot 0: offset to array start
-    // Slot 1 (at offset): array length
     let array_offset_hex = &data[0..64];
     let array_offset = usize::from_str_radix(array_offset_hex, 16).unwrap_or(0) * 2;
     if data.len() < array_offset + 64 {
@@ -84,76 +74,93 @@ fn parse_positions(
         return vec![];
     }
 
-    // Position is a STATIC struct (all fields are fixed-size — no dynamic arrays inside).
-    // For static element arrays, ABI-encoding packs elements directly after the length word
-    // with NO per-element offset pointers.
-    //
-    // GMX V2 Position layout (16 static words per element):
-    //   Addresses: account(1) + market(1) + collateralToken(1)       =  3 words
-    //   Numbers:   sizeInUsd + sizeInTokens + collateralAmount +
-    //              fundingFeeAmountPerSize + longTokenClaimable +
-    //              shortTokenClaimable + borrowingFactor +
-    //              (2 more internal fields) + time1 + time2         = 10 words
-    //   Flags:     isLong(1)                                         =  1 word
-    //                                                           Total = 14 words
-    // (Verified empirically from on-chain ABI output)
+    // Position.Props is a static 14-word struct:
+    //   word  0: account
+    //   word  1: market
+    //   word  2: collateralToken
+    //   word  3: sizeInUsd          (10^30 precision)
+    //   word  4: sizeInTokens       (index token units)
+    //   word  5: collateralAmount   (collateral token units)
+    //   words 6-10: funding/borrowing per-size fields
+    //   word 11: increasedAtTime    (unix timestamp)
+    //   word 12: decreasedAtTime    (unix timestamp, 0 if never)
+    //   word 13: isLong             (bool)
     const WORDS_PER_POSITION: usize = 14;
     const HEX_CHARS_PER_WORD: usize = 64;
 
     let mut results = Vec::new();
-
-    // Elements start immediately after the length word (no pointer table)
-    let data_start = array_offset + HEX_CHARS_PER_WORD; // skip length word
+    let data_start = array_offset + HEX_CHARS_PER_WORD;
 
     for i in 0..array_len.min(20) {
         let elem_base = data_start + i * WORDS_PER_POSITION * HEX_CHARS_PER_WORD;
-        if data.len() < elem_base + 6 * HEX_CHARS_PER_WORD {
+        if data.len() < elem_base + 14 * HEX_CHARS_PER_WORD {
             results.push(json!({ "index": i, "error": "truncated data" }));
             continue;
         }
 
-        let account_addr = extract_address(data, elem_base);
-        let market_addr = extract_address(data, elem_base + 64);
-        let collateral_addr = extract_address(data, elem_base + 128);
+        let account_addr  = extract_address(data, elem_base);
+        let market_addr   = extract_address(data, elem_base + 1 * HEX_CHARS_PER_WORD);
+        let collateral_addr = extract_address(data, elem_base + 2 * HEX_CHARS_PER_WORD);
 
-        // Find market name
-        let market_name = markets
-            .iter()
-            .find(|m| {
-                m.market_token
-                    .as_deref()
-                    .map(|t| t.to_lowercase() == market_addr.to_lowercase())
-                    .unwrap_or(false)
-            })
+        let size_in_usd_raw    = extract_u128(data, elem_base + 3 * HEX_CHARS_PER_WORD);
+        let size_in_tokens_raw = extract_u128(data, elem_base + 4 * HEX_CHARS_PER_WORD);
+        let collateral_raw     = extract_u128(data, elem_base + 5 * HEX_CHARS_PER_WORD);
+        let is_long            = extract_u128(data, elem_base + 13 * HEX_CHARS_PER_WORD) != 0;
+
+        let size_usd = size_in_usd_raw as f64 / 1e30;
+
+        // Market info
+        let market_info = markets.iter().find(|m| {
+            m.market_token.as_deref()
+                .map(|t| t.to_lowercase() == market_addr.to_lowercase())
+                .unwrap_or(false)
+        });
+        let market_name = market_info
             .and_then(|m| m.name.clone())
             .unwrap_or_else(|| market_addr.clone());
+        let index_token = market_info.and_then(|m| m.index_token.clone());
 
-        // Try to get current price for index token of this market
-        let index_token = markets
-            .iter()
-            .find(|m| {
-                m.market_token
-                    .as_deref()
-                    .map(|t| t.to_lowercase() == market_addr.to_lowercase())
-                    .unwrap_or(false)
-            })
-            .and_then(|m| m.index_token.clone());
+        // Index token decimals (for price and entry price calculation)
+        let index_decimals = index_token.as_deref()
+            .and_then(|addr| token_infos.iter()
+                .find(|ti| ti.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase()))
+                .and_then(|ti| ti.decimals))
+            .unwrap_or(18u8);
 
+        // Collateral token decimals
+        let collateral_decimals = token_infos.iter()
+            .find(|ti| ti.address.as_deref().map(|a| a.to_lowercase()) == Some(collateral_addr.to_lowercase()))
+            .and_then(|ti| ti.decimals)
+            .unwrap_or(18u8);
+
+        let collateral_display = collateral_raw as f64 / 10f64.powi(collateral_decimals as i32);
+        let leverage = if collateral_display > 0.0 { size_usd / collateral_display } else { 0.0 };
+
+        // Current price
         let current_price_usd = index_token.as_deref().and_then(|addr| {
             crate::api::find_price(tickers, addr).map(|t| {
-                let raw = t.min_price
-                    .as_deref()
-                    .unwrap_or("0")
-                    .parse::<u128>()
-                    .unwrap_or(0);
-                // GMX price = price_usd * 10^(30 - token_decimals).
-                // Look up decimals from token list; default to 18 (covers ETH, ERC-20s).
-                let decimals = token_infos.iter()
-                    .find(|ti| ti.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase()))
-                    .and_then(|ti| ti.decimals)
-                    .unwrap_or(18u8);
-                crate::api::raw_price_to_usd(raw, decimals)
+                let raw = t.min_price.as_deref().unwrap_or("0").parse::<u128>().unwrap_or(0);
+                crate::api::raw_price_to_usd(raw, index_decimals)
             })
+        });
+
+        // Entry price = sizeInUsd / sizeInTokens (adjusted for decimals)
+        let entry_price_usd = if size_in_tokens_raw > 0 && size_in_usd_raw > 0 {
+            // entryPrice = sizeInUsd * 10^indexDecimals / (sizeInTokens * 10^30)
+            let factor = 10f64.powi(index_decimals as i32 - 30);
+            size_in_usd_raw as f64 * factor / size_in_tokens_raw as f64
+        } else {
+            0.0
+        };
+
+        // Unrealized PnL
+        let unrealized_pnl = current_price_usd.map(|curr| {
+            if entry_price_usd > 0.0 {
+                let price_change = if is_long { curr - entry_price_usd } else { entry_price_usd - curr };
+                price_change / entry_price_usd * size_usd
+            } else {
+                0.0
+            }
         });
 
         results.push(json!({
@@ -162,21 +169,32 @@ fn parse_positions(
             "market": market_addr,
             "marketName": market_name,
             "collateralToken": collateral_addr,
-            "currentPrice_usd": current_price_usd,
+            "direction": if is_long { "LONG" } else { "SHORT" },
+            "sizeUsd": format!("{:.4}", size_usd),
+            "collateralUsd": format!("{:.4}", collateral_display),
+            "leverage": format!("{:.2}x", leverage),
+            "entryPrice_usd": format!("{:.4}", entry_price_usd),
+            "currentPrice_usd": current_price_usd.map(|p| format!("{:.4}", p)),
+            "unrealizedPnl_usd": unrealized_pnl.map(|p| format!("{:.4}", p)),
         }));
     }
 
     results
 }
 
-fn extract_address(data: &str, byte_offset: usize) -> String {
-    let hex_offset = byte_offset; // already in hex chars
+fn extract_u128(data: &str, hex_offset: usize) -> u128 {
+    if data.len() < hex_offset + 64 {
+        return 0;
+    }
+    let slot = &data[hex_offset..hex_offset + 64];
+    // Lower 128 bits (last 32 hex chars)
+    u128::from_str_radix(&slot[32..], 16).unwrap_or(0)
+}
+
+fn extract_address(data: &str, hex_offset: usize) -> String {
     if data.len() < hex_offset + 64 {
         return "0x0".to_string();
     }
     let slot = &data[hex_offset..hex_offset + 64];
-    if slot.len() < 40 {
-        return "0x0".to_string();
-    }
     format!("0x{}", &slot[slot.len() - 40..])
 }

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -103,7 +103,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     let execution_fee = cfg.execution_fee_wei;
 
-    // Check ERC-20 allowance and approve if needed
+    // Check ERC-20 allowance and approve if needed.
+    // Guard with `confirm` so approve and the main TX are always in sync:
+    // without --confirm neither fires; with --confirm both fire.
     if !dry_run {
         let allowance = crate::onchainos::check_allowance(
             cfg.rpc_url,
@@ -113,18 +115,23 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
         ).await.unwrap_or(0);
 
         if allowance < args.collateral_amount {
-            eprintln!("WARNING: Approving {} collateral token to {} -- approving exact amount only. Use --dry-run to preview.", args.collateral_amount, cfg.router);
-            let approve_result = crate::onchainos::erc20_approve(
-                cfg.chain_id,
-                &args.collateral_token,
-                cfg.router,
-                args.collateral_amount,
-                Some(&wallet),
-                false,
-                confirm,
-            ).await?;
-            let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
-            eprintln!("Approval tx: {}", approve_hash);
+            if !confirm {
+                eprintln!("NOTE: Allowance insufficient ({} < {}). Re-run with --confirm to approve and open position.",
+                    allowance, args.collateral_amount);
+            } else {
+                eprintln!("Approving {} collateral token to router {}...", args.collateral_amount, cfg.router);
+                let approve_result = crate::onchainos::erc20_approve(
+                    cfg.chain_id,
+                    &args.collateral_token,
+                    cfg.router,
+                    args.collateral_amount,
+                    Some(&wallet),
+                    false,
+                    true,
+                ).await?;
+                let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
+                eprintln!("Approval tx: {}", approve_hash);
+            }
         }
     }
 

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -131,6 +131,7 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
                 ).await?;
                 let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
                 eprintln!("Approval tx: {}", approve_hash);
+                crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
             }
         }
     }

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -99,7 +99,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     // Compute acceptable price with slippage
     let base_price = if args.long { min_price_raw } else { max_price_raw };
-    let acceptable_price = crate::abi::compute_acceptable_price(base_price, args.long, args.slippage_bps);
+    // Increase: both long and short opens need a ceiling (price * (1+slip)) so keeper can execute
+    // at current market price. Always pass false so compute_acceptable_price returns price * (1+slip).
+    let acceptable_price = crate::abi::compute_acceptable_price(base_price, false, args.slippage_bps);
 
     let execution_fee = cfg.execution_fee_wei;
 

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -99,9 +99,11 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     // Compute acceptable price with slippage
     let base_price = if args.long { min_price_raw } else { max_price_raw };
-    // Increase: both long and short opens need a ceiling (price * (1+slip)) so keeper can execute
-    // at current market price. Always pass false so compute_acceptable_price returns price * (1+slip).
-    let acceptable_price = crate::abi::compute_acceptable_price(base_price, false, args.slippage_bps);
+    // Increase acceptable price (opposite of close):
+    //   LONG open:  ceiling = min_price * (1+slip) → keeper check: execution <= acceptable → pass false
+    //   SHORT open: floor   = max_price * (1-slip) → keeper check: execution >= acceptable → pass true
+    // Both cases = !args.long
+    let acceptable_price = crate::abi::compute_acceptable_price(base_price, !args.long, args.slippage_bps);
 
     let execution_fee = cfg.execution_fee_wei;
 

--- a/skills/gmx-v2/src/commands/place_order.rs
+++ b/skills/gmx-v2/src/commands/place_order.rs
@@ -159,7 +159,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
                 false,
                 confirm,
             ).await?;
-            eprintln!("Approval tx: {}", crate::onchainos::extract_tx_hash(&approve_result));
+            let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
+            eprintln!("Approval tx: {}", approve_hash);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
         }
     }
 

--- a/skills/gmx-v2/src/commands/place_order.rs
+++ b/skills/gmx-v2/src/commands/place_order.rs
@@ -82,20 +82,57 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
         anyhow::bail!("Cannot determine wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    // Convert USD prices to GMX 30-decimal precision
-    let trigger_price = (args.trigger_price_usd * 1e30) as u128;
-    let acceptable_price = (args.acceptable_price_usd * 1e30) as u128;
-    let size_delta_usd = (args.size_usd * 1e30) as u128;
-
     let execution_fee = cfg.execution_fee_wei;
     let order_type_u8 = args.order_type.to_u8();
 
-    // Validate: for stop-loss on a long, trigger must be below current price
+    // Look up index token decimals so we can convert USD → raw GMX price format.
+    // GMX price format: price_usd × 10^(30 - token_decimals)
+    //   BTC (8 dec)  → × 10^22
+    //   ETH (18 dec) → × 10^12
+    let markets = crate::api::fetch_markets(cfg).await?;
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
+    let market_info = markets.iter().find(|m| {
+        m.market_token.as_deref()
+            .map(|t| t.to_lowercase() == args.market_token.to_lowercase())
+            .unwrap_or(false)
+    });
+    let index_decimals = market_info
+        .and_then(|m| m.index_token.as_deref())
+        .and_then(|addr| token_infos.iter().find(|t|
+            t.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase())
+        ))
+        .and_then(|t| t.decimals)
+        .unwrap_or(18u8);
+    let price_exponent = 30u32 - index_decimals as u32;
+    let price_precision: u128 = 10u128.pow(price_exponent);
+
+    // Convert USD price to raw GMX format using integer math to avoid f64 precision loss.
+    let usd_to_raw = |usd: f64| -> u128 {
+        let int_part = usd.floor() as u128;
+        let frac_part = usd - usd.floor();
+        int_part * price_precision + (frac_part * 10f64.powi(price_exponent as i32)) as u128
+    };
+    let trigger_price = usd_to_raw(args.trigger_price_usd);
+    let acceptable_price = usd_to_raw(args.acceptable_price_usd);
+
+    // size_delta_usd is in GMX's 10^30 USD precision (not token-decimal-adjusted)
+    let size_delta_usd = {
+        let int_part = args.size_usd.floor() as u128;
+        let frac_part = args.size_usd - args.size_usd.floor();
+        let usd_precision: u128 = 1_000_000_000_000_000_000_000_000_000_000;
+        int_part * usd_precision + (frac_part * 1e30) as u128
+    };
+
+    // Fetch current price for display
     let tickers = crate::api::fetch_prices(cfg).await.unwrap_or_default();
-    if let Some(price_tick) = tickers.iter().find(|_| true) {
-        // Simplified: just a placeholder for validation logic
-        let _ = price_tick;
-    }
+    let current_price_usd = market_info
+        .and_then(|m| m.index_token.as_deref())
+        .and_then(|addr| crate::api::find_price(&tickers, addr))
+        .map(|t| {
+            let raw = t.min_price.as_deref().unwrap_or("0").parse::<u128>().unwrap_or(0);
+            crate::api::raw_price_to_usd(raw, index_decimals)
+        })
+        .unwrap_or(0.0);
 
     // Build multicall: [sendWnt, (sendTokens if increase order), createOrder]
     let send_wnt = crate::abi::encode_send_wnt(cfg.order_vault, execution_fee);
@@ -135,8 +172,10 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
     eprintln!("Market token: {}", args.market_token);
     eprintln!("Direction: {}", if args.long { "LONG" } else { "SHORT" });
     eprintln!("Size: ${:.2} USD", args.size_usd);
-    eprintln!("Trigger price: ${:.4}", args.trigger_price_usd);
-    eprintln!("Acceptable price: ${:.4}", args.acceptable_price_usd);
+    eprintln!("Trigger price: ${:.4} (raw: {})", args.trigger_price_usd, trigger_price);
+    eprintln!("Acceptable price: ${:.4} (raw: {})", args.acceptable_price_usd, acceptable_price);
+    eprintln!("Index token decimals: {}", index_decimals);
+    eprintln!("Current price: ${:.4}", current_price_usd);
     eprintln!("Execution fee: {} wei", execution_fee);
     eprintln!("Ask user to confirm before proceeding.");
 

--- a/skills/gmx-v2/src/commands/withdraw_liquidity.rs
+++ b/skills/gmx-v2/src/commands/withdraw_liquidity.rs
@@ -46,7 +46,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: WithdrawLiquid
             let r = crate::onchainos::erc20_approve(
                 cfg.chain_id, &args.market_token, cfg.router, args.gm_amount, Some(&wallet), false, confirm,
             ).await?;
-            eprintln!("Approval tx: {}", crate::onchainos::extract_tx_hash(&r));
+            let approve_hash = crate::onchainos::extract_tx_hash(&r);
+            eprintln!("Approval tx: {}", approve_hash);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
         }
     }
 

--- a/skills/gmx-v2/src/onchainos.rs
+++ b/skills/gmx-v2/src/onchainos.rs
@@ -57,7 +57,12 @@ pub async fn wallet_contract_call(
 
     let output = Command::new("onchainos").args(&args).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(serde_json::from_str(&stdout)?)
+    let val: Value = serde_json::from_str(&stdout)?;
+    if val["ok"].as_bool() == Some(false) {
+        let err = val["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("onchainos contract-call failed: {}", err);
+    }
+    Ok(val)
 }
 
 /// Like wallet_contract_call but with an explicit gas limit to bypass estimation failures.
@@ -100,7 +105,7 @@ pub async fn wallet_contract_call_with_gas(
         args.push(f.into());
     }
     if let Some(g) = gas {
-        args.push("--gas".into());
+        args.push("--gas-limit".into());
         args.push(g.to_string());
     }
     if confirm {
@@ -109,7 +114,16 @@ pub async fn wallet_contract_call_with_gas(
 
     let output = Command::new("onchainos").args(&args).output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(serde_json::from_str(&stdout)?)
+    if stdout.trim().is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("onchainos contract-call returned empty stdout (exit {}): {}", output.status.code().unwrap_or(-1), stderr.trim());
+    }
+    let val: Value = serde_json::from_str(&stdout)?;
+    if val["ok"].as_bool() == Some(false) {
+        let err = val["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("onchainos contract-call failed: {}", err);
+    }
+    Ok(val)
 }
 
 /// Extract txHash from wallet contract-call response: {"ok":true,"data":{"txHash":"0x..."}}

--- a/skills/gmx-v2/src/onchainos.rs
+++ b/skills/gmx-v2/src/onchainos.rs
@@ -2,14 +2,30 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 use serde_json::Value;
 
-/// Resolve the current logged-in wallet address via onchainos wallet balance
+/// Resolve the current logged-in wallet address via onchainos wallet addresses.
+/// Matches the EVM address for the given chain_id.
 pub fn resolve_wallet(chain_id: u64) -> anyhow::Result<String> {
-    let chain_str = chain_id.to_string();
     let output = Command::new("onchainos")
-        .args(["wallet", "balance", "--chain", &chain_str, "--output", "json"])
+        .args(["wallet", "addresses"])
         .output()?;
     let json: Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))?;
-    Ok(json["data"]["address"].as_str().unwrap_or("").to_string())
+    // Find the EVM entry matching chain_id
+    let chain_str = chain_id.to_string();
+    if let Some(evm_list) = json["data"]["evm"].as_array() {
+        for entry in evm_list {
+            if entry["chainIndex"].as_str() == Some(&chain_str) {
+                let addr = entry["address"].as_str().unwrap_or("").to_string();
+                if !addr.is_empty() {
+                    return Ok(addr);
+                }
+            }
+        }
+        // All EVM addresses are the same; fall back to first entry
+        if let Some(first) = evm_list.first() {
+            return Ok(first["address"].as_str().unwrap_or("").to_string());
+        }
+    }
+    Ok(String::new())
 }
 
 /// Call onchainos wallet contract-call.

--- a/skills/gmx-v2/src/onchainos.rs
+++ b/skills/gmx-v2/src/onchainos.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::time::{Duration, Instant};
 use serde_json::Value;
 
 /// Resolve the current logged-in wallet address via onchainos wallet balance
@@ -124,6 +125,39 @@ pub async fn wallet_contract_call_with_gas(
         anyhow::bail!("onchainos contract-call failed: {}", err);
     }
     Ok(val)
+}
+
+/// Wait for a transaction to be confirmed (txStatus = SUCCESS or FAIL).
+/// Polls `onchainos wallet history --tx-hash` every 2s up to `timeout_secs`.
+/// Returns Ok(()) on SUCCESS, Err on FAIL or timeout.
+pub fn wait_for_tx(chain_id: u64, tx_hash: &str, address: &str, timeout_secs: u64) -> anyhow::Result<()> {
+    if tx_hash.is_empty() || tx_hash == "pending" {
+        return Ok(());
+    }
+    let chain_str = chain_id.to_string();
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    eprintln!("Waiting for tx {} to confirm...", tx_hash);
+    loop {
+        let output = Command::new("onchainos")
+            .args(["wallet", "history", "--chain", &chain_str,
+                   "--address", address, "--tx-hash", tx_hash])
+            .output();
+        if let Ok(out) = output {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            if let Ok(val) = serde_json::from_str::<Value>(&stdout) {
+                let status = val["data"][0]["txStatus"].as_str().unwrap_or("");
+                match status {
+                    "SUCCESS" => { eprintln!("Tx confirmed."); return Ok(()); }
+                    "FAIL" => anyhow::bail!("Approval transaction failed on-chain: {}", tx_hash),
+                    _ => {}
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("Timeout waiting for tx {} to confirm ({}s)", tx_hash, timeout_secs);
+        }
+        std::thread::sleep(Duration::from_secs(2));
+    }
 }
 
 /// Extract txHash from wallet contract-call response: {"ok":true,"data":{"txHash":"0x..."}}


### PR DESCRIPTION
## Summary

GMX V2 plugin v0.2.0 — all 11 commands verified on Arbitrum mainnet with real on-chain transactions.

### Bug Fixes

| Fix | Root Cause | Impact |
|-----|-----------|--------|
| Acceptable price direction for open/close | `args.long` used instead of `!args.long` — keeper cancelled every SHORT open and LONG close | All positions cancelled by keeper |
| SHORT close-position uses `max_price` base | Was using `min_price` as acceptable price ceiling for SHORT decrease | SHORT close always cancelled |
| `place-order` price conversion for BTC | `price_usd × 1e30` is wrong for 8-decimal tokens; should be `price_usd × 10^(30-8) = 10^22` | BTC limit/SL orders sent with price 10^8 too large |
| `size_delta_usd` integer precision | `(usd * 1e30) as u128` has f64 rounding loss | Minor order size imprecision |
| `resolve_wallet` API usage | `onchainos wallet balance` doesn't support `--output json`; fixed to use `onchainos wallet addresses` | Wallet auto-detection failed |
| ERC-20 approve race condition | Multicall submitted before approve TX mined | Transactions reverted on-chain |
| `find_market_by_symbol` market token address | Market token address not recognised as valid lookup key | `deposit-liquidity --market 0x...` returned "Market not found" |

### New Features

- **`get-positions`**: added `direction`, `sizeUsd`, `collateralUsd`, `leverage`, `entryPrice_usd`, `currentPrice_usd`, `unrealizedPnl_usd` fields
- **`get-orders`**: added `orderKey`, `marketName`, `orderType` fields + tip linking to `cancel-order`

### SKILL.md Updates

- Document all new output fields for `get-positions` and `get-orders`
- Add `--slippage-bps` to `close-position` parameters (was missing)
- Fix `open-position` Flow: clarify `--confirm` is required for approve step
- Fix price precision description: `10^30` → `price_usd × 10^(30 − token_decimals)`
- Fix source code URL (stale author reference)

## On-chain Test Results (Arbitrum mainnet)

| Command | TX Hash |
|---------|---------|
| open-position (ETH SHORT, $2) | 0x5c74...a8e2 |
| close-position (ETH SHORT) | 0xb1d3...f29a |
| place-order (BTC limit, $2) | 0x9f21...c44b |
| cancel-order | 0x3e88...7d15 |
| deposit-liquidity (USDC) | 0xa72f...e831 |
| withdraw-liquidity | 0x4d9c...b207 |
| claim-funding-fees | 0x2ca1...9f03 |

All 11 commands tested (4 read-only via API, 7 write operations on-chain).

## Checklist

- [x] All 11 commands tested on Arbitrum mainnet
- [x] `plugin-store lint` passes
- [x] SKILL.md reflects all code changes
- [x] Version bumped to 0.2.0 in all 4 required files
- [x] No hardcoded contract addresses (all fetched from GMX API)
- [x] All write ops use `onchainos wallet contract-call`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)