### PR TITLE
fix(aave-v3): v0.2.0 — token decimals, repay symbol path, reserves symbol

### DIFF
--- a/skills/aave-v3-plugin/Cargo.lock
+++ b/skills/aave-v3-plugin/Cargo.lock
@@ -515,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,32 +612,6 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -804,15 +784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,21 +888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,12 +916,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1003,8 +953,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1014,9 +966,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1041,25 +995,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1148,7 +1083,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1173,22 +1107,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1209,11 +1128,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1493,6 +1410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,12 +1433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,23 +1441,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1583,50 +1483,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1716,12 +1572,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1826,6 +1676,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -1946,29 +1851,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1976,6 +1878,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2096,6 +1999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2108,6 +2012,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2147,15 +2052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,29 +2069,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2445,27 +2318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2334,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2502,6 +2374,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2532,35 +2419,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -2749,12 +2613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,39 +2760,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/skills/aave-v3-plugin/Cargo.toml
+++ b/skills/aave-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aave-v3"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/aave-v3-plugin/SKILL.md
+++ b/skills/aave-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aave-v3-plugin
 description: "Aave V3 lending and borrowing. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
-version: "0.1.0"
+version: "0.2.0"
 author: "skylavis-sky"
 tags:
   - lending
@@ -135,11 +135,11 @@ Please connect your wallet first: run `onchainos wallet login`
 
 | User Intent | Command |
 |-------------|---------|
-| Supply / deposit / lend asset | `aave-v3-plugin supply --asset <ADDRESS> --amount <AMOUNT>` |
-| Withdraw / redeem aTokens | `aave-v3-plugin withdraw --asset <SYMBOL> --amount <AMOUNT>` |
-| Borrow asset | `aave-v3-plugin borrow --asset <ADDRESS> --amount <AMOUNT>` |
-| Repay debt | `aave-v3-plugin repay --asset <ADDRESS> --amount <AMOUNT>` |
-| Repay all debt | `aave-v3-plugin repay --asset <ADDRESS> --all` |
+| Supply / deposit / lend asset | `aave-v3-plugin supply --asset <SYMBOL_OR_ADDRESS> --amount <AMOUNT>` |
+| Withdraw / redeem aTokens | `aave-v3-plugin withdraw --asset <SYMBOL_OR_ADDRESS> --amount <AMOUNT>` |
+| Borrow asset | `aave-v3-plugin borrow --asset <SYMBOL_OR_ADDRESS> --amount <AMOUNT>` |
+| Repay debt | `aave-v3-plugin repay --asset <SYMBOL_OR_ADDRESS> --amount <AMOUNT>` |
+| Repay all debt | `aave-v3-plugin repay --asset <SYMBOL_OR_ADDRESS> --all` |
 | Check health factor | `aave-v3-plugin health-factor` |
 | View positions | `aave-v3-plugin positions` |
 | List reserve rates / APYs | `aave-v3-plugin reserves` |
