### PR TITLE
fix(etherfi,pancakeswap): version-check binary in install script to force upgrade

### DIFF
--- a/skills/etherfi/SKILL.md
+++ b/skills/etherfi/SKILL.md
@@ -37,7 +37,12 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install etherfi binary (auto-injected)
 
 ```bash
-if ! command -v etherfi >/dev/null 2>&1; then
+NEED_INSTALL=true
+if command -v etherfi >/dev/null 2>&1; then
+  _VER=$(etherfi --version 2>/dev/null | awk '{print $2}')
+  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
+fi
+if [ "$NEED_INSTALL" = "true" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""

--- a/skills/pancakeswap/SKILL.md
+++ b/skills/pancakeswap/SKILL.md
@@ -32,7 +32,12 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install pancakeswap binary (auto-injected)
 
 ```bash
-if ! command -v pancakeswap >/dev/null 2>&1; then
+NEED_INSTALL=true
+if command -v pancakeswap >/dev/null 2>&1; then
+  _VER=$(pancakeswap --version 2>/dev/null | awk '{print $2}')
+  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
+fi
+if [ "$NEED_INSTALL" = "true" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""


### PR DESCRIPTION
## Problem

Install scripts used `if ! command -v <binary>` — skips re-download when binary is already in PATH, even if it's an older version.

Effect:
- Users who had etherfi v0.2.0 installed re-ran the install after okx/plugin-store#117 was merged
- SKILL.md updated to v0.2.1 but **old binary was kept** (still uses dead ether.fi API → `apy: N/A`, `tvl: N/A`, `weETHtoEETH: N/A`)
- Same issue for pancakeswap (old tick-decoding bug binary could persist)

## Fix

Add a version check before skipping the download:

```bash
NEED_INSTALL=true
if command -v etherfi >/dev/null 2>&1; then
  _VER=$(etherfi --version 2>/dev/null | awk '{print $2}')
  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
fi
if [ "$NEED_INSTALL" = "true" ]; then
  # download...
fi
```

If the installed binary already matches the expected version → skip (no change in behavior for fresh installs or already-updated users).  
If the installed binary is an older version → force re-download and overwrite.

## Affected skills

- `skills/etherfi/SKILL.md` — fixes silent N/A for APY/TVL/exchange rate after v0.2.1 upgrade
- `skills/pancakeswap/SKILL.md` — same pattern, prevents stale binary after v0.2.1 upgrade

## Test plan

- [ ] Fresh install: binary not present → downloads normally
- [ ] Already on v0.2.1: `NEED_INSTALL=false` → skips download
- [ ] Upgrading from v0.2.0: `_VER != "0.2.1"` → re-downloads v0.2.1 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)