### PR TITLE
fix(compound-v3): v0.2.0 — correct Arbitrum base asset (USDC.e → native USDC) and Polygon RPC

### DIFF
--- a/skills/compound-v3/Cargo.toml
+++ b/skills/compound-v3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compound-v3"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/compound-v3/SKILL.md
+++ b/skills/compound-v3/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: compound-v3
 description: "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards. Trigger phrases: compound supply, compound borrow, compound repay, compound withdraw, compound rewards, compound position, compound market."
-version: "0.1.0"
+version: "0.2.0"
 author: "skylavis-sky"
 tags:
   - lending
@@ -48,7 +48,7 @@ if ! command -v compound-v3 >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/compound-v3@0.1.0/compound-v3-${TARGET}${EXT}" -o ~/.local/bin/compound-v3${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/compound-v3@0.2.0/compound-v3-${TARGET}${EXT}" -o ~/.local/bin/compound-v3${EXT}
   chmod +x ~/.local/bin/compound-v3${EXT}
 fi
 ```
@@ -70,7 +70,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"compound-v3","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"compound-v3","version":"0.2.0"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/compound-v3/plugin.yaml
+++ b/skills/compound-v3/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: compound-v3
-version: "0.1.0"
+version: "0.1.1"
 description: "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards"
 author:
   name: skylavis-sky
@@ -26,4 +26,6 @@ api_calls:
   - "https://ethereum.publicnode.com"
   - "https://base-rpc.publicnode.com"
   - "https://arbitrum-one-rpc.publicnode.com"
-  - "https://polygon-rpc.com"
+  - "https://polygon-bor-rpc.publicnode.com"
+  - "https://plugin-store-dun.vercel.app/install"
+  - "https://www.okx.com/priapi/v1/wallet/plugins/download/report"

--- a/skills/compound-v3/plugin.yaml
+++ b/skills/compound-v3/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: compound-v3
-version: "0.1.1"
+version: "0.2.0"
 description: "Compound V3 (Comet) lending plugin: supply collateral, borrow/repay the base asset, and claim COMP rewards"
 author:
   name: skylavis-sky

--- a/skills/compound-v3/src/config.rs
+++ b/skills/compound-v3/src/config.rs
@@ -37,7 +37,7 @@ pub fn get_market_config(chain_id: u64, market: &str) -> anyhow::Result<MarketCo
             chain_id: 42161,
             comet_proxy: "0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf",
             rewards_contract: "0x88730d254A2f7e6AC8388c3198aFd694bA9f7fae",
-            base_asset: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+            base_asset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
             base_asset_decimals: 6,
             base_asset_symbol: "USDC",
             rpc_url: "https://arbitrum-one-rpc.publicnode.com",
@@ -49,7 +49,7 @@ pub fn get_market_config(chain_id: u64, market: &str) -> anyhow::Result<MarketCo
             base_asset: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
             base_asset_decimals: 6,
             base_asset_symbol: "USDC",
-            rpc_url: "https://polygon-rpc.com",
+            rpc_url: "https://polygon-bor-rpc.publicnode.com",
         }),
         _ => anyhow::bail!(
             "Unsupported chain_id={} market={}. Supported: chain 1/8453/42161/137 market usdc",

--- a/skills/compound-v3/src/config.rs
+++ b/skills/compound-v3/src/config.rs
@@ -65,7 +65,7 @@ pub fn default_rpc_url(chain_id: u64) -> &'static str {
         1 => "https://ethereum.publicnode.com",
         8453 => "https://base-rpc.publicnode.com",
         42161 => "https://arbitrum-one-rpc.publicnode.com",
-        137 => "https://polygon-rpc.com",
+        137 => "https://polygon-bor-rpc.publicnode.com",
         _ => "https://base-rpc.publicnode.com",
     }
 }

--- a/skills/compound-v3/src/onchainos.rs
+++ b/skills/compound-v3/src/onchainos.rs
@@ -81,7 +81,7 @@ pub async fn erc20_approve(
     chain_id: u64,
     token_addr: &str,
     spender: &str,
-    amount: u128, // u128::MAX for unlimited
+    amount: u128,
     from: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<Value> {


### PR DESCRIPTION
## Summary

Bug fix release v0.2.0 for compound-v3. Two issues were causing failures on Arbitrum (borrow/repay broken) and Polygon (all market reads broken).

### Bug 1 — Arbitrum base_asset: USDC.e instead of native USDC

**Root cause** (`src/config.rs` line 40): `base_asset` was hardcoded to `0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8` (USDC.e bridged). On-chain verification via `eth_call baseToken()` (selector `0xc55dae63`) on the Arbitrum Comet proxy (`0x9c4ec768...`) returns `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` (native USDC).

**Impact**: `borrow` called `Comet.withdraw(USDC.e, amount)` which the contract treats as collateral withdrawal → arithmetic underflow. `repay` called `ERC-20.approve(USDC.e, amount)` → wrong token contract, approve reverts.

**Fix**: `base_asset` → `0xaf88d065e77c8cC2239327C5EDb3A432268e5831`

### Bug 2 — Polygon RPC returning HTML

**Root cause** (`src/config.rs` lines 52 + `default_rpc_url`): `polygon-rpc.com` is a web landing page, not a JSON-RPC endpoint. All Polygon calls failed with HTML parse errors.

**Fix**: `polygon-rpc.com` → `polygon-bor-rpc.publicnode.com`

## Files Changed

| File | Change |
|------|--------|
| `src/config.rs` | Arbitrum `base_asset` corrected; Polygon `rpc_url` corrected (both in `get_market_config` and `default_rpc_url`) |
| `plugin.yaml` | `polygon-rpc.com` → `polygon-bor-rpc.publicnode.com`; added install reporting URLs to `api_calls`; version → 0.2.0 |
| `SKILL.md` | version → 0.2.0 |

## Validation — Live L4 On-Chain Transactions (Arbitrum 42161)

| Test | Result | Tx |
|------|--------|-----|
| L4-A1 Supply WETH collateral | ✅ PASS | [0xe5627e67](https://arbiscan.io/tx/0xe5627e67a2321b442ae42b0be48445712ba790cf685c629f543232c9b6f23bf2) |
| L4-A3 **Borrow 0.01 USDC** | ✅ **PASS — no underflow** | [0xc5e503e3](https://arbiscan.io/tx/0xc5e503e35a3e239bd7a9a4257ef5fe145b5c3a4d233041497c88c3acfd6276ce) |
| L4-A5 **Repay (approve)** | ✅ **PASS** | [0xa4b78f22](https://arbiscan.io/tx/0xa4b78f229209add84528e2e6dea70a07b9b26b7feaf8ef11e25fac1b72c35b87) |
| L4-A5 **Repay (supply)** | ✅ **PASS** | [0xebd1787d](https://arbiscan.io/tx/0xebd1787ddfa508bcac8046fad3f161be8d318be82d32dcbe27763a3284ccd294) |
| L4-A7 Withdraw WETH | ✅ PASS | [0xef1c5745](https://arbiscan.io/tx/0xef1c5745fa3f3ed9253c9646debd6b120946a380d7df34197792e7000162348b) |

## Validation — Live L4 On-Chain Transactions (Base 8453)

| Test | Result | Tx |
|------|--------|-----|
| L4-B1 Supply 0.01 USDC (approve) | ✅ PASS | [0xd6dc75ca](https://basescan.org/tx/0xd6dc75ca625822cb4a50ac56e238e487b850c1d0066139fb8f76497c3d1f9248) |
| L4-B1 Supply 0.01 USDC (supply) | ✅ PASS | [0x1585c20c](https://basescan.org/tx/0x1585c20c3fc0841041038aceaeaf03759ee0c0c4ac61fdf46521465f64623c7f) |
| L4-B2 Withdraw | ✅ PASS | [0xded9f125](https://basescan.org/tx/0xded9f12569767b19db381db8645b9c46623e8b5fa9f9075b02a23980395cb1e4) |

## Checklist

- [x] `plugin-store lint` passes (0 errors, 3 warnings — same warnings as v0.1.0)
- [x] Arbitrum borrow/repay validated with live L4 on-chain transactions
- [x] Polygon get-markets validated (L2)
- [x] All four chains (Ethereum, Base, Arbitrum, Polygon) verified

🤖 Generated with Claude Code