### PR TITLE
docs(pendle): agent guidance — RPC propagation delay after broadcast

### DIFF
--- a/skills/pendle/SKILL.md
+++ b/skills/pendle/SKILL.md
@@ -141,22 +141,24 @@ onchainos wallet status
 5. Execute only after explicit user approval — run the command **without** `--dry-run`
 6. Report approve tx hash(es) (if any), main tx hash, and outcome
 
-### Fallback: if the binary's main tx fails or `tx_hash` is `"pending"`
+> **RPC propagation delay**: The plugin returns as soon as the transaction is broadcast (txHash received). On-chain state (positions, balances) may not reflect the change immediately — Arbitrum RPC nodes typically lag 5–30 seconds after broadcast. If `get-positions` or a balance check immediately after a write op still shows the old value, **do not treat this as a failure** — wait 15–30 seconds and re-query before concluding the transaction didn't land.
 
-The binary handles approvals and the main transaction internally. If the main transaction fails (binary returns an error, or `tx_hash` is `"pending"`/empty), use the `calldata` and `router` fields from the binary output to execute manually:
+### Fallback: if the binary returns an error
+
+The binary handles approvals and the main transaction internally. If the command exits with an error, use the `calldata` and `router` fields from a `--dry-run` output to execute manually:
 
 ```bash
 # 1. Get calldata via dry-run (includes router + calldata + requiredApprovals)
 pendle --chain <CHAIN_ID> <command> ... --dry-run
 
 # 2. Handle approvals from requiredApprovals (if any)
-onchainos wallet contract-call --chain <CHAIN_ID> --to <TOKEN_ADDR> --input-data <APPROVE_CALLDATA>
+onchainos wallet contract-call --chain <CHAIN_ID> --to <TOKEN_ADDR> --input-data <APPROVE_CALLDATA> --force
 
 # 3. Execute main transaction using calldata from dry-run output
-onchainos wallet contract-call --chain <CHAIN_ID> --to <router> --input-data <calldata>
+onchainos wallet contract-call --chain <CHAIN_ID> --to <router> --input-data <calldata> --force
 ```
 
-All write commands (`buy-pt`, `sell-pt`, `buy-yt`, `sell-yt`, `add-liquidity`, `remove-liquidity`, `mint-py`, `redeem-py`) include `router` and `calldata` in their output for this purpose.
+All write commands include `router` and `calldata` in their output for this purpose.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Docs-only fix**: no source code or version changes
- Adds a note to the Execution Flow section warning agents that on-chain state (positions, balances) may lag 5–30 seconds after a transaction is broadcast on Arbitrum, and that an unchanged position immediately after a write op should not be treated as a failure
- Removes stale reference to `tx_hash` being `"pending"` in the fallback section — that was the old broken behaviour (v0.2.0); `extract_tx_hash` now bails with an error if txHash is absent

## Background

Observed in live testing: `sell-pt` broadcast successfully (txHash received), but an immediate `get-positions` call showed the old position because the Arbitrum RPC node hadn't indexed the new block yet. The agent reported "not successfully sold". Four minutes later the position closed and USDC balance confirmed the sale. The transaction was correct; the agent's position-check timing was not.

## Changes

`skills/pendle/SKILL.md` — Execution Flow for Write Operations:
- Added RPC propagation delay callout after step 6
- Renamed fallback section from "if tx_hash is pending" to "if the binary returns an error"
- Added `--force` to the manual fallback `onchainos wallet contract-call` examples (required for broadcast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)