### PR TITLE
fix(etherfi): fix eETHExpected=0 in unwrap and asEETH=0 in positions (v0.2.2)

### DIFF
--- a/skills/etherfi/.claude-plugin/plugin.json
+++ b/skills/etherfi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "etherfi",
   "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/etherfi/Cargo.lock
+++ b/skills/etherfi/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "etherfi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/etherfi/Cargo.toml
+++ b/skills/etherfi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etherfi"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/etherfi/SKILL.md
+++ b/skills/etherfi/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Liquid restaking on Ethereum. Deposit ETH into ether.fi LiquidityPool to receive eETH,
   wrap eETH into weETH (ERC-4626 yield-bearing token) to earn staking + EigenLayer
   restaking rewards, unstake eETH back to ETH, check balances, and view current APY.
-version: 0.2.1
+version: 0.2.2
 author: GeoGu360
 tags:
   - liquid-staking
@@ -40,7 +40,7 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 NEED_INSTALL=true
 if command -v etherfi >/dev/null 2>&1; then
   _VER=$(etherfi --version 2>/dev/null | awk '{print $2}')
-  [ "$_VER" = "0.2.1" ] && NEED_INSTALL=false
+  [ "$_VER" = "0.2.2" ] && NEED_INSTALL=false
 fi
 if [ "$NEED_INSTALL" = "true" ]; then
   OS=$(uname -s | tr A-Z a-z)
@@ -58,7 +58,7 @@ if [ "$NEED_INSTALL" = "true" ]; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/etherfi@0.2.1/etherfi-${TARGET}${EXT}" -o ~/.local/bin/etherfi${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/etherfi@0.2.2/etherfi-${TARGET}${EXT}" -o ~/.local/bin/etherfi${EXT}
   chmod +x ~/.local/bin/etherfi${EXT}
 fi
 ```
@@ -80,7 +80,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"etherfi","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"etherfi","version":"0.2.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/etherfi/plugin.yaml
+++ b/skills/etherfi/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: etherfi
-version: 0.2.1
+version: 0.2.2
 description: Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap/unwrap eETH/weETH (ERC-4626), unstake eETH back to ETH, and check positions with APY
 author:
   name: GeoGu360

--- a/skills/etherfi/src/commands/positions.rs
+++ b/skills/etherfi/src/commands/positions.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use crate::api::fetch_stats;
 use crate::config::{eeth_address, format_units, rpc_url, weeth_address, CHAIN_ID};
 use crate::onchainos::resolve_wallet;
-use crate::rpc::{get_balance, weeth_convert_to_assets};
+use crate::rpc::get_balance;
 
 #[derive(Args)]
 pub struct PositionsArgs {
@@ -30,9 +30,11 @@ pub async fn run(args: PositionsArgs) -> anyhow::Result<()> {
     // Fetch weETH balance (18 decimals)
     let weeth_balance = get_balance(weeth, &owner, rpc).await.unwrap_or(0);
 
-    // Convert weETH to eETH equivalent for display
+    // Convert weETH to eETH equivalent for display.
+    // weETH.convertToAssets() reverts on this contract; use getRate() instead.
     let weeth_as_eeth = if weeth_balance > 0 {
-        weeth_convert_to_assets(weeth, weeth_balance, rpc).await.unwrap_or(0)
+        let rate = crate::rpc::weeth_get_rate(weeth, rpc).await.unwrap_or(0.0);
+        (weeth_balance as f64 * rate) as u128
     } else {
         0
     };

--- a/skills/etherfi/src/commands/unwrap.rs
+++ b/skills/etherfi/src/commands/unwrap.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use crate::calldata::build_unwrap_calldata;
 use crate::config::{format_units, parse_units, rpc_url, weeth_address, CHAIN_ID};
 use crate::onchainos::{extract_tx_hash, resolve_wallet, wallet_contract_call};
-use crate::rpc::{get_balance, weeth_convert_to_assets};
+use crate::rpc::get_balance;
 
 #[derive(Args)]
 pub struct UnwrapArgs {
@@ -31,10 +31,10 @@ pub async fn run(args: UnwrapArgs) -> anyhow::Result<()> {
     // Resolve wallet address
     let wallet = resolve_wallet(CHAIN_ID)?;
 
-    // Preview: how much eETH will be returned
-    let eeth_expected = weeth_convert_to_assets(weeth, weeth_wei, rpc)
-        .await
-        .unwrap_or(0);
+    // Preview: how much eETH will be returned.
+    // weETH.convertToAssets() reverts on this contract; use getRate() instead.
+    let rate = crate::rpc::weeth_get_rate(weeth, rpc).await.unwrap_or(0.0);
+    let eeth_expected = (weeth_wei as f64 * rate) as u128;
 
     println!(
         "Unwrapping {} weETH ({} wei) → eETH",


### PR DESCRIPTION
## Problem

`weETH.convertToAssets(uint256)` reverts on the weETH contract — the ERC-4626 view function is not supported by this implementation. Two call sites used `.unwrap_or(0)`, silently returning 0:

- `unwrap --dry-run` → `eETHExpected: 0` (regardless of amount)
- `positions` → `asEETH: 0` for any non-zero weETH balance

Verified with direct `eth_call`: both `convertToAssets` and `convertToShares` return `execution reverted`.

## Fix

Replace both call sites with `weeth_get_rate()`-based calculation:

```
eETH = weETH_wei * rate / 1e18
```

`getRate()` (selector `0x679aefce`) is already proven to work and is used for the `weETHtoEETH` field in `positions`. No new RPC calls added.

## Affected commands

| Command | Before | After |
|---------|--------|-------|
| `unwrap --dry-run --amount 0.1` | `eETHExpected: 0` | `eETHExpected: 0.10923595` |
| `positions` (with weETH balance) | `asEETH: 0` | `asEETH: 0.001955` (correct) |

## Test plan

- [x] `unwrap --amount 0.1 --dry-run` → `eETHExpected` matches `amount × weETHtoEETH` rate
- [x] `positions` with non-zero weETH balance → `asEETH` calculated correctly
- [x] `wrap` + `positions` on-chain — `asEETH` reflects updated balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)