### PR TITLE
fix(polymarket): correct buy order price ratio to avoid tick-size rejection

### DIFF
--- a/skills/polymarket/.claude-plugin/plugin.json
+++ b/skills/polymarket/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket",
   "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket/.claude-plugin/plugin.json
+++ b/skills/polymarket/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket",
   "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket/Cargo.lock
+++ b/skills/polymarket/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket/Cargo.lock
+++ b/skills/polymarket/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket/Cargo.toml
+++ b/skills/polymarket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket/Cargo.toml
+++ b/skills/polymarket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket"
-version = "0.3.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, and manage orders on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, polymarket yes token, polymarket no token, prediction market trade, polymarket price."
-version: "0.3.0"
+version: "0.2.1"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -20,7 +20,7 @@ tags:
 ### Install polymarket binary
 
 ```bash
-REQUIRED_VERSION="0.3.0"
+REQUIRED_VERSION="0.2.1"
 INSTALLED_VERSION=$(polymarket --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
@@ -116,7 +116,7 @@ Polymarket is a prediction market platform on Polygon where users trade outcome 
 polymarket --version
 ```
 
-Expected: `polymarket 0.3.0`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.2.1`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel only)
 

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, and manage orders on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, polymarket yes token, polymarket no token, prediction market trade, polymarket price."
-version: "0.2.0"
+version: "0.3.0"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -20,7 +20,7 @@ tags:
 ### Install polymarket binary
 
 ```bash
-REQUIRED_VERSION="0.2.0"
+REQUIRED_VERSION="0.3.0"
 INSTALLED_VERSION=$(polymarket --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
@@ -116,7 +116,7 @@ Polymarket is a prediction market platform on Polygon where users trade outcome 
 polymarket --version
 ```
 
-Expected: `polymarket 0.2.0`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.3.0`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel only)
 

--- a/skills/polymarket/plugin.yaml
+++ b/skills/polymarket/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket
-version: "0.2.0"
+version: "0.3.0"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket/plugin.yaml
+++ b/skills/polymarket/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket
-version: "0.3.0"
+version: "0.2.1"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket/src/commands/buy.rs
+++ b/skills/polymarket/src/commands/buy.rs
@@ -93,12 +93,16 @@ pub async fn run(
         eprintln!("[polymarket] Approval tx: {}", tx_hash);
     }
 
-    // Build order amounts
-    let rounded_usdc = round_amount_down(usdc_amount, tick_size);
-    let maker_amount_raw = to_token_units(rounded_usdc);
-    let shares = rounded_usdc / limit_price;
+    // Build order amounts — compute shares first, then back-compute USDC from
+    // price × rounded_shares to guarantee the maker/taker ratio is exactly limit_price.
+    // (Rounding shares and USDC independently produces a skewed ratio that fails API
+    // tick-size validation, e.g. 10_000_000 / 10_200_000 = 50/51 ≠ 0.98.)
+    let shares = usdc_amount / limit_price;
     let rounded_shares = round_size_down(shares);
     let taker_amount_raw = to_token_units(rounded_shares);
+    let actual_usdc = limit_price * rounded_shares;
+    let rounded_usdc = round_amount_down(actual_usdc, tick_size);
+    let maker_amount_raw = to_token_units(rounded_usdc);
 
     let salt = rand_salt();
 


### PR DESCRIPTION
## Summary

- **Bug**: Passing \`--price 0.98\` (or any valid price) caused the Polymarket API to reject with \`"Price (0.9803921568627451) breaks minimum tick size rule: 0.001"\`
- **Root cause**: \`maker_amount\` and \`taker_amount\` were computed by rounding USDC and shares independently. For 10 USDC at 0.98: \`rounded_shares = floor(10.204 × 100)/100 = 10.20\`, giving ratio \`10_000_000 / 10_200_000 = 50/51 = 0.9803921...\` — not a valid tick multiple.
- **Fix**: Compute shares first, round shares down, then back-compute USDC as \`price × rounded_shares\`. This guarantees \`maker / taker = limit_price\` exactly (same pattern as the Python \`clob-client\` reference implementation).
- **Version**: bumped 0.2.0 → 0.2.1 (patch bump for bug fix)

The \`sell\` command was not affected — it already computes in the correct direction (\`USDC = price × shares\`).

## Technical Details

- **Language**: Rust
- **Binary**: \`polymarket\`
- **Chains**: Polygon (137)
- **APIs**: Polymarket CLOB API, Gamma API, Data API
- **Wallet ops**: EIP-712 order signing, USDC.e approve, CTF setApprovalForAll

## Testing

- [ ] \`polymarket --version\` returns \`polymarket 0.2.1\`
- [ ] \`polymarket buy --market <id> --outcome YES --price 0.98 --amount 10\` — no tick-size error, order submitted
- [ ] \`polymarket buy --market <id> --outcome YES --price 0.50 --amount 5\` — round number, verify passes
- [ ] \`polymarket buy --market <id> --outcome YES --price 0.97 --amount 1\` — small amount, correct rounding
- [ ] Dry-run: confirm \`maker_amount / taker_amount\` in signed order equals the requested price

## Checklist

- [x] Source code included (local build)
- [x] Version bumped in all 4 required files (plugin.yaml, Cargo.toml, SKILL.md, .claude-plugin/plugin.json) + Cargo.lock regenerated
- [x] SKILL.md version references updated (frontmatter, REQUIRED_VERSION, Expected line)
- [x] SKILL.md prose accurate — exact-amount approvals, --force documented, Data Trust Boundary present
- [x] Only \`skills/polymarket/\` files in diff (\`git diff --name-only upstream/main...HEAD | grep -v '^skills/'\` = empty)
- [x] All on-chain writes via onchainos wallet contract-call
- [x] plugin.yaml api_calls match source code
- [x] .claude-plugin/plugin.json present