@@ -299,14 +299,13 @@ aave-v3-plugin --chain 137 repay --asset 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84
 ```
 
 **Key parameters:**
-- `--asset` — ERC-20 contract address of the debt token
+- `--asset` — token symbol (e.g. USDC, WETH) or ERC-20 contract address
 - `--amount` — partial repay amount
-- `--all` — repay full outstanding balance (uses uint256.max)
+- `--all` — repay full outstanding balance
 
 **Notes:**
 - ERC-20 approval is checked automatically; if insufficient, an approve tx is submitted first
-- `--all` repay uses the wallet's actual token balance (not uint256.max) to avoid revert when accrued interest exceeds the wallet balance
-- Always pass the ERC-20 address for `--asset`, not the symbol
+- `--all` repay uses the wallet's actual token balance to avoid revert when accrued interest exceeds wallet balance
 
 **Expected output:**
 <external-content>
@@ -377,6 +376,7 @@ aave-v3-plugin --chain 8453 reserves --asset 0x833589fCD6eDb6E08f4c7C32D4f71b54b
   "reserveCount": 12,
   "reserves": [
     {
+      "symbol": "USDC",
       "underlyingAsset": "0x833589...",
       "supplyApy": "3.2500%",
       "variableBorrowApy": "5.1200%"

--- a/skills/aave-v3-plugin/plugin.yaml
+++ b/skills/aave-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: aave-v3-plugin
-version: "0.1.0"
+version: "0.2.0"
 description: "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
 author:
   name: skylavis-sky

--- a/skills/aave-v3-plugin/src/commands/repay.rs
+++ b/skills/aave-v3-plugin/src/commands/repay.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use serde_json::{json, Value};
 
 use crate::calldata;
-use crate::commands::supply::infer_decimals;
 use crate::config::get_chain_config;
 use crate::onchainos;
 use crate::rpc;
@@ -37,6 +36,10 @@ pub async fn run(
         .await
         .context("Failed to resolve Pool address")?;
 
+    // Resolve token contract address and decimals (handles both symbol and 0x address)
+    let (token_addr, decimals) = onchainos::resolve_token(asset, chain_id)
+        .with_context(|| format!("Could not resolve token address for '{}'", asset))?;
+
     // Pre-flight: check debt
     let account_data = rpc::get_user_account_data(&pool_addr, &from_addr, cfg.rpc_url)
         .await
@@ -59,7 +62,7 @@ pub async fn run(
     // For --all: query the wallet's actual token balance and use that as the repay amount.
     // Using uint256.max reverts when wallet balance < accrued dust interest.
     let (amount_minimal, amount_display) = if all {
-        let balance = rpc::get_erc20_balance(asset, &from_addr, cfg.rpc_url)
+        let balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
             .await
             .context("Failed to fetch token balance for full repay")?;
         if balance == 0 {
@@ -67,20 +70,16 @@ pub async fn run(
         }
         (balance, format!("all ({})", balance))
     } else {
-        let decimals = onchainos::resolve_token(asset, chain_id)
-            .map(|(_, d)| d as u64)
-            .unwrap_or_else(|_| infer_decimals(asset));
         let v = amount.unwrap();
         let minimal = (v * 10u128.pow(decimals as u32) as f64) as u128;
         (minimal, v.to_string())
     };
 
-    // Step 4: Check ERC-20 allowance for asset → pool
-    // For full repay (u128::MAX) we approve unconditionally since we can't know exact debt
+    // Step 4: Check ERC-20 allowance for token → pool
     let needs_approval = if all {
         true
     } else {
-        let allowance = rpc::get_allowance(asset, &from_addr, &pool_addr, cfg.rpc_url)
+        let allowance = rpc::get_allowance(&token_addr, &from_addr, &pool_addr, cfg.rpc_url)
             .await
             .unwrap_or(0);
         allowance < amount_minimal
@@ -88,12 +87,16 @@ pub async fn run(
 
     let mut approval_result: Option<Value> = None;
     if needs_approval {
-        eprintln!(
-            "Insufficient ERC-20 allowance for {} → {}. Approving...",
-            asset, pool_addr
-        );
-        let approve_res = onchainos::dex_approve(chain_id, asset, &pool_addr, dry_run)
-            .context("onchainos dex approve failed")?;
+        let approve_calldata = calldata::encode_erc20_approve(&pool_addr, u128::MAX)
+            .context("Failed to encode approve calldata")?;
+        let approve_res = onchainos::wallet_contract_call(
+            chain_id,
+            &token_addr,
+            &approve_calldata,
+            Some(&from_addr),
+            dry_run,
+        )
+        .context("ERC-20 approve failed")?;
         // Wait for approve tx to be mined before submitting repay
         if !dry_run {
             let approve_tx = approve_res["data"]["txHash"]
@@ -110,7 +113,7 @@ pub async fn run(
     }
 
     // Step 5: encode and submit repay
-    let calldata = calldata::encode_repay(asset, amount_minimal, &from_addr)
+    let calldata = calldata::encode_repay(&token_addr, amount_minimal, &from_addr)
         .context("Failed to encode repay calldata")?;
 
     let result = onchainos::wallet_contract_call(

--- a/skills/aave-v3-plugin/src/commands/reserves.rs
+++ b/skills/aave-v3-plugin/src/commands/reserves.rs
@@ -58,16 +58,22 @@ pub async fn run(
     let mut reserves: Vec<Value> = Vec::new();
 
     for addr in &reserve_addresses {
-        // Apply address filter if specified
+        // Fetch symbol first so we can filter by it
+        let symbol = rpc::get_erc20_symbol(addr, cfg.rpc_url).await.unwrap_or_default();
+
+        // Apply filter: match by address (0x...) or symbol (case-insensitive)
         if let Some(filter) = asset_filter {
-            if filter.starts_with("0x") && !addr.eq_ignore_ascii_case(filter) {
+            if filter.starts_with("0x") {
+                if !addr.eq_ignore_ascii_case(filter) {
+                    continue;
+                }
+            } else if !symbol.eq_ignore_ascii_case(filter) {
                 continue;
             }
         }
 
         // Call Pool.getReserveData(address asset) — selector 0x35ea6a75
-        // Returns DataTypes.ReserveData packed struct; APY rates at slots 2 and 4.
-        match get_reserve_data_from_pool(&pool_addr, addr, cfg.rpc_url).await {
+        match get_reserve_data_from_pool(&pool_addr, addr, &symbol, cfg.rpc_url).await {
             Ok(reserve_data) => {
                 reserves.push(reserve_data);
             }
@@ -93,6 +99,7 @@ pub async fn run(
 async fn get_reserve_data_from_pool(
     pool_addr: &str,
     asset_addr: &str,
+    symbol: &str,
     rpc_url: &str,
 ) -> anyhow::Result<Value> {
     // getReserveData(address asset) → selector 0x35ea6a75
@@ -116,6 +123,7 @@ async fn get_reserve_data_from_pool(
     let variable_borrow_rate = decode_ray_to_apy_pct(raw, 4)?;
 
     Ok(json!({
+        "symbol": symbol,
         "underlyingAsset": asset_addr,
         "supplyApy": format!("{:.4}%", liquidity_rate),
         "variableBorrowApy": format!("{:.4}%", variable_borrow_rate)

--- a/skills/aave-v3-plugin/src/onchainos.rs
+++ b/skills/aave-v3-plugin/src/onchainos.rs
@@ -108,14 +108,10 @@ pub fn defi_positions(chain_id: u64, wallet_addr: &str) -> anyhow::Result<Value>
 }
 
 /// Resolve a token symbol or address to (contract_address, decimals).
-/// If `asset` is already a 0x-prefixed 42-char hex address, returns it as-is with decimals=18.
-/// Otherwise queries onchainos token search by symbol on the given chain.
+/// For both symbol and address inputs, queries onchainos token search to get actual decimals.
+/// Falls back to decimals=18 only if the token is not found in onchainos.
 pub fn resolve_token(asset: &str, chain_id: u64) -> anyhow::Result<(String, u8)> {
-    // If it already looks like an address, trust it
-    if asset.starts_with("0x") && asset.len() == 42 {
-        let decimals = infer_decimals_from_addr();
-        return Ok((asset.to_lowercase(), decimals));
-    }
+    let is_address = asset.starts_with("0x") && asset.len() == 42;
     let chain_name = chain_id_to_name(chain_id);
     let mut cmd = base_cmd();
     cmd.args(["token", "search", "--query", asset, "--chain", chain_name]);
@@ -124,16 +120,22 @@ pub fn resolve_token(asset: &str, chain_id: u64) -> anyhow::Result<(String, u8)>
     let tokens = result
         .as_array()
         .or_else(|| result.get("data").and_then(|d| d.as_array()))
-        .ok_or_else(|| anyhow::anyhow!("No tokens found for symbol '{}' on chain {}", asset, chain_id))?;
+        .ok_or_else(|| anyhow::anyhow!("No tokens found for '{}' on chain {}", asset, chain_id))?;
 
     let first = tokens.first().ok_or_else(|| {
         anyhow::anyhow!("No token match for '{}' on chain {}", asset, chain_id)
     })?;
 
-    let addr = first["tokenContractAddress"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing tokenContractAddress in token search result"))?
-        .to_lowercase();
+    // For address input: use the original address directly (token search confirms it exists);
+    // for symbol input: extract the contract address from search results.
+    let addr = if is_address {
+        asset.to_lowercase()
+    } else {
+        first["tokenContractAddress"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing tokenContractAddress in token search result"))?
+            .to_lowercase()
+    };
 
     let decimals = first["decimal"]
         .as_str()
@@ -141,10 +143,6 @@ pub fn resolve_token(asset: &str, chain_id: u64) -> anyhow::Result<(String, u8)>
         .unwrap_or(18);
 
     Ok((addr, decimals))
-}
-
-fn infer_decimals_from_addr() -> u8 {
-    18
 }
 
 /// Public alias for use in dry-run command string formatting.

--- a/skills/aave-v3-plugin/src/rpc.rs
+++ b/skills/aave-v3-plugin/src/rpc.rs
@@ -244,6 +244,23 @@ pub async fn get_allowance(
     decode_u128_at(raw, 0)
 }
 
+/// Get ERC-20 token symbol: token.symbol()
+/// Function selector: symbol() -> 0x95d89b41
+pub async fn get_erc20_symbol(token_addr: &str, rpc_url: &str) -> anyhow::Result<String> {
+    let hex_result = eth_call(rpc_url, token_addr, "0x95d89b41").await?;
+    let raw = strip_0x(&hex_result);
+    // ABI-encoded string: offset(32) + length(32) + data(padded)
+    if raw.len() < 128 {
+        return Ok(String::new());
+    }
+    let len = usize::from_str_radix(&raw[64..128], 16).unwrap_or(0);
+    if len == 0 || raw.len() < 128 + len * 2 {
+        return Ok(String::new());
+    }
+    let bytes = hex::decode(&raw[128..128 + len * 2]).unwrap_or_default();
+    Ok(String::from_utf8_lossy(&bytes).to_string())
+}
+
 // ── helpers ─────────────────────────────────────────────────────────────────
 
 fn strip_0x(s: &str) -> &str {


### PR DESCRIPTION
Replaces #104 with a clean branch based directly on upstream/main (no stale registry.json).

## Fixes

### Bug 1 — `resolve_token` hardcoded decimals=18 for all ERC-20 addresses
`infer_decimals_from_addr()` always returned 18. USDC (6 dec) passed as an address caused `amountMinimal` to be 10^12× too large → on-chain revert for all write operations. SKILL.md mandated address input for `borrow`/`repay`, making them 100% broken.

**Fix:** Route address inputs through `onchainos token search` (same as symbols) to get actual decimals.

### Bug 2 — `repay` failed when `--asset` was a symbol
`rpc::get_erc20_balance`, `rpc::get_allowance`, and `onchainos::dex_approve` received the raw symbol string instead of a contract address.

**Fix:** Call `resolve_token` at function entry; use `token_addr` throughout. Replace `dex_approve` with `wallet_contract_call + encode_erc20_approve`.

### Bug 3 — `reserves` output had no token symbols; `--asset` filter didn't support symbols
**Fix:** Add `rpc::get_erc20_symbol()` (ERC-20 `symbol()` selector); include `symbol` field in output; support case-insensitive symbol filtering.

## Verification — live txs on Base (chain 8453) with USDC address

| Op | Tx |
|----|----|
| supply | `0x5d0f4207...` |
| borrow | `0xe6f108b7...` |
| repay | `0x093b7437...` |
| withdraw | `0x81568fb4...` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)