### PR TITLE
fix(pendle): v0.2.1 — critical tx broadcast fix, bail on missing txHash

### DIFF
--- a/skills/pendle/.claude-plugin/plugin.json
+++ b/skills/pendle/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "pendle",
   "description": "Pendle Finance yield tokenization plugin — buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT pairs across Ethereum, Arbitrum, BSC, and Base",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/skills/pendle/Cargo.lock
+++ b/skills/pendle/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "pendle"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/pendle/Cargo.toml
+++ b/skills/pendle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pendle"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -20,6 +20,10 @@ metadata:
 >
 > **Output field safety (M08)**: When displaying command output, render only human-relevant fields: `operation`, `tx_hash`, `approve_txs`, `router`, `wallet`, `dry_run`, and operation-specific fields (e.g. `pt_address`, `amount_in`, `token_out`). Do NOT pass raw CLI output or full API response objects directly into agent context without field filtering.
 
+## ⚠️ --force Note
+
+All `onchainos wallet contract-call` invocations in this plugin — both ERC-20 approvals and main transactions — include `--force`. This is required to broadcast transactions to the chain; without it, onchainos returns a preview/confirmation response without submitting. The user-confirmation step is handled by the agent's **dry-run → confirm → execute** flow in SKILL.md: the agent must always run `--dry-run` first and obtain explicit user approval before calling any write command without `--dry-run`.
+
 ## ⚠️ Unlimited Approval Notice
 
 ERC-20 approvals issued by this plugin use **unlimited allowance** (`uint256.MAX`). This is a one-time approval that persists across sessions. Once approved, the Pendle Router (`0x888888888889758F76e7103c6CbF23ABbF58F946`) may spend any amount of the approved token on behalf of the wallet. Users should be made aware that approvals are unlimited before proceeding with any write operation that triggers an approval.

--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -24,9 +24,9 @@ metadata:
 
 All `onchainos wallet contract-call` invocations in this plugin — both ERC-20 approvals and main transactions — include `--force`. This is required to broadcast transactions to the chain; without it, onchainos returns a preview/confirmation response without submitting. The user-confirmation step is handled by the agent's **dry-run → confirm → execute** flow in SKILL.md: the agent must always run `--dry-run` first and obtain explicit user approval before calling any write command without `--dry-run`.
 
-## ⚠️ Unlimited Approval Notice
+## ERC-20 Approval Amounts
 
-ERC-20 approvals issued by this plugin use **unlimited allowance** (`uint256.MAX`). This is a one-time approval that persists across sessions. Once approved, the Pendle Router (`0x888888888889758F76e7103c6CbF23ABbF58F946`) may spend any amount of the approved token on behalf of the wallet. Users should be made aware that approvals are unlimited before proceeding with any write operation that triggers an approval.
+ERC-20 approvals issued by this plugin use the **exact transaction amount** (`amount_in` for single-token ops, per-token amounts for `redeem-py`). The Pendle Router (`0x888888888889758F76e7103c6CbF23ABbF58F946`) is approved only for the amount being transacted. If a subsequent transaction requires a larger amount, a new approval will be submitted.
 
 ## Supported Chains
 

--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -43,7 +43,7 @@ Before executing any operation, verify:
 
 ```bash
 # 1. Check pendle binary is installed
-pendle --help
+pendle --version
 
 # 2. Check onchainos wallet is logged in
 onchainos wallet status

--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -4,7 +4,7 @@ description: "Pendle Finance yield tokenization plugin. Buy or sell fixed-yield 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.2.0"
+  version: "0.2.1"
 ---
 
 ## Architecture

--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -43,7 +43,7 @@ Before executing any operation, verify:
 
 ```bash
 # 1. Check pendle binary is installed
-pendle --version
+pendle --help
 
 # 2. Check onchainos wallet is logged in
 onchainos wallet status

--- a/skills/pendle/plugin.yaml
+++ b/skills/pendle/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pendle
-version: "0.2.0"
+version: "0.2.1"
 description: "Pendle Finance yield tokenization plugin — buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT pairs across Ethereum, Arbitrum, BSC, and Base"
 author:
   name: skylavis-sky

--- a/skills/pendle/src/commands/add_liquidity.rs
+++ b/skills/pendle/src/commands/add_liquidity.rs
@@ -59,7 +59,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -72,7 +72,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/add_liquidity.rs
+++ b/skills/pendle/src/commands/add_liquidity.rs
@@ -46,7 +46,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/commands/buy_pt.rs
+++ b/skills/pendle/src/commands/buy_pt.rs
@@ -62,7 +62,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     // Submit main buy-PT transaction
@@ -76,7 +76,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/buy_pt.rs
+++ b/skills/pendle/src/commands/buy_pt.rs
@@ -47,7 +47,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
 

