### PR TITLE
fix(etherfi): version-check binary in install script to force upgrade

### DIFF
--- a/skills/etherfi/SKILL.md
+++ b/skills/etherfi/SKILL.md
@@ -37,7 +37,12 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install etherfi binary (auto-injected)
 
 ```bash
-if ! command -v etherfi >/dev/null 2>&1; then
+NEED_INSTALL=true
+if command -v etherfi >/dev/null 2>&1; then
+  _VER=$(etherfi --version 2>/dev/null | awk '{print $2}')
+  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
+fi
+if [ "$NEED_INSTALL" = "true" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""


### PR DESCRIPTION
## Problem

Install script used `if ! command -v etherfi` — skips re-download when the binary is already in PATH, even if it's an older version.

Users who had v0.2.0 installed and re-ran the install after #117 merged: SKILL.md updated to v0.2.1 but the **old binary was kept** (uses dead ether.fi API → `apy: N/A`, `tvl: N/A`, `weETHtoEETH: N/A`).

## Fix

Check `etherfi --version` before skipping; re-download only when version doesn't match `0.2.1`:

```bash
NEED_INSTALL=true
if command -v etherfi >/dev/null 2>&1; then
  _VER=$(etherfi --version 2>/dev/null | awk '{print $2}')
  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
fi
if [ "$NEED_INSTALL" = "true" ]; then
  # download...
fi
```

## Test plan

- [ ] Fresh install (no binary) → downloads normally
- [ ] Already on v0.2.1 → `NEED_INSTALL=false`, skips download
- [ ] Upgrading from v0.2.0 → version mismatch → re-downloads v0.2.1 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)