### PR TITLE
fix(clanker): graceful empty-price in token-info — v0.1.1

### DIFF
--- a/skills/clanker/.claude-plugin/plugin.json
+++ b/skills/clanker/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clanker",
   "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/clanker/Cargo.lock
+++ b/skills/clanker/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clanker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/clanker/Cargo.toml
+++ b/skills/clanker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clanker"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/clanker/SKILL.md
+++ b/skills/clanker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clanker
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum. Trigger phrases: deploy token, launch token on Clanker, create token on Base, search Clanker tokens, list latest tokens, claim LP rewards, claim Clanker fees."
-version: "0.1.0"
+version: "0.1.1"
 author: "GeoGu360"
 tags:
   - token-launch
@@ -12,74 +12,6 @@ tags:
 ---
 
 
-## Pre-flight Dependencies (auto-injected by Plugin Store CI)
-
-> Run once per session before first use. These checks ensure required tools are installed.
-
-### Install onchainos CLI + Skills (auto-injected)
-
-```bash
-# 1. Install onchainos CLI
-onchainos --version 2>/dev/null || curl -fsSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
-
-# 2. Install onchainos skills (enables AI agent to use onchainos commands)
-npx skills add okx/onchainos-skills --yes --global
-
-# 3. Install plugin-store skills (enables plugin discovery and management)
-npx skills add okx/plugin-store --skill plugin-store --yes --global
-```
-
-### Install clanker binary (auto-injected)
-
-```bash
-if ! command -v clanker >/dev/null 2>&1; then
-  OS=$(uname -s | tr A-Z a-z)
-  ARCH=$(uname -m)
-  EXT=""
-  case "${OS}_${ARCH}" in
-    darwin_arm64)  TARGET="aarch64-apple-darwin" ;;
-    darwin_x86_64) TARGET="x86_64-apple-darwin" ;;
-    linux_x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
-    linux_i686)    TARGET="i686-unknown-linux-gnu" ;;
-    linux_aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
-    linux_armv7l)  TARGET="armv7-unknown-linux-gnueabihf" ;;
-    mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
-    mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
-    mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
-  esac
-  mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/clanker@0.1.0/clanker-${TARGET}${EXT}" -o ~/.local/bin/clanker${EXT}
-  chmod +x ~/.local/bin/clanker${EXT}
-fi
-```
-
-### Report install (auto-injected, runs once)
-
-```bash
-REPORT_FLAG="$HOME/.plugin-store/reported/clanker"
-if [ ! -f "$REPORT_FLAG" ]; then
-  mkdir -p "$HOME/.plugin-store/reported"
-  # Device fingerprint → SHA256 → 32-char device ID
-  DEV_RAW="$(hostname):$(uname -s):$(uname -m):$HOME"
-  DEV_ID=$(echo -n "$DEV_RAW" | shasum -a 256 | head -c 32)
-  # HMAC signature (obfuscated key, same as CLI binary)
-  _K=$(echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | base64 -d 2>/dev/null || echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | openssl base64 -d)
-  HMAC_SIG=$(echo -n "${_K}${DEV_ID}" | shasum -a 256 | head -c 8)
-  DIV_ID="${DEV_ID}${HMAC_SIG}"
-  unset _K
-  # Report to Vercel stats
-  curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
-    -H "Content-Type: application/json" \
-    -d '{"name":"clanker","version":"0.1.0"}' >/dev/null 2>&1 || true
-  # Report to OKX API (with HMAC-signed device token)
-  curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
-    -H "Content-Type: application/json" \
-    -d '{"pluginName":"clanker","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
-  touch "$REPORT_FLAG"
-fi
-```
-
----
 
 
 ## Pre-flight
@@ -220,6 +152,42 @@ clanker [--chain 8453] token-info --address <contract-address>
 ```bash
 clanker --chain 8453 token-info --address 0xTokenAddress
 ```
+
+**Expected output — price available:**
+<external-content>
+```json
+{
+  "ok": true,
+  "data": {
+    "token_address": "0xTokenAddress",
+    "chain_id": 8453,
+    "info": { "name": "SkyDog", "symbol": "SKYDOG", "decimals": 18 },
+    "price": { "price": "0.00123", "priceUsd": "0.00123" },
+    "price_available": true,
+    "price_note": null
+  }
+}
+```
+</external-content>
+
+**Expected output — no price data (new or illiquid token):**
+<external-content>
+```json
+{
+  "ok": true,
+  "data": {
+    "token_address": "0xTokenAddress",
+    "chain_id": 8453,
+    "info": { "name": "Odyssey Mechanics", "symbol": "ODYSSE", "decimals": 18 },
+    "price": null,
+    "price_available": false,
+    "price_note": "No price data available — token is not yet tracked by any price oracle. This is common for newly deployed or low-liquidity Clanker tokens."
+  }
+}
+```
+</external-content>
+
+When `price_available` is `false`, inform the user that metadata was found but price data is not yet available from any oracle. Suggest checking creator history via `search-tokens` or monitoring the token on BaseScan for trading activity.
 
 ---
 
@@ -383,3 +351,14 @@ clanker claim-rewards --token-address 0xTokenAddress --from 0xYourWallet
 - The `requestKey` is auto-generated as a UUID per call to prevent accidental double-deployment
 - Never share your Clanker API key — it authorizes token deployments from your partner account
 - Fee locker address is resolved dynamically at runtime to handle contract upgrades
+
+---
+
+## Changelog
+
+### v0.1.1 (2026-04-11)
+
+- **fix**: `token-info` now surfaces `price_available: false` and a human-readable `price_note` when `onchainos token price-info` returns no data (`data: []`). Previously returned a bare `price: []` with no context, confusing AI agents and users. Common for newly deployed or low-liquidity Clanker tokens.
+- **fix**: Version alignment — `.claude-plugin/plugin.json` was incorrectly set to `1.0.0`; aligned to `0.1.1` with all other version files.
+- **docs**: Added expected output examples to `token-info` section for both price-available and no-price scenarios.
+- **chore**: Removed CI-injected pre-flight block (re-injected post-merge by CI).

--- a/skills/clanker/plugin.yaml
+++ b/skills/clanker/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: clanker
-version: "0.1.0"
+version: "0.1.1"
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards"
 author:
   name: GeoGu360

--- a/skills/clanker/src/commands/token_info.rs
+++ b/skills/clanker/src/commands/token_info.rs
@@ -6,13 +6,31 @@ pub fn run(chain_id: u64, token_address: &str) -> Result<()> {
     let info = onchainos::token_info(chain_id, token_address)?;
     let price = onchainos::token_price_info(chain_id, token_address)?;
 
+    // price["data"] is [] when no price oracle covers this token (common for new/illiquid tokens).
+    // Surface a clear status rather than a bare empty array.
+    let price_data = &price["data"];
+    let price_available = !price_data.is_null()
+        && !(price_data.is_array() && price_data.as_array().map_or(true, |a| a.is_empty()));
+
+    let price_field = if price_available {
+        price_data.clone()
+    } else {
+        serde_json::json!(null)
+    };
+
     let output = serde_json::json!({
         "ok": true,
         "data": {
             "token_address": token_address,
             "chain_id": chain_id,
             "info": info["data"],
-            "price": price["data"],
+            "price": price_field,
+            "price_available": price_available,
+            "price_note": if price_available {
+                serde_json::json!(null)
+            } else {
+                serde_json::json!("No price data available — token is not yet tracked by any price oracle. This is common for newly deployed or low-liquidity Clanker tokens.")
+            }
         }
     });
 


### PR DESCRIPTION
## Summary

- **fix**: `token-info` returned `price: []` when `onchainos token price-info` had no oracle coverage for a token. Now outputs `price: null`, `price_available: false`, and a human-readable `price_note` explaining why. This is the correct UX for newly deployed or low-liquidity Clanker tokens.
- **fix**: `.claude-plugin/plugin.json` version was `1.0.0` (pre-existing mismatch). Aligned to `0.1.1` with all other version files.
- **docs**: Added `<external-content>` expected output examples to the `token-info` section covering both the price-available and no-price cases, so AI agents know how to interpret and explain the result to users.
- **chore**: Removed CI-injected pre-flight block (re-injected post-merge by CI).

## Root Cause

`onchainos token price-info` returns `data: []` when no price oracle tracks the token. The previous code passed this through verbatim:

```rust
// before
"price": price["data"],   // → "price": []
```

This confused users (e.g. Odyssey Mechanics / ODYSSE on Base — metadata found, `price: []` with no explanation).

## Fix

```rust
// after — token_info.rs
let price_available = !price_data.is_null()
    && !(price_data.is_array() && price_data.as_array().map_or(true, |a| a.is_empty()));
// ...
"price": price_field,           // null when unavailable
"price_available": price_available,
"price_note": if price_available { null } else { "No price data available — ..." }
```

## Testing

Verified via dry-run output shape. No on-chain transactions required for this read-path fix.

## Checklist

- [x] `plugin-store lint` passes (0 errors, 0 warnings)
- [x] Version bumped in all 4 files (plugin.yaml, SKILL.md, Cargo.toml, .claude-plugin/plugin.json)
- [x] CI-injected pre-flight block removed
- [x] Branch based on upstream/main — diff shows only `skills/clanker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)