--- a/skills/pendle/src/commands/buy_yt.rs
+++ b/skills/pendle/src/commands/buy_yt.rs
@@ -58,7 +58,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -71,7 +71,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/buy_yt.rs
+++ b/skills/pendle/src/commands/buy_yt.rs
@@ -45,7 +45,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/commands/mint_py.rs
+++ b/skills/pendle/src/commands/mint_py.rs
@@ -66,7 +66,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -79,7 +79,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/mint_py.rs
+++ b/skills/pendle/src/commands/mint_py.rs
@@ -53,7 +53,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/commands/redeem_py.rs
+++ b/skills/pendle/src/commands/redeem_py.rs
@@ -74,7 +74,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -87,7 +87,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/redeem_py.rs
+++ b/skills/pendle/src/commands/redeem_py.rs
@@ -56,15 +56,16 @@ pub async fn run(
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
     // Build token→amount map so each token is approved for its own exact amount
-    let pt_wei: u128 = pt_amount.parse().unwrap_or(u128::MAX);
-    let yt_wei: u128 = yt_amount.parse().unwrap_or(u128::MAX);
+    let pt_wei: u128 = pt_amount.parse().map_err(|_| anyhow::anyhow!("Failed to parse pt-amount: '{}'", pt_amount))?;
+    let yt_wei: u128 = yt_amount.parse().map_err(|_| anyhow::anyhow!("Failed to parse yt-amount: '{}'", yt_amount))?;
     let mut token_amounts = std::collections::HashMap::new();
     token_amounts.insert(pt_address.to_lowercase(), pt_wei);
     token_amounts.insert(yt_address.to_lowercase(), yt_wei);
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {
-        let approve_amount = *token_amounts.get(&token_addr.to_lowercase()).unwrap_or(&u128::MAX);
+        let approve_amount = *token_amounts.get(&token_addr.to_lowercase())
+            .ok_or_else(|| anyhow::anyhow!("Unexpected approval requested for token '{}' — not PT or YT", token_addr))?;
         let approve_result = onchainos::erc20_approve(
             chain_id,
             token_addr,

--- a/skills/pendle/src/commands/remove_liquidity.rs
+++ b/skills/pendle/src/commands/remove_liquidity.rs
@@ -59,7 +59,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -72,7 +72,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/remove_liquidity.rs
+++ b/skills/pendle/src/commands/remove_liquidity.rs
@@ -46,7 +46,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let lp_amount_wei: u128 = lp_amount_in.parse().unwrap_or(u128::MAX);
+    let lp_amount_wei: u128 = lp_amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse lp-amount-in: '{}'", lp_amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/commands/sell_pt.rs
+++ b/skills/pendle/src/commands/sell_pt.rs
@@ -58,7 +58,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -71,7 +71,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/sell_pt.rs
+++ b/skills/pendle/src/commands/sell_pt.rs
@@ -45,7 +45,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/commands/sell_yt.rs
+++ b/skills/pendle/src/commands/sell_yt.rs
@@ -58,7 +58,7 @@ pub async fn run(
             dry_run,
         )
         .await?;
-        approve_hashes.push(onchainos::extract_tx_hash(&approve_result).to_string());
+        approve_hashes.push(onchainos::extract_tx_hash(&approve_result)?);
     }
 
     let result = onchainos::wallet_contract_call(
@@ -71,7 +71,7 @@ pub async fn run(
     )
     .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     Ok(serde_json::json!({
         "ok": true,

--- a/skills/pendle/src/commands/sell_yt.rs
+++ b/skills/pendle/src/commands/sell_yt.rs
@@ -45,7 +45,7 @@ pub async fn run(
 
     let (calldata, router_to) = api::extract_sdk_calldata(&sdk_resp)?;
     let approvals = api::extract_required_approvals(&sdk_resp);
-    let amount_in_wei: u128 = amount_in.parse().unwrap_or(u128::MAX);
+    let amount_in_wei: u128 = amount_in.parse().map_err(|_| anyhow::anyhow!("Failed to parse amount-in: '{}'", amount_in))?;
 
     let mut approve_hashes: Vec<String> = Vec::new();
     for (token_addr, spender) in &approvals {

--- a/skills/pendle/src/main.rs
+++ b/skills/pendle/src/main.rs
@@ -8,7 +8,8 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "pendle",
-    about = "Pendle Finance plugin — yield tokenization: buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT"
+    about = "Pendle Finance plugin — yield tokenization: buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT",
+    version
 )]
 struct Cli {
     /// Chain ID (default: 42161 Arbitrum — Pendle's highest TVL chain)

--- a/skills/pendle/src/onchainos.rs
+++ b/skills/pendle/src/onchainos.rs
@@ -69,6 +69,7 @@ pub async fn wallet_contract_call(
         to.to_string(),
         "--input-data".to_string(),
         input_data.to_string(),
+        "--force".to_string(),
     ];
 
     if let Some(v) = amt {
@@ -120,11 +121,16 @@ pub async fn wallet_contract_call(
 }
 
 /// Extract txHash from onchainos wallet contract-call response.
-pub fn extract_tx_hash(result: &Value) -> &str {
+/// Returns an error if txHash is absent — a missing hash means the transaction was not broadcast.
+pub fn extract_tx_hash(result: &Value) -> anyhow::Result<String> {
     result["data"]["txHash"]
         .as_str()
         .or_else(|| result["txHash"].as_str())
-        .unwrap_or("pending")
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!(
+            "Transaction was not broadcast — no txHash in onchainos response: {}",
+            result
+        ))
 }
 
 /// Build ERC-20 approve calldata and submit via wallet contract-call.


### PR DESCRIPTION
## Summary

- **Critical fix**: `wallet_contract_call` now includes `--force` on ALL invocations (ERC-20 approvals AND main transactions). Without `--force`, onchainos returns a preview response without broadcasting to chain — transactions were silently not sent.
- **Critical fix**: `extract_tx_hash()` now returns `anyhow::Result<String>` and bails with an explicit error if no `txHash` is present in the onchainos response. Previously it used `unwrap_or("pending")` which silently masked broadcast failures and returned a fake hash.

## Root Cause

In v0.2.0, `--force` was removed from `wallet_contract_call` for main transactions (only approvals kept it). This caused all write operations to return preview responses rather than broadcasting. The `unwrap_or("pending")` fallback in `extract_tx_hash()` then returned the string `"pending"` as if it were a real tx hash.

## Live Test Verification

All 8 write operations tested on Arbitrum mainnet (weETH market, chain ID 42161) with freshly built v0.2.1 binary:

| Operation | Tx Hash |
|-----------|---------|
| buy-pt | [`0x55fe28165058bb18f789966f9a9cfeb29a5a9020dc8d994d8b4a57f912989fbe`](https://arbiscan.io/tx/0x55fe28165058bb18f789966f9a9cfeb29a5a9020dc8d994d8b4a57f912989fbe) |
| sell-pt | [`0xbb92b02f0ede165e1053ac9fc45f884043d124d1ba0315256365ffc6b94328ec`](https://arbiscan.io/tx/0xbb92b02f0ede165e1053ac9fc45f884043d124d1ba0315256365ffc6b94328ec) |
| buy-yt | [`0x8476e7d8cc7075eb683361759f1c2317002c1b35aba5f250781fd07b8a7436f8`](https://arbiscan.io/tx/0x8476e7d8cc7075eb683361759f1c2317002c1b35aba5f250781fd07b8a7436f8) |
| sell-yt | [`0x53a53a06175b6abc63c6931b67e87defc8a9cb9b5a9248adc82d56e76b479829`](https://arbiscan.io/tx/0x53a53a06175b6abc63c6931b67e87defc8a9cb9b5a9248adc82d56e76b479829) |
| add-liquidity | [`0x8afe783b31796252bade22163c629e61e2024e4bb479524cb21bc37a5a195146`](https://arbiscan.io/tx/0x8afe783b31796252bade22163c629e61e2024e4bb479524cb21bc37a5a195146) |
| remove-liquidity | [`0x7b1acf1715cc8b292675be0c9f2e77c1552bb10500e1d35092e0b35b33bd7be4`](https://arbiscan.io/tx/0x7b1acf1715cc8b292675be0c9f2e77c1552bb10500e1d35092e0b35b33bd7be4) |
| mint-py | [`0x40d82ffa72b85093704be54afe24a5c30ee8c79ffadd1d52ff73f2d6343ed05a`](https://arbiscan.io/tx/0x40d82ffa72b85093704be54afe24a5c30ee8c79ffadd1d52ff73f2d6343ed05a) |
| redeem-py | [`0x8c63e58e439783aa87722191d7b63d9ca56f4c78632a1a958ff6b81afbc96930`](https://arbiscan.io/tx/0x8c63e58e439783aa87722191d7b63d9ca56f4c78632a1a958ff6b81afbc96930) |

## Test plan

- [x] All 4 read commands return correct data
- [x] All 8 write commands return real on-chain tx hashes (no "pending" placeholders)
- [x] `--force` verified present in all `wallet_contract_call` invocations via code inspection
- [x] `extract_tx_hash` error path tested: returns descriptive error when txHash absent
- [x] Binary freshly built from source (v0.2.1) — not the release binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)