### PR TITLE
fix(kamino-liquidity): correct binary download URL + add --version flag

### DIFF
--- a/skills/kamino-liquidity/SKILL.md
+++ b/skills/kamino-liquidity/SKILL.md
@@ -24,7 +24,7 @@ onchainos --version 2>/dev/null || curl -fsSL https://raw.githubusercontent.com/
 npx skills add okx/onchainos-skills --yes --global
 
 # 3. Install plugin-store skills (enables plugin discovery and management)
-npx skills add MigOKG/plugin-store --skill plugin-store --yes --global
+npx skills add okx/plugin-store --skill plugin-store --yes --global
 ```
 
 ### Install kamino-liquidity binary (auto-injected)
@@ -46,7 +46,7 @@ if ! command -v kamino-liquidity >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/MigOKG/plugin-store/releases/download/plugins/kamino-liquidity@0.1.0/kamino-liquidity-${TARGET}${EXT}" -o ~/.local/bin/kamino-liquidity${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/kamino-liquidity@0.1.0/kamino-liquidity-${TARGET}${EXT}" -o ~/.local/bin/kamino-liquidity${EXT}
   chmod +x ~/.local/bin/kamino-liquidity${EXT}
 fi
 ```

--- a/skills/kamino-liquidity/src/main.rs
+++ b/skills/kamino-liquidity/src/main.rs
@@ -8,7 +8,8 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     name = "kamino-liquidity",
-    about = "Kamino Liquidity plugin — deposit into and withdraw from Kamino KVault earn vaults on Solana"
+    about = "Kamino Liquidity plugin — deposit into and withdraw from Kamino KVault earn vaults on Solana",
+    version
 )]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

- **Bug fix**: Pre-flight install script pointed to `MigOKG/plugin-store` (author's fork) — causing 404 for all users. Updated both the binary download URL and the plugin-store skill install reference to `okx/plugin-store`.
- **Improvement**: Added `--version` flag via `#[command(version)]` in `main.rs` — `kamino-liquidity --version` now returns `kamino-liquidity 0.1.0` instead of erroring with code 2.

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | `MigOKG/plugin-store` → `okx/plugin-store` in binary URL and skill install (2 occurrences) |
| `src/main.rs` | Added `version` to `#[command(...)]` attribute |

## Testing

- [x] Binary download URL returns 302 → valid asset (verified)
- [x] `kamino-liquidity --version` returns `kamino-liquidity 0.1.0`
- [x] Only `skills/kamino-liquidity/` files in diff