### PR TITLE
fix(pancakeswap): surface RPC errors in pools command instead of silent tick=0 (v0.2.1)

### DIFF
--- a/skills/pancakeswap/.claude-plugin/plugin.json
+++ b/skills/pancakeswap/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/pancakeswap/Cargo.lock
+++ b/skills/pancakeswap/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "pancakeswap"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap/Cargo.toml
+++ b/skills/pancakeswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap/SKILL.md
+++ b/skills/pancakeswap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
-version: "0.2.0"
+version: "0.2.1"
 author: "GeoGu360"
 tags:
   - dex
@@ -48,7 +48,7 @@ if ! command -v pancakeswap >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap@0.2.0/pancakeswap-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap@0.2.1/pancakeswap-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap${EXT}
   chmod +x ~/.local/bin/pancakeswap${EXT}
 fi
 ```
@@ -67,7 +67,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap","version":"0.2.1"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"pancakeswap","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -209,7 +209,9 @@ pancakeswap pools --token0 WBNB --token1 USDT --chain 56
 pancakeswap pools --token0 WETH --token1 USDC --chain 42161
 ```
 
-Returns pool addresses, liquidity, and current price (sqrtPriceX96) for each fee tier. This is a read-only operation using `eth_call` — no transactions or gas required.
+Returns pool addresses, liquidity, current price, and current tick for each fee tier. This is a read-only operation using `eth_call` — no transactions or gas required.
+
+If an RPC call fails (e.g. node rate-limit), the affected pool row displays `[RPC error — try again or check rate limits]` with the error detail, instead of silently showing `tick: 0`.
 
 ---
 

--- a/skills/pancakeswap/plugin.yaml
+++ b/skills/pancakeswap/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap
-version: "0.2.0"
+version: "0.2.1"
 description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360

--- a/skills/pancakeswap/src/commands/pools.rs
+++ b/skills/pancakeswap/src/commands/pools.rs
@@ -28,31 +28,39 @@ pub async fn run(args: PoolsArgs) -> Result<()> {
         match crate::rpc::get_pool_address(cfg.factory, &addr0, &addr1, fee, cfg.rpc_url).await {
             Ok(pool_addr) => {
                 found += 1;
-                // Query slot0 and liquidity
-                let (sqrt_price, tick) = crate::rpc::get_slot0(&pool_addr, cfg.rpc_url)
-                    .await
-                    .unwrap_or((0, 0));
-                let liquidity = crate::rpc::get_pool_liquidity(&pool_addr, cfg.rpc_url)
-                    .await
-                    .unwrap_or(0);
+                let fee_label = format!("{:.2}%", fee as f64 / 10000.0);
 
-                // Compute approximate price from sqrtPriceX96
-                // price = (sqrtPriceX96 / 2^96)^2
-                let price = if sqrt_price > 0 {
-                    let sq = sqrt_price as f64 / 2f64.powi(96);
-                    format!("{:.4}", sq * sq)
-                } else {
-                    "N/A".to_string()
-                };
+                // Query slot0 and liquidity — surface RPC errors explicitly
+                // so agents don't mistake rate-limit failures for tick=0 bugs.
+                let slot0 = crate::rpc::get_slot0(&pool_addr, cfg.rpc_url).await;
+                let liq = crate::rpc::get_pool_liquidity(&pool_addr, cfg.rpc_url).await;
 
-                println!(
-                    "{:<8} {:<44} {:>14} {:>12}",
-                    format!("{:.2}%", fee as f64 / 10000.0),
-                    pool_addr,
-                    liquidity,
-                    price,
-                );
-                println!("         tick: {}", tick);
+                match (slot0, liq) {
+                    (Ok((sqrt_price, tick)), Ok(liquidity)) => {
+                        let price = if sqrt_price > 0 {
+                            let sq = sqrt_price as f64 / 2f64.powi(96);
+                            format!("{:.4}", sq * sq)
+                        } else {
+                            "N/A".to_string()
+                        };
+                        println!(
+                            "{:<8} {:<44} {:>14} {:>12}",
+                            fee_label, pool_addr, liquidity, price,
+                        );
+                        println!("         tick: {}", tick);
+                    }
+                    (slot0_res, liq_res) => {
+                        let err = slot0_res.err()
+                            .or(liq_res.err())
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| "unknown error".to_string());
+                        println!(
+                            "{:<8} {:<44} [RPC error — try again or check rate limits]",
+                            fee_label, pool_addr,
+                        );
+                        println!("         error: {}", err);
+                    }
+                }
             }
             Err(_) => {
                 // Pool doesn't exist for this fee tier — skip silently


### PR DESCRIPTION
## Summary

- `pools` command: when `get_slot0()` or `get_pool_liquidity()` fail (e.g. node rate-limit, network timeout), the affected pool row now prints a clear `[RPC error — try again or check rate limits]` message with the underlying error, instead of silently showing `tick: 0` and `liquidity: 0`
- Bump version `0.2.0 → 0.2.1` across all 4 required files
- Update SKILL.md `pools` section to document tick output field and RPC error behavior

## Root Cause

Previously:
```rust
let (sqrt_price, tick) = get_slot0(&pool_addr, rpc_url).await.unwrap_or((0, 0));
let liquidity = get_pool_liquidity(&pool_addr, rpc_url).await.unwrap_or(0);
```
A transient RPC failure silently produced `tick: 0`, causing agents to report the skill as broken or misdiagnose a code bug.

## Test plan

- [ ] `pancakeswap pools --token0 USDT --token1 WBNB --chain 56` returns correct non-zero ticks
- [ ] 10 concurrent calls all succeed without triggering rate-limit errors on BSC public RPC
- [ ] On RPC failure, output shows `[RPC error — try again or check rate limits]` instead of `tick: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)