### PR TITLE
fix(curve): v0.2.3 — human-readable --amount (accept decimals like 0.5)

### DIFF
--- a/skills/curve/.claude-plugin/plugin.json
+++ b/skills/curve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve/Cargo.lock
+++ b/skills/curve/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "curve"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve/Cargo.toml
+++ b/skills/curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve/SKILL.md
+++ b/skills/curve/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.2"
+version: "0.2.3"
 author: "GeoGu360"
 tags:
   - dex
@@ -32,7 +32,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install curve binary (auto-injected)
 
 ```bash
-if ! command -v curve >/dev/null 2>&1; then
+REQUIRED_VERSION="0.2.3"
+INSTALLED_VERSION=$(curve --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$INSTALLED_VERSION" | sort -V | head -1)" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -48,7 +50,7 @@ if ! command -v curve >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve@0.2.2/curve-${TARGET}${EXT}" -o ~/.local/bin/curve${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve@0.2.3/curve-${TARGET}${EXT}" -o ~/.local/bin/curve${EXT}
   chmod +x ~/.local/bin/curve${EXT}
 fi
 ```
@@ -70,7 +72,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve","version":"0.2.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve","version":"0.2.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -303,8 +305,8 @@ curve --chain <chain_id> [--dry-run] add-liquidity --pool <pool_address> --amoun
 
 **Parameters:**
 - `--pool` — Pool contract address (obtain from `get-pools`)
-- `--amounts` — Comma-separated token amounts in minimal units matching pool coin order (e.g. `"0,1000000,1000000"` for 3pool: DAI,USDC,USDT)
-- `--min-mint` — Minimum LP tokens to accept (default: 0)
+- `--amounts` — Comma-separated token amounts in human-readable units matching pool coin order (e.g. `"0,500.0,500.0"` for 3pool: DAI,USDC,USDT); decimals resolved automatically from pool data
+- `--min-mint` — Minimum LP tokens to accept in human-readable units (default: 0)
 - `--wallet` — Sender address
 
 **Execution flow:**
@@ -316,7 +318,7 @@ curve --chain <chain_id> [--dry-run] add-liquidity --pool <pool_address> --amoun
 
 **Example — 3pool (DAI/USDC/USDT), supply 500 USDC + 500 USDT:**
 ```
-curve --chain 1 add-liquidity --pool 0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7 --amounts "0,500000000,500000000"
+curve --chain 1 add-liquidity --pool 0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7 --amounts "0,500.0,500.0"
 ```
 
 ---
@@ -332,9 +334,9 @@ curve --chain <chain_id> [--dry-run] remove-liquidity --pool <pool_address> [--l
 
 **Parameters:**
 - `--pool` — Pool contract address
-- `--lp-amount` — LP tokens to redeem (default: full wallet balance)
+- `--lp-amount` — LP tokens to redeem in human-readable units (default: full wallet balance)
 - `--coin-index` — Coin index for single-coin withdrawal (omit for proportional)
-- `--min-amounts` — Minimum amounts to receive (default: 0); pass as many values as pool coins (2, 3, or 4)
+- `--min-amounts` — Minimum amounts to receive in human-readable units (default: 0); pass as many values as pool coins (2, 3, or 4); decimals resolved automatically from pool data
 - `--wallet` — Sender address
 
 **Execution flow:**
@@ -378,6 +380,8 @@ curve --chain 42161 remove-liquidity --pool <2pool_addr> --min-amounts "0,0"
 | `execution reverted` on swap/add-liquidity after approve | Approve tx not yet mined before main tx submitted; RPC polling failed inside Tokio runtime | Fixed in v0.2.2: approve confirmation polls via `onchainos wallet history` in `spawn_blocking` |
 | `--amount 1000` rejected or swap uses wrong amount | `--amount` expected minimal units (e.g. 1000000 for 1 USDC) | Fixed in v0.2.2: `--amount` now accepts human-readable float (e.g. `1000.0`); decimals resolved from pool |
 | `token_in.symbol` shows raw address in output | Symbol not resolved when input was an address | Fixed in v0.2.2: symbol and decimals resolved from pool coin data |
+| `--amounts "0,500000000,500000000"` causes wrong add-liquidity amount or confusion | `add-liquidity --amounts` expected raw minimal units | Fixed in v0.2.3: `--amounts` now accepts human-readable values (e.g. `"0,500.0,500.0"`); decimals resolved per coin from pool data |
+| `--lp-amount 1000000000000000000` rejected with "invalid digit" or wrong amount | `--lp-amount` and `--min-amounts` for remove-liquidity expected raw u128 integers | Fixed in v0.2.3: both accept human-readable decimal strings (e.g. `--lp-amount 1.5`); LP tokens always 18 decimals |
 
 ## Security Notes
 

--- a/skills/curve/plugin.yaml
+++ b/skills/curve/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve
-version: "0.2.2"
+version: "0.2.3"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360
@@ -29,3 +29,5 @@ api_calls:
   - "https://base-rpc.publicnode.com"
   - "https://polygon-bor-rpc.publicnode.com"
   - "https://bsc-rpc.publicnode.com"
+  - "https://plugin-store-dun.vercel.app/install"
+  - "https://www.okx.com/priapi/v1/wallet/plugins/download/report"

--- a/skills/curve/src/commands/add_liquidity.rs
+++ b/skills/curve/src/commands/add_liquidity.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result};
 pub async fn run(
     chain_id: u64,
     pool_address: String,
-    amounts: Vec<u128>,
-    min_mint: u128,
+    amount_strs: Vec<String>,
+    min_mint_str: String,
     wallet: Option<String>,
     dry_run: bool,
 ) -> Result<()> {
@@ -25,22 +25,46 @@ pub async fn run(
         }
     };
 
-    // Fetch pool info to get coin list
+    // Fetch pool info to get coin list and decimals
     let pools = api::get_all_pools(chain_name).await?;
     let pool = api::find_pool_by_address(&pools, &pool_address);
 
     let n_coins = match pool {
         Some(p) => p.coins.len(),
-        None => amounts.len(), // fallback: infer from amounts length
+        None => amount_strs.len(), // fallback: infer from amounts length
     };
 
-    if amounts.len() != n_coins {
+    if amount_strs.len() != n_coins {
         anyhow::bail!(
             "Pool has {} coins but {} amounts were provided",
             n_coins,
-            amounts.len()
+            amount_strs.len()
         );
     }
+
+    // Parse human-readable amounts using per-coin decimals
+    let amounts: Vec<u128> = if let Some(p) = pool {
+        let mut parsed = Vec::with_capacity(n_coins);
+        for (i, s) in amount_strs.iter().enumerate() {
+            let coin_decimals: u8 = p
+                .coins
+                .get(i)
+                .and_then(|c| c.decimals.as_deref())
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(18);
+            parsed.push(rpc::parse_human_amount(s, coin_decimals)?);
+        }
+        parsed
+    } else {
+        // No pool info — assume 18 decimals for all coins
+        amount_strs
+            .iter()
+            .map(|s| rpc::parse_human_amount(s, 18))
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    // Parse min_mint as LP tokens (always 18 decimals)
+    let min_mint = rpc::parse_human_amount(&min_mint_str, 18)?;
 
     // Build add_liquidity calldata based on coin count
     let calldata = match n_coins {

--- a/skills/curve/src/commands/remove_liquidity.rs
+++ b/skills/curve/src/commands/remove_liquidity.rs
@@ -5,9 +5,9 @@ use anyhow::Result;
 pub async fn run(
     chain_id: u64,
     pool_address: String,
-    lp_amount: Option<u128>,   // None means "all"
-    coin_index: Option<i64>,   // None = proportional, Some(i) = single-coin
-    min_amounts: Vec<u128>,    // min amounts for proportional; single value for one-coin
+    lp_amount_str: Option<String>, // None means "all"; human-readable LP token amount (18 dec)
+    coin_index: Option<i64>,       // None = proportional, Some(i) = single-coin
+    min_amount_strs: Vec<String>,  // human-readable min amounts per coin
     wallet: Option<String>,
     dry_run: bool,
 ) -> Result<()> {
@@ -37,9 +37,15 @@ pub async fn run(
         .filter(|s| !s.is_empty())
         .unwrap_or(&pool_address);
 
+    // Parse human-readable lp_amount if provided (LP tokens are always 18 decimals)
+    let parsed_lp_amount: Option<u128> = match &lp_amount_str {
+        Some(s) => Some(rpc::parse_human_amount(s, 18)?),
+        None => None,
+    };
+
     // Get LP balance
     let lp_balance = if dry_run {
-        lp_amount.unwrap_or(1_000_000_000_000_000_000u128) // 1e18 placeholder
+        parsed_lp_amount.unwrap_or(1_000_000_000_000_000_000u128) // 1e18 placeholder
     } else {
         let bal = rpc::balance_of(lp_token_addr, &wallet_addr, rpc_url).await?;
         if bal == 0 {
@@ -48,8 +54,28 @@ pub async fn run(
         bal
     };
 
-    let actual_lp_amount = lp_amount.unwrap_or(lp_balance);
+    let actual_lp_amount = parsed_lp_amount.unwrap_or(lp_balance);
     let n_coins = pool.map(|p| p.coins.len()).unwrap_or(2);
+
+    // Parse human-readable min_amounts using per-coin decimals
+    let min_amounts: Vec<u128> = if let Some(p) = pool {
+        let mut parsed = Vec::new();
+        for (i, s) in min_amount_strs.iter().enumerate() {
+            let coin_decimals: u8 = p
+                .coins
+                .get(i)
+                .and_then(|c| c.decimals.as_deref())
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(18);
+            parsed.push(rpc::parse_human_amount(s, coin_decimals)?);
+        }
+        parsed
+    } else {
+        min_amount_strs
+            .iter()
+            .map(|s| rpc::parse_human_amount(s, 18))
+            .collect::<Result<Vec<_>>>()?
+    };
 
     // Build calldata
     let calldata = if let Some(idx) = coin_index {

--- a/skills/curve/src/main.rs
+++ b/skills/curve/src/main.rs
@@ -98,13 +98,13 @@ enum Commands {
         #[arg(long)]
         pool: String,
 
-        /// Comma-separated token amounts in minimal units (e.g. "1000000,1000000" for 2-coin pool)
+        /// Comma-separated token amounts in human-readable units matching pool coin order (e.g. "0,500.0,500.0" for 3pool: DAI,USDC,USDT)
         #[arg(long)]
         amounts: String,
 
-        /// Minimum LP tokens to mint (default: 0)
+        /// Minimum LP tokens to accept in human-readable units (default: 0)
         #[arg(long, default_value = "0")]
-        min_mint: u128,
+        min_mint: String,
 
         /// Sender wallet address (default: onchainos active wallet)
         #[arg(long)]
@@ -117,15 +117,15 @@ enum Commands {
         #[arg(long)]
         pool: String,
 
-        /// LP token amount to redeem in minimal units (default: full balance)
+        /// LP token amount to redeem in human-readable units (default: full balance)
         #[arg(long)]
-        lp_amount: Option<u128>,
+        lp_amount: Option<String>,
 
         /// Coin index for single-coin withdrawal (omit for proportional)
         #[arg(long, allow_hyphen_values = true)]
         coin_index: Option<i64>,
 
-        /// Comma-separated minimum output amounts (default: "0" or "0,0" etc.)
+        /// Comma-separated minimum output amounts in human-readable units (default: "0" or "0,0" etc.)
         #[arg(long, default_value = "0")]
         min_amounts: String,
 
@@ -175,11 +175,11 @@ async fn main() {
             min_mint,
             wallet,
         } => {
-            let parsed_amounts: Vec<u128> = amounts
+            let amount_strs: Vec<String> = amounts
                 .split(',')
-                .filter_map(|s| s.trim().parse().ok())
+                .map(|s| s.trim().to_string())
                 .collect();
-            commands::add_liquidity::run(chain_id, pool, parsed_amounts, min_mint, wallet, dry_run)
+            commands::add_liquidity::run(chain_id, pool, amount_strs, min_mint, wallet, dry_run)
                 .await
         }
         Commands::RemoveLiquidity {
@@ -189,16 +189,16 @@ async fn main() {
             min_amounts,
             wallet,
         } => {
-            let parsed_mins: Vec<u128> = min_amounts
+            let min_amount_strs: Vec<String> = min_amounts
                 .split(',')
-                .filter_map(|s| s.trim().parse().ok())
+                .map(|s| s.trim().to_string())
                 .collect();
             commands::remove_liquidity::run(
                 chain_id,
                 pool,
                 lp_amount,
                 coin_index,
-                parsed_mins,
+                min_amount_strs,
                 wallet,
                 dry_run,
             )

--- a/skills/curve/src/rpc.rs
+++ b/skills/curve/src/rpc.rs
@@ -1,5 +1,48 @@
 // rpc.rs — Direct eth_call utilities (no onchainos)
 
+/// Parse a human-readable decimal amount string into minimal units (u128).
+///
+/// Examples (decimals=6):
+///   "1.0"  → 1_000_000
+///   "0.5"  → 500_000
+///   "1000" → 1_000_000_000_000
+pub fn parse_human_amount(amount_str: &str, decimals: u8) -> anyhow::Result<u128> {
+    let s = amount_str.trim();
+    let factor = 10u128.pow(decimals as u32);
+    if let Some(dot_pos) = s.find('.') {
+        let int_part: u128 = if dot_pos == 0 {
+            0
+        } else {
+            s[..dot_pos]
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?
+        };
+        let frac_str = &s[dot_pos + 1..];
+        if frac_str.len() > decimals as usize {
+            anyhow::bail!(
+                "Amount '{}' has {} decimal places but token only supports {}",
+                s,
+                frac_str.len(),
+                decimals
+            );
+        }
+        let frac: u128 = if frac_str.is_empty() {
+            0
+        } else {
+            frac_str
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?
+        };
+        let frac_factor = 10u128.pow(decimals as u32 - frac_str.len() as u32);
+        Ok(int_part * factor + frac * frac_factor)
+    } else {
+        let int_val: u128 = s
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?;
+        Ok(int_val * factor)
+    }
+}
+
 /// Perform a raw JSON-RPC eth_call
 pub async fn eth_call(to: &str, data: &str, rpc_url: &str) -> anyhow::Result<String> {
     let client = reqwest::Client::new();


### PR DESCRIPTION
## Summary

- **Bug**: `add-liquidity --amounts` and `remove-liquidity --lp-amount` / `--min-amounts` accepted only raw `u128` integer minimal-unit values (e.g. `500000000` for 500 USDC). Passing human-readable decimals like `0.5` caused clap to reject the input or silently produce wrong amounts.
- **Fix**: All amount parameters now accept human-readable decimal strings; decimals are resolved per-coin from Curve pool data (or 18 for LP tokens).
- `quote` and `swap --amount` were already `f64` and are unchanged.

## Changes

| File | Change |
|------|--------|
| `src/rpc.rs` | Add `parse_human_amount(s, decimals) -> u128` helper |
| `src/main.rs` | `AddLiquidity.min_mint: u128 → String`; `RemoveLiquidity.lp_amount: Option<u128> → Option<String>`; `min_amounts` split strings passed through without pre-parsing |
| `src/commands/add_liquidity.rs` | Parse `amount_strs` per-coin with pool decimals; parse `min_mint` as 18-dec LP tokens |
| `src/commands/remove_liquidity.rs` | Parse `lp_amount_str` as 18-dec LP tokens; parse `min_amount_strs` per-coin with pool decimals |
| `SKILL.md` | Update examples (`"0,500000000,500000000"` → `"0,500.0,500.0"`); version-compare install guard; bump 0.2.2 → 0.2.3; add troubleshooting entries |
| `plugin.yaml` | Add install-report URLs to `api_calls` (resolves lint E141 → W141); bump version |
| `Cargo.toml` / `plugin.json` | Version bump 0.2.2 → 0.2.3 |

## Test plan

- [ ] `cargo build --release` succeeds with no new errors
- [ ] `plugin-store lint .` passes with 0 errors (3 pre-existing warnings, same as compound-v3 baseline)
- [ ] `curve --chain 1 add-liquidity --pool 0xbebc... --amounts "0,500.0,500.0" --dry-run` outputs correct `amounts_raw` (500000000 for USDC/USDT at 6 dec)
- [ ] `curve --chain 1 add-liquidity --pool 0xbebc... --amounts "0,500000000,500000000" --dry-run` still works (integer strings parse as whole-unit multiples)
- [ ] `curve --chain 1 remove-liquidity --pool 0x... --lp-amount 1.5 --dry-run` correctly sets `lp_amount_raw = 1500000000000000000`
- [ ] `curve --chain 1 remove-liquidity --pool 0x... --min-amounts "0.5,0.5" --dry-run` resolves per-coin decimals

🤖 Generated with [Claude Code](https://claude.com/claude-code)