### PR TITLE
fix(curve): Multicall3 batching, LP token address & ETH native handling (v0.2.1)

### DIFF
--- a/skills/curve/.claude-plugin/plugin.json
+++ b/skills/curve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve/Cargo.lock
+++ b/skills/curve/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "curve"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve/Cargo.toml
+++ b/skills/curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve/SKILL.md
+++ b/skills/curve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.0"
+version: "0.2.1"
 author: "GeoGu360"
 tags:
   - dex
@@ -48,7 +48,7 @@ if ! command -v curve >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve@0.1.0/curve-${TARGET}${EXT}" -o ~/.local/bin/curve${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve@0.2.1/curve-${TARGET}${EXT}" -o ~/.local/bin/curve${EXT}
   chmod +x ~/.local/bin/curve${EXT}
 fi
 ```
@@ -70,7 +70,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve","version":"0.2.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -371,6 +371,11 @@ curve --chain 42161 remove-liquidity --pool <2pool_addr> --min-amounts "0,0"
 | `execution reverted` on quote/swap | Wrong pool selected (duplicate low-TVL pool) | Fixed in v0.2.0: pools are now sorted by TVL so the deepest pool is always selected |
 | `Unsupported pool coin count: 4` | 4-coin pool used with remove-liquidity | Fixed in v0.2.0: 4-coin proportional withdrawal now supported |
 | `transferFrom reverted` on approve | Approval broadcast before prior tx confirmed | Fixed in v0.2.0: `wait_for_tx` polls receipt before main op |
+| `get-balances` returns 0 positions or misses v1 pools (3pool, ETH/stETH) | LP token is a separate contract; old code queried pool address | Fixed in v0.2.1: uses `lpTokenAddress` from API when present |
+| `get-balances` very slow (~minutes) | ~839 sequential eth_calls | Fixed in v0.2.1: Multicall3 batching reduces to ~5 RPC calls |
+| `get-balances` shows hundreds of dust positions | Curve factory pools seeded with 1–64 wei LP tokens | Fixed in v0.2.1: `MIN_LP_BALANCE=1_000_000` filter |
+| `execution reverted` on `add-liquidity` for ETH-containing pools | Native ETH was being approved as ERC-20 and not passed as msg.value | Fixed in v0.2.1: ETH sentinel detected, passed via `--amt` |
+| `remove-liquidity` fails with "No LP token balance" on v1 pools | Balance check used pool address instead of LP token address | Fixed in v0.2.1: resolves `lpTokenAddress` before balance check |
 
 ## Security Notes
 

--- a/skills/curve/plugin.yaml
+++ b/skills/curve/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve
-version: "0.2.0"
+version: "0.2.1"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve/src/api.rs
+++ b/skills/curve/src/api.rs
@@ -44,6 +44,10 @@ pub struct PoolData {
     pub gauge_crv_apy: Option<Vec<Option<f64>>>,
     #[serde(default, rename = "latestDailyApyPcent")]
     pub latest_daily_apy_pcent: Option<f64>,
+    /// Separate LP token contract address (older Curve v1 pools).
+    /// For factory/crypto pools the LP token IS the pool address — field absent or null.
+    #[serde(default, rename = "lpTokenAddress")]
+    pub lp_token_address: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/skills/curve/src/commands/add_liquidity.rs
+++ b/skills/curve/src/commands/add_liquidity.rs
@@ -71,11 +71,21 @@ pub async fn run(
         return Ok(());
     }
 
-    // Approve each token with a non-zero amount, waiting for each to confirm on-chain
+    // ETH sentinel address used by Curve for native ETH coins
+    const ETH_SENTINEL: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+    // Approve each ERC-20 token; skip native ETH (no approve needed)
+    // and accumulate any ETH amount to pass as msg.value
+    let mut eth_value: u128 = 0;
     if let Some(p) = pool {
         for (i, coin) in p.coins.iter().enumerate() {
             let amount = amounts[i];
             if amount == 0 {
+                continue;
+            }
+            // Native ETH: no approve, pass as msg.value
+            if coin.address.to_lowercase() == ETH_SENTINEL {
+                eth_value += amount;
                 continue;
             }
             let allowance = rpc::get_allowance(&coin.address, &wallet_addr, &pool_address, rpc_url)
@@ -100,13 +110,14 @@ pub async fn run(
         }
     }
 
-    // Execute add_liquidity — requires --force
+    // Execute add_liquidity — pass ETH as msg.value if pool contains native ETH
+    let amt = if eth_value > 0 { Some(eth_value as u64) } else { None };
     let result = onchainos::wallet_contract_call(
         chain_id,
         &pool_address,
         &calldata,
         Some(&wallet_addr),
-        None,
+        amt,
         true,  // --force required
         false,
     )

--- a/skills/curve/src/commands/get_balances.rs
+++ b/skills/curve/src/commands/get_balances.rs
@@ -1,6 +1,14 @@
-// commands/get_balances.rs — Query user LP token balances across Curve pools
+// commands/get_balances.rs — Query user LP token balances across Curve pools via Multicall3
 use crate::{api, config, onchainos, rpc};
 use anyhow::Result;
+
+/// Max pools per Multicall3 batch (~88 KB calldata each, safe for public nodes).
+const BATCH_SIZE: usize = 200;
+
+/// Minimum LP balance to show — filters out Curve's 1-wei and 64-wei pool
+/// initialization seeds that appear as "positions" for every factory pool.
+/// Any real deposit produces orders of magnitude more LP tokens than this.
+const MIN_LP_BALANCE: u128 = 1_000_000;
 
 pub async fn run(chain_id: u64, wallet: Option<String>) -> Result<()> {
     let chain_name = config::chain_name(chain_id);
@@ -12,32 +20,50 @@ pub async fn run(chain_id: u64, wallet: Option<String>) -> Result<()> {
         None => {
             let w = onchainos::resolve_wallet(chain_id)?;
             if w.is_empty() {
-                anyhow::bail!("Cannot determine wallet address. Pass --wallet or ensure onchainos is logged in.");
+                anyhow::bail!(
+                    "Cannot determine wallet address. Pass --wallet or ensure onchainos is logged in."
+                );
             }
             w
         }
     };
 
-    // Fetch all pools
+    // Fetch all pools from Curve API
     let pools = api::get_all_pools(chain_name).await?;
+    // For older Curve v1 pools, the LP token is a separate contract (lpTokenAddress).
+    // For factory/crypto pools the LP token IS the pool address.
+    let lp_addrs: Vec<&str> = pools
+        .iter()
+        .map(|p| {
+            p.lp_token_address
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&p.address)
+        })
+        .collect();
 
-    // Check LP token balance for each pool (LP token = pool address in Curve)
-    let mut positions = Vec::new();
-    for pool in &pools {
-        let balance = rpc::balance_of(&pool.address, &wallet_addr, rpc_url)
+    // Batch balanceOf via Multicall3: N sequential calls → ceil(N/200) calls
+    let mut all_balances: Vec<u128> = Vec::with_capacity(pools.len());
+    for chunk in lp_addrs.chunks(BATCH_SIZE) {
+        let balances = rpc::multicall_balance_of(chunk, &wallet_addr, rpc_url)
             .await
-            .unwrap_or(0);
-        if balance > 0 {
-            let coins: Vec<_> = pool
-                .coins
-                .iter()
-                .map(|c| c.symbol.as_str())
-                .collect();
+            .unwrap_or_else(|_| vec![0u128; chunk.len()]);
+        all_balances.extend(balances);
+    }
+
+    // Collect pools where LP balance > 0
+    let mut positions = Vec::new();
+    for (pool, balance) in pools.iter().zip(all_balances.iter()) {
+        if *balance >= MIN_LP_BALANCE {
+            let coins: Vec<_> = pool.coins.iter().map(|c| c.symbol.as_str()).collect();
+            // All Curve LP tokens use 18 decimals
+            let lp_human = format!("{:.6}", *balance as f64 / 1e18);
             positions.push(serde_json::json!({
                 "pool_id": pool.id,
                 "pool_name": pool.name,
                 "pool_address": pool.address,
                 "coins": coins,
+                "lp_balance": lp_human,
                 "lp_balance_raw": balance.to_string(),
                 "tvl_usd": pool.usd_total
             }));

--- a/skills/curve/src/commands/remove_liquidity.rs
+++ b/skills/curve/src/commands/remove_liquidity.rs
@@ -26,11 +26,22 @@ pub async fn run(
         }
     };
 
+    // Fetch pool info first — needed to resolve LP token address for v1 pools
+    let pools = api::get_all_pools(chain_name).await?;
+    let pool = api::find_pool_by_address(&pools, &pool_address);
+
+    // Resolve LP token address: v1 pools use a separate LP token contract;
+    // factory/crypto pools use the pool address itself as the LP token.
+    let lp_token_addr = pool
+        .and_then(|p| p.lp_token_address.as_deref())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&pool_address);
+
     // Get LP balance
     let lp_balance = if dry_run {
         lp_amount.unwrap_or(1_000_000_000_000_000_000u128) // 1e18 placeholder
     } else {
-        let bal = rpc::balance_of(&pool_address, &wallet_addr, rpc_url).await?;
+        let bal = rpc::balance_of(lp_token_addr, &wallet_addr, rpc_url).await?;
         if bal == 0 {
             anyhow::bail!("No LP token balance for pool {}", pool_address);
         }
@@ -38,10 +49,6 @@ pub async fn run(
     };
 
     let actual_lp_amount = lp_amount.unwrap_or(lp_balance);
-
-    // Fetch pool info
-    let pools = api::get_all_pools(chain_name).await?;
-    let pool = api::find_pool_by_address(&pools, &pool_address);
     let n_coins = pool.map(|p| p.coins.len()).unwrap_or(2);
 
     // Build calldata

--- a/skills/curve/src/rpc.rs
+++ b/skills/curve/src/rpc.rs
@@ -1,5 +1,8 @@
 // rpc.rs — Direct eth_call utilities (no onchainos)
 
+/// Multicall3 contract — deployed at the same address on all major EVM chains.
+const MULTICALL3: &str = "0xcA11bde05977b3631167028862bE2a173976CA11";
+
 /// Perform a raw JSON-RPC eth_call
 pub async fn eth_call(to: &str, data: &str, rpc_url: &str) -> anyhow::Result<String> {
     let client = reqwest::Client::new();
@@ -42,6 +45,132 @@ pub async fn get_allowance(
     let data = format!("0xdd62ed3e{}{}", owner_padded, spender_padded);
     let hex = eth_call(token, &data, rpc_url).await?;
     Ok(u128::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap_or(0))
+}
+
+/// Batch balanceOf(owner) calls via Multicall3 aggregate3.
+///
+/// Replaces N sequential eth_calls with a single call to the Multicall3 contract.
+/// token_addrs and the returned Vec have the same length and order.
+/// Individual failures return 0 (allowFailure = true).
+///
+/// Encoding: aggregate3((address target, bool allowFailure, bytes callData)[])
+/// Selector: 0x82ad56cb
+pub async fn multicall_balance_of(
+    token_addrs: &[&str],
+    owner: &str,
+    rpc_url: &str,
+) -> anyhow::Result<Vec<u128>> {
+    let n = token_addrs.len();
+    if n == 0 {
+        return Ok(vec![]);
+    }
+
+    // balanceOf(address) calldata: selector (4 bytes) + owner padded to 32 bytes = 36 bytes
+    let owner_padded = format!("{:0>64}", owner.trim_start_matches("0x"));
+    let balance_of_hex = format!("70a08231{}", owner_padded); // 72 hex chars = 36 bytes
+
+    // ABI-encode aggregate3 input
+    // Layout (all in hex, no 0x):
+    //   selector (8 hex) | offset_to_array=0x20 (64) | array_len=N (64)
+    //   | N×offset_pointers (each 64) | N×struct_encodings (each 384 = 192 bytes)
+    //
+    // Each struct (address, bool, bytes=36 bytes):
+    //   [0]   address right-padded to 32 bytes
+    //   [32]  allowFailure = 1
+    //   [64]  offset to bytes within struct = 96 (0x60)
+    //   [96]  bytes length = 36 (0x24)
+    //   [128] first 32 bytes of calldata  (selector + first 28 bytes of padded owner)
+    //   [160] last 4 bytes of calldata + 28 zero-bytes padding
+    //
+    // struct[i] offset (relative to start of array body after length word) = N*32 + i*192
+
+    let mut hex_data = String::with_capacity(8 + 128 + n * 64 + n * 384);
+    hex_data.push_str("82ad56cb");
+    hex_data.push_str(&format!("{:0>64x}", 32u64));   // outer offset = 0x20
+    hex_data.push_str(&format!("{:0>64x}", n as u64)); // array length
+
+    for i in 0..n {
+        let offset = n * 32 + i * 192;
+        hex_data.push_str(&format!("{:0>64x}", offset as u64));
+    }
+    for addr in token_addrs {
+        let addr_clean = addr.trim_start_matches("0x");
+        hex_data.push_str(&format!("{:0>64}", addr_clean)); // address
+        hex_data.push_str(&format!("{:0>64x}", 1u64));      // allowFailure = true
+        hex_data.push_str(&format!("{:0>64x}", 96u64));     // bytes offset within struct
+        hex_data.push_str(&format!("{:0>64x}", 36u64));     // bytes length = 36
+        hex_data.push_str(&balance_of_hex[..64]);            // first 32 bytes of calldata
+        hex_data.push_str(&balance_of_hex[64..]);            // last 4 bytes of calldata
+        hex_data.push_str(&"0".repeat(56));                  // 28 bytes padding
+    }
+
+    let calldata = format!("0x{}", hex_data);
+    let result_hex = eth_call(MULTICALL3, &calldata, rpc_url).await?;
+    let clean = &result_hex[2..]; // strip "0x" prefix only (not leading zeros)
+
+    // Convert hex string → bytes
+    let bytes: Vec<u8> = (0..clean.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&clean[i..i + 2], 16).unwrap_or(0))
+        .collect();
+
+    // Decode (bool success, bytes returnData)[]
+    // [0:32]   outer offset = 0x20
+    // [32:64]  array length N
+    // [64:64+N*32]  N offset pointers (each 32 bytes, relative to array content start at byte 64)
+    //
+    // Each element (bool, bytes):
+    //   [+0:+32]   bool success
+    //   [+32:+64]  offset to bytes data within element (= 0x40 = 64 when bytes.length > 0)
+    //   [+64:+96]  bytes length (= 32 for successful balanceOf; = 0 for failed/reverted call)
+    //   [+96:+128] bytes data (present only when length > 0)
+    //
+    // IMPORTANT: elements have variable size — failed calls (bytes.length=0) produce 96-byte
+    // elements, successful calls 128 bytes. We must read actual offset pointers rather than
+    // computing elem position as 64 + N*32 + i*128 (which would misalign after any failed call).
+
+    let mut balances = vec![0u128; n];
+    for i in 0..n {
+        // Read the actual offset for element[i] from the offset pointer table
+        let ptr_start = 64 + i * 32;
+        if ptr_start + 32 > bytes.len() {
+            break;
+        }
+        // Offset is a uint256 (big-endian); we only need the low usize bytes
+        let mut off_buf = [0u8; 8];
+        off_buf.copy_from_slice(&bytes[ptr_start + 24..ptr_start + 32]);
+        let elem_offset = usize::from_be_bytes(off_buf);
+        // Element absolute position = array content start (64) + element offset
+        let elem = 64 + elem_offset;
+
+        // Check success flag (last byte of 32-byte bool word)
+        if bytes.get(elem + 31).copied().unwrap_or(0) == 0 {
+            continue; // call reverted — skip
+        }
+
+        // bytes length is at element offset + 64 (after bool + bytes-ptr-word)
+        let len_pos = elem + 64;
+        if len_pos + 32 > bytes.len() {
+            continue;
+        }
+        let mut len_buf = [0u8; 8];
+        len_buf.copy_from_slice(&bytes[len_pos + 24..len_pos + 32]);
+        let data_len = usize::from_be_bytes(len_buf);
+        if data_len < 16 {
+            continue; // need at least 16 bytes to extract u128
+        }
+
+        let data_start = elem + 96;
+        let data_end = data_start + data_len;
+        if data_end > bytes.len() {
+            continue;
+        }
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(&bytes[data_end - 16..data_end]);
+        balances[i] = u128::from_be_bytes(buf);
+    }
+
+    Ok(balances)
 }
 
 /// Decode a 32-byte ABI-encoded uint256 result to u128


### PR DESCRIPTION
## Summary

Four bugs fixed in the Curve skill, bumping version `0.2.0 → 0.2.1`.

### Bug Fixes

**1. `get-balances` missing v1 pool positions (3pool, ETH/stETH, tricrypto2)**
- Root cause: older Curve v1 pools have a *separate* LP token contract (`lpTokenAddress`); code was calling `balanceOf` on the pool address instead, always returning 0.
- Fix: deserialize `lpTokenAddress` from the Curve API into `PoolData`; use it in `get-balances` and `remove-liquidity` when present, fallback to pool address for factory/crypto pools.

**2. `get-balances` extremely slow (~minutes) and showing hundreds of dust positions**
- Root cause: ~839 sequential `eth_call`s (one per pool), hitting RPC timeout. Factory pools are also initialized with 1–64 wei LP seeds that showed as fake positions.
- Fix: replace sequential calls with Multicall3 `aggregate3` batching (BATCH_SIZE=200, ~5 RPC calls total). Add `MIN_LP_BALANCE=1_000_000` dust filter. Add human-readable `lp_balance` field (raw ÷ 1e18).

**3. Multicall3 response decoder offset misalignment**
- Root cause: decoder assumed all response elements were 128 bytes (`elem = 64 + N×32 + i×128`). Failed `balanceOf` calls return 96-byte elements (empty `returnData`), shifting every subsequent element offset and returning 0 for all pools after the first failed call.
- Fix: read actual offset pointers from the ABI response header instead of computing positions directly. Also fix `result_hex[2:]` (strip only `"0x"` prefix) vs `lstrip("0x")` which was stripping all leading zero bytes.

**4. `add-liquidity` execution revert on ETH-containing pools**
- Root cause: native ETH coins use the `0xEeee...EEEe` sentinel address. Code was attempting `approve()` on the ETH sentinel (reverts) and not passing ETH as `msg.value`.
- Fix: detect ETH sentinel, skip ERC-20 approve, accumulate amount as `eth_value`, pass via `--amt` (onchainos `msg.value`).

**5. `remove-liquidity` "No LP token balance" on v1 pools**
- Root cause: LP balance check used the pool contract address; v1 pools need the separate `lpTokenAddress`.
- Fix: resolve `lpTokenAddress` from API before the balance check (same fix as `get-balances`).

## Files Changed

| File | Change |
|------|--------|
| `src/api.rs` | Add `lp_token_address: Option<String>` field to `PoolData` |
| `src/rpc.rs` | Add `multicall_balance_of()` via Multicall3; fix response decoder |
| `src/commands/get_balances.rs` | Multicall3 batching, LP token address fix, dust filter, human-readable balance |
| `src/commands/add_liquidity.rs` | ETH sentinel detection, skip approve, pass as msg.value |
| `src/commands/remove_liquidity.rs` | Resolve LP token address before balance check |
| `Cargo.toml` / `plugin.yaml` / `SKILL.md` / `.claude-plugin/plugin.json` | Bump to v0.2.1 |

## Test plan

- [x] `get-balances` returns all 5 positions (3pool, ETH/stETH, tricrypto2, rETH/wstETH, ETHx-ETH) correctly on Ethereum mainnet
- [x] `get-balances` completes in ~4s (was timing out)
- [x] No dust positions shown (previously 285 fake positions)
- [x] `add-liquidity` ETH/stETH pool: deposits ETH as msg.value, no approve error
- [x] `add-liquidity` ETHx-ETH pool: dual-sided ETH + ETHx deposit confirmed on-chain
- [x] `add-liquidity` tricrypto2 (USDT/WBTC/WETH): single-sided USDT deposit confirmed on-chain
- [x] `remove-liquidity` 3pool, ETH/stETH, tricrypto2: all confirmed on-chain
- [x] Version `0.2.1` consistent across all 4 required files

🤖 Generated with [Claude Code](https://claude.com/claude-code)