### PR TITLE
feat(hyperliquid): add leverage command, slippage/post-only params, fix tick-size rounding (v0.2.2)

### DIFF
--- a/skills/hyperliquid/.claude-plugin/plugin.json
+++ b/skills/hyperliquid/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperliquid",
   "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/hyperliquid/Cargo.lock
+++ b/skills/hyperliquid/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "hyperliquid"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/hyperliquid/Cargo.toml
+++ b/skills/hyperliquid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperliquid"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/hyperliquid/SKILL.md
+++ b/skills/hyperliquid/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyperliquid
 description: Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).
-version: 0.2.1
+version: 0.2.2
 author: GeoGu360
 tags:
   - perps
@@ -50,7 +50,7 @@ if ! command -v hyperliquid >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid@0.2.1/hyperliquid-${TARGET}${EXT}" -o ~/.local/bin/hyperliquid${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid@0.2.2/hyperliquid-${TARGET}${EXT}" -o ~/.local/bin/hyperliquid${EXT}
   chmod +x ~/.local/bin/hyperliquid${EXT}
 fi
 ```
@@ -72,7 +72,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"hyperliquid","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"hyperliquid","version":"0.2.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -220,7 +220,46 @@ hyperliquid positions --show-orders
 
 ---
 
-### 2. `prices` — Get Market Mid Prices
+### 2. `orders` — List Open Orders
+
+Lists all open perpetual orders (limit, TP/SL, stop-loss). Optionally filter by coin.
+
+**Read-only — no signing required.**
+
+```bash
+# List all open orders
+hyperliquid orders
+
+# Filter by coin
+hyperliquid orders --coin BTC
+hyperliquid orders --coin ETH
+```
+
+**Output:**
+```json
+{
+  "ok": true,
+  "count": 2,
+  "orders": [
+    {
+      "coin": "BTC",
+      "side": "sell",
+      "orderType": "Stop Market",
+      "origSz": "0.00016",
+      "limitPx": "58245",
+      "triggerPx": "58245",
+      "tpsl": "sl",
+      "oid": 91490942
+    }
+  ]
+}
+```
+
+**Display:** `coin`, `side`, `orderType`, `origSz`, `limitPx`, `triggerPx`, `tpsl`, `oid`. Use `oid` with `cancel --order-id` to remove an order.
+
+---
+
+### 3. `prices` — Get Market Mid Prices
 
 Returns current mid prices for all Hyperliquid perpetual markets, or a specific coin.
 
@@ -263,7 +302,7 @@ hyperliquid prices --market SOL
 
 ---
 
-### 3. `order` — Place Perpetual Order
+### 5. `order` — Place Perpetual Order
 
 Places a market or limit perpetual order. Optionally attach a **stop-loss and/or take-profit bracket** in one shot (OCO). **Requires `--confirm` to execute.**
 
@@ -288,7 +327,33 @@ hyperliquid order \
   --coin BTC --side buy --size 0.01 --type limit --price 100000 \
   --sl-px 95000 \
   --confirm
+
+# Limit order with post-only (maker rebate, cancelled if it would cross spread)
+hyperliquid order --coin ETH --side buy --size 0.1 --type limit --price 3000 --post-only --confirm
+
+# Market order with custom slippage tolerance (1% instead of default 5%)
+hyperliquid order --coin BTC --side buy --size 0.001 --slippage 1.0 --confirm
+
+# Reduce-only order (close existing position, never increase it)
+hyperliquid order --coin BTC --side sell --size 0.001 --reduce-only --confirm
 ```
+
+**Parameters:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--coin` | — | Coin symbol |
+| `--side` | — | `buy` or `sell` |
+| `--size` | — | Size in base units |
+| `--type` | `market` | `market` or `limit` |
+| `--price` | — | Required for limit orders |
+| `--sl-px` | — | Stop-loss trigger price (attaches bracket) |
+| `--tp-px` | — | Take-profit trigger price (attaches bracket) |
+| `--slippage` | `5.0` | Market order slippage tolerance in % |
+| `--post-only` | off | ALO TIF — cancelled instead of crossing spread (limit only) |
+| `--reduce-only` | off | Never increase position, only reduce |
+| `--dry-run` | off | Show payload without signing |
+| `--confirm` | off | Sign and submit |
 
 **Output (executed with bracket):**
 ```json
@@ -314,7 +379,7 @@ hyperliquid order \
 
 ---
 
-### 4. `close` — Market-Close an Open Position
+### 6. `close` — Market-Close an Open Position
 
 One-command market close. Automatically reads your current position direction and size. **Requires `--confirm` to execute.**
 
@@ -327,7 +392,20 @@ hyperliquid close --coin BTC --confirm
 
 # Close only half the position
 hyperliquid close --coin BTC --size 0.005 --confirm
+
+# Close with tighter slippage tolerance (1% instead of default 5%)
+hyperliquid close --coin BTC --slippage 1.0 --confirm
 ```
+
+**Parameters:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--coin` | — | Coin to close |
+| `--size` | full | Partial close size in base units |
+| `--slippage` | `5.0` | Market order slippage tolerance in % |
+| `--dry-run` | off | Show payload without signing |
+| `--confirm` | off | Sign and submit |
 
 **Output:**
 ```json
@@ -345,7 +423,7 @@ hyperliquid close --coin BTC --size 0.005 --confirm
 
 ---
 
-### 5. `tpsl` — Set Stop-Loss / Take-Profit on Existing Position
+### 7. `tpsl` — Set Stop-Loss / Take-Profit on Existing Position
 
 Place TP/SL on an already-open position. Auto-detects position size and direction. **Requires `--confirm` to execute.**
 
@@ -390,7 +468,7 @@ hyperliquid tpsl --coin BTC --tp-px 110000 --size 0.005 --confirm
 
 ---
 
-### 6. `cancel` — Cancel Open Order
+### 8. `cancel` — Cancel Open Order
 
 Cancels an open perpetual order by order ID. **Requires `--confirm` to execute.**
 
@@ -446,7 +524,7 @@ hyperliquid cancel \
 
 ---
 
-### 7. `deposit` — Deposit USDC from Arbitrum to Hyperliquid
+### 9. `deposit` — Deposit USDC from Arbitrum to Hyperliquid
 
 Deposits USDC from your Arbitrum wallet into your Hyperliquid account via the official bridge contract.
 
@@ -491,7 +569,7 @@ hyperliquid deposit --amount 100 --dry-run
 
 ---
 
-### 8. `register` — Detect onchainos Signing Address
+### 10. `register` — Detect onchainos Signing Address
 
 Discovers your actual Hyperliquid signing address (the EOA key onchainos uses to sign EIP-712 actions) and provides setup instructions. **Run this once before placing your first order.**
 
@@ -546,6 +624,49 @@ hyperliquid register --dry-run
 </external-content>
 
 **Display:** `status`, `hl_signing_address` (if setup_required), and the recommended next step from `options.option_1_recommended.command`.
+
+---
+
+### 11. `leverage` — Set Leverage for a Coin
+
+Sets cross or isolated margin leverage for a coin. Account-level setting per asset — applies to all future orders for that coin. **Requires `--confirm` to execute.**
+
+```bash
+# Preview: set BTC to 5x cross margin
+hyperliquid leverage --coin BTC --leverage 5 --mode cross
+
+# Execute: set ETH to 10x isolated margin
+hyperliquid leverage --coin ETH --leverage 10 --mode isolated --confirm
+
+# Dry run: inspect payload without signing
+hyperliquid leverage --coin SOL --leverage 3 --mode cross --dry-run
+```
+
+**Parameters:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--coin` | Yes | Coin symbol (e.g. BTC, ETH, SOL) |
+| `--leverage` | Yes | Integer multiplier 1–50 |
+| `--mode` | Yes | `cross` or `isolated` |
+| `--confirm` | No | Sign and submit (default: preview only) |
+| `--dry-run` | No | Show payload without signing or submitting |
+
+**Output:**
+```json
+{
+  "ok": true,
+  "action": "leverage",
+  "coin": "BTC",
+  "leverage": 5,
+  "mode": "cross",
+  "result": { ... }
+}
+```
+
+**Display:** `coin`, `leverage`, `mode`, `result` status.
+
+**Note:** Leverage applies globally to the coin — it affects open positions and new orders.
 
 ---
 
@@ -618,7 +739,7 @@ Use `hyperliquid prices` to get a full list of available markets.
 - All on-chain write operations require **explicit user confirmation** via `--confirm`
 - Never share your private key or seed phrase
 - All signing is routed through `onchainos` (TEE-sandboxed)
-- This plugin does **not** support isolated margin configuration — use the Hyperliquid web UI for advanced margin settings
+- Use `hyperliquid leverage --mode isolated` to configure isolated margin, or `--mode cross` for cross margin
 
 ---
 

--- a/skills/hyperliquid/plugin.yaml
+++ b/skills/hyperliquid/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: hyperliquid
-version: "0.2.1"
+version: "0.2.2"
 description: "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC"
 author:
   name: GeoGu360

--- a/skills/hyperliquid/src/commands/close.rs
+++ b/skills/hyperliquid/src/commands/close.rs
@@ -14,6 +14,11 @@ pub struct CloseArgs {
     #[arg(long)]
     pub size: Option<String>,
 
+    /// Slippage tolerance in percent (default: 5.0).
+    /// E.g. --slippage 1.0 allows at most 1% worse than mid price.
+    #[arg(long, default_value = "5.0")]
+    pub slippage: f64,
+
     /// Dry run — show payload without signing or submitting
     #[arg(long)]
     pub dry_run: bool,
@@ -95,7 +100,7 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     let closing_side = if position_is_long { "sell" } else { "buy" };
     let close_is_buy = !position_is_long;
     let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
-    let slippage_px_str = market_slippage_px(mid_f, close_is_buy, sz_decimals);
+    let slippage_px_str = market_slippage_px(mid_f, close_is_buy, sz_decimals, args.slippage);
 
     let action = build_close_action(asset_idx, position_is_long, &close_size, &slippage_px_str);
 
@@ -111,6 +116,7 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
                 "currentMidPrice": current_price,
                 "type": "market",
                 "reduceOnly": true,
+                "slippagePct": args.slippage,
                 "nonce": nonce
             },
             "action": action

--- a/skills/hyperliquid/src/commands/leverage.rs
+++ b/skills/hyperliquid/src/commands/leverage.rs
@@ -1,0 +1,76 @@
+use clap::Args;
+use crate::api::get_asset_meta;
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
+use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
+use crate::signing::{build_update_leverage_action, submit_exchange_request};
+
+#[derive(Args)]
+pub struct LeverageArgs {
+    /// Coin to set leverage for (e.g. BTC, ETH, SOL)
+    #[arg(long)]
+    pub coin: String,
+
+    /// Leverage multiplier (e.g. 2 for 2x, 10 for 10x; max 50)
+    #[arg(long)]
+    pub leverage: u32,
+
+    /// Margin mode: cross or isolated [default: cross]
+    #[arg(long, value_parser = ["cross", "isolated"], default_value = "cross")]
+    pub mode: String,
+
+    /// Confirm and submit (without this flag, prints a preview)
+    #[arg(long)]
+    pub confirm: bool,
+}
+
+pub async fn run(args: LeverageArgs) -> anyhow::Result<()> {
+    if args.leverage < 1 || args.leverage > 50 {
+        anyhow::bail!("Leverage must be between 1 and 50 (got {})", args.leverage);
+    }
+
+    let info = info_url();
+    let exchange = exchange_url();
+    let coin = normalize_coin(&args.coin);
+    let is_cross = args.mode == "cross";
+    let nonce = now_ms();
+
+    let (asset_idx, _) = get_asset_meta(info, &coin).await?;
+
+    let action = build_update_leverage_action(asset_idx, is_cross, args.leverage);
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "preview": {
+                "coin": coin,
+                "assetIndex": asset_idx,
+                "leverage": args.leverage,
+                "mode": args.mode,
+                "isCross": is_cross
+            },
+            "action": action
+        }))?
+    );
+
+    if !args.confirm {
+        println!("\n[PREVIEW] Add --confirm to submit this leverage update.");
+        return Ok(());
+    }
+
+    let wallet = resolve_wallet(CHAIN_ID)?;
+    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
+    let result = submit_exchange_request(exchange, signed).await?;
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "coin": coin,
+            "leverage": args.leverage,
+            "mode": args.mode,
+            "result": result
+        }))?
+    );
+
+    Ok(())
+}

--- a/skills/hyperliquid/src/commands/mod.rs
+++ b/skills/hyperliquid/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod cancel;
 pub mod close;
 pub mod deposit;
+pub mod leverage;
 pub mod order;
 pub mod orders;
 pub mod positions;

--- a/skills/hyperliquid/src/commands/order.rs
+++ b/skills/hyperliquid/src/commands/order.rs
@@ -4,7 +4,7 @@ use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, AR
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
 use crate::signing::{
     build_bracketed_order_action, build_limit_order_action, build_market_order_action,
-    format_px, market_slippage_px, submit_exchange_request,
+    format_px, market_slippage_px, round_px, submit_exchange_request,
 };
 
 #[derive(Args)]
@@ -41,6 +41,16 @@ pub struct OrderArgs {
     #[arg(long)]
     pub reduce_only: bool,
 
+    /// Post-only (limit orders only) — order is cancelled instead of crossing the spread;
+    /// ensures maker rebate. Uses Hyperliquid's ALO (Add Liquidity Only) TIF.
+    #[arg(long)]
+    pub post_only: bool,
+
+    /// Slippage tolerance in percent for market orders (default: 5.0).
+    /// E.g. --slippage 1.0 allows at most 1% worse than mid price.
+    #[arg(long, default_value = "5.0")]
+    pub slippage: f64,
+
     /// Dry run — preview order payload without signing or submitting
     #[arg(long)]
     pub dry_run: bool,
@@ -73,6 +83,15 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         }
     }
 
+    // --post-only only applies to limit orders
+    if args.post_only && args.r#type != "limit" {
+        anyhow::bail!("--post-only requires --type limit");
+    }
+
+    if args.slippage <= 0.0 || args.slippage > 100.0 {
+        anyhow::bail!("--slippage must be between 0 and 100 (got {})", args.slippage);
+    }
+
     let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
 
     let mids = get_all_mids(info).await?;
@@ -84,7 +103,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     // Slippage-protected price for market orders — 5% tolerance, rounded to HL's
     // sz_decimals significant figures (matches Python SDK round_to_sz_decimals).
     let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
-    let slippage_px_str = market_slippage_px(mid_f, is_buy, sz_decimals);
+    let slippage_px_str = market_slippage_px(mid_f, is_buy, sz_decimals, args.slippage);
 
     let has_bracket = args.sl_px.is_some() || args.tp_px.is_some();
 
@@ -107,20 +126,21 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                 let _: f64 = price_str
                     .parse()
                     .map_err(|_| anyhow::anyhow!("Invalid price '{}'", price_str))?;
+                let tif = if args.post_only { "Alo" } else { "Gtc" };
                 serde_json::json!({
                     "a": asset_idx,
                     "b": is_buy,
                     "p": price_str,
                     "s": args.size,
                     "r": args.reduce_only,
-                    "t": { "limit": { "tif": "Gtc" } }
+                    "t": { "limit": { "tif": tif } }
                 })
             }
             _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
         };
 
-        let sl_px_str = args.sl_px.map(format_px);
-        let tp_px_str = args.tp_px.map(format_px);
+        let sl_px_str = args.sl_px.map(|px| round_px(px, sz_decimals));
+        let tp_px_str = args.tp_px.map(|px| round_px(px, sz_decimals));
 
         build_bracketed_order_action(
             entry_element,
@@ -129,6 +149,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             &args.size,
             sl_px_str.as_deref(),
             tp_px_str.as_deref(),
+            sz_decimals,
         )
     } else {
         match args.r#type.as_str() {
@@ -141,7 +162,8 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                 let _: f64 = price_str
                     .parse()
                     .map_err(|_| anyhow::anyhow!("Invalid price '{}'", price_str))?;
-                build_limit_order_action(asset_idx, is_buy, price_str, &args.size, args.reduce_only)
+                let tif = if args.post_only { "Alo" } else { "Gtc" };
+                build_limit_order_action(asset_idx, is_buy, price_str, &args.size, args.reduce_only, tif)
             }
             _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
         }
@@ -157,11 +179,13 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                 "size": args.size,
                 "type": args.r#type,
                 "price": args.price,
-                "stopLoss": args.sl_px.map(format_px),
-                "takeProfit": args.tp_px.map(format_px),
+                "stopLoss": args.sl_px.map(|px| round_px(px, sz_decimals)),
+                "takeProfit": args.tp_px.map(|px| round_px(px, sz_decimals)),
                 "reduceOnly": args.reduce_only,
                 "currentMidPrice": current_price,
                 "grouping": if has_bracket { "normalTpsl" } else { "na" },
+                "slippagePct": args.slippage,
+                "postOnly": args.post_only,
                 "nonce": nonce
             },
             "action": action
@@ -192,8 +216,8 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             "side": args.side,
             "size": args.size,
             "type": args.r#type,
-            "stopLoss": args.sl_px.map(format_px),
-            "takeProfit": args.tp_px.map(format_px),
+            "stopLoss": args.sl_px.map(|px| round_px(px, sz_decimals)),
+            "takeProfit": args.tp_px.map(|px| round_px(px, sz_decimals)),
             "result": result
         }))?
     );

--- a/skills/hyperliquid/src/commands/tpsl.rs
+++ b/skills/hyperliquid/src/commands/tpsl.rs
@@ -1,8 +1,8 @@
 use clap::Args;
-use crate::api::{get_asset_index, get_all_mids, get_clearinghouse_state};
+use crate::api::{get_asset_meta, get_all_mids, get_clearinghouse_state};
 use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
-use crate::signing::{build_standalone_tpsl_action, format_px, submit_exchange_request};
+use crate::signing::{build_standalone_tpsl_action, round_px, submit_exchange_request};
 
 #[derive(Args)]
 pub struct TpslArgs {
@@ -41,7 +41,7 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
     let coin = normalize_coin(&args.coin);
     let nonce = now_ms();
 
-    let asset_idx = get_asset_index(info, &coin).await?;
+    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
     let wallet = resolve_wallet(CHAIN_ID)?;
 
     // Auto-detect position direction and size
@@ -138,8 +138,8 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         None => format!("{}", position_size),
     };
 
-    let sl_px_str = args.sl_px.map(format_px);
-    let tp_px_str = args.tp_px.map(format_px);
+    let sl_px_str = args.sl_px.map(|px| round_px(px, sz_decimals));
+    let tp_px_str = args.tp_px.map(|px| round_px(px, sz_decimals));
 
     let action = build_standalone_tpsl_action(
         asset_idx,
@@ -147,18 +147,19 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         &size_str,
         sl_px_str.as_deref(),
         tp_px_str.as_deref(),
+        sz_decimals,
     );
 
     // Compute implied slippage limit prices for display
     let sl_limit_display = args.sl_px.map(|px| {
         let closing_is_buy = !position_is_long;
         let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        format_px(limit)
+        round_px(limit, sz_decimals)
     });
     let tp_limit_display = args.tp_px.map(|px| {
         let closing_is_buy = !position_is_long;
         let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        format_px(limit)
+        round_px(limit, sz_decimals)
     });
 
     println!(
@@ -173,12 +174,12 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
                 "currentMidPrice": current_price_str,
                 "liquidationPrice": liquidation_px_str,
                 "stopLoss": args.sl_px.map(|px| serde_json::json!({
-                    "triggerPx": format_px(px),
+                    "triggerPx": round_px(px, sz_decimals),
                     "executionType": "market",
                     "worstFillPx": sl_limit_display
                 })),
                 "takeProfit": args.tp_px.map(|px| serde_json::json!({
-                    "triggerPx": format_px(px),
+                    "triggerPx": round_px(px, sz_decimals),
                     "executionType": "market",
                     "worstFillPx": tp_limit_display
                 })),

--- a/skills/hyperliquid/src/main.rs
+++ b/skills/hyperliquid/src/main.rs
@@ -10,6 +10,7 @@ use commands::{
     cancel::CancelArgs,
     close::CloseArgs,
     deposit::DepositArgs,
+    leverage::LeverageArgs,
     order::OrderArgs,
     orders::OrdersArgs,
     positions::PositionsArgs,
@@ -37,6 +38,8 @@ enum Commands {
     Orders(OrdersArgs),
     /// Get current mid prices for all markets or a specific coin
     Prices(PricesArgs),
+    /// Set leverage for a coin (cross or isolated margin; requires --confirm)
+    Leverage(LeverageArgs),
     /// Place a market or limit order; optionally attach TP/SL bracket (requires --confirm)
     Order(OrderArgs),
     /// Market-close an open position in one command (requires --confirm)
@@ -58,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Positions(args) => commands::positions::run(args).await,
         Commands::Orders(args) => commands::orders::run(args).await,
         Commands::Prices(args) => commands::prices::run(args).await,
+        Commands::Leverage(args) => commands::leverage::run(args).await,
         Commands::Order(args) => commands::order::run(args).await,
         Commands::Close(args) => commands::close::run(args).await,
         Commands::Tpsl(args) => commands::tpsl::run(args).await,

--- a/skills/hyperliquid/src/signing.rs
+++ b/skills/hyperliquid/src/signing.rs
@@ -49,24 +49,27 @@ pub fn round_px(px: f64, sz_decimals: u32) -> String {
 }
 
 /// Compute slippage-protected price for a market order.
-/// is_buy=true → price * 1.05 (pay up to 5% above mid)
-/// is_buy=false → price * 0.95 (accept down to 5% below mid)
+/// slippage_pct: percentage tolerance (e.g. 5.0 = 5%).
+/// is_buy=true  → mid * (1 + slippage/100) — pay up to N% above mid
+/// is_buy=false → mid * (1 - slippage/100) — accept down to N% below mid
 /// Rounds to sz_decimals significant figures to match HL's validation.
-pub fn market_slippage_px(mid_px: f64, is_buy: bool, sz_decimals: u32) -> String {
-    let px = if is_buy { mid_px * 1.05 } else { mid_px * 0.95 };
+pub fn market_slippage_px(mid_px: f64, is_buy: bool, sz_decimals: u32, slippage_pct: f64) -> String {
+    let multiplier = if is_buy { 1.0 + slippage_pct / 100.0 } else { 1.0 - slippage_pct / 100.0 };
+    let px = mid_px * multiplier;
     round_px(px, sz_decimals)
 }
 
 /// Slippage-protected limit price for market trigger orders.
 /// When a trigger fires as "market", HL still needs a worst-acceptable-price.
 /// Convention: 10% slippage tolerance (same as HL web UI default).
-fn trigger_limit_px(trigger_px: f64, is_buy: bool) -> String {
+/// Must be rounded to sz_decimals significant figures to satisfy HL tick-size validation.
+fn trigger_limit_px(trigger_px: f64, is_buy: bool, sz_decimals: u32) -> String {
     let px = if is_buy {
         trigger_px * 1.1
     } else {
         trigger_px * 0.9
     };
-    format_px(px)
+    round_px(px, sz_decimals)
 }
 
 // ─── Entry orders ────────────────────────────────────────────────────────────
@@ -99,13 +102,15 @@ pub fn build_market_order_action(
     })
 }
 
-/// Build the order action payload for a limit order (GTC).
+/// Build the order action payload for a limit order.
+/// tif: "Gtc" (default), "Alo" (post-only / add-liquidity-only)
 pub fn build_limit_order_action(
     asset: usize,
     is_buy: bool,
     price_str: &str,
     size_str: &str,
     reduce_only: bool,
+    tif: &str,
 ) -> Value {
     json!({
         "type": "order",
@@ -117,7 +122,7 @@ pub fn build_limit_order_action(
             "r": reduce_only,
             "t": {
                 "limit": {
-                    "tif": "Gtc"
+                    "tif": tif
                 }
             }
         }],
@@ -169,6 +174,7 @@ pub fn build_trigger_order_element(
     trigger_px_str: &str,
     is_market: bool,
     limit_px_override: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let is_buy = !position_is_long; // close opposite of entry
 
@@ -176,7 +182,7 @@ pub fn build_trigger_order_element(
         Some(px) => px.to_string(),
         None if is_market => {
             let trigger_px: f64 = trigger_px_str.parse().unwrap_or(0.0);
-            trigger_limit_px(trigger_px, is_buy)
+            trigger_limit_px(trigger_px, is_buy, sz_decimals)
         }
         None => trigger_px_str.to_string(),
     };
@@ -206,17 +212,18 @@ pub fn build_standalone_tpsl_action(
     size_str: &str,
     sl_px: Option<&str>,
     tp_px: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let mut orders = vec![];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "sl", px, true, None,
+            asset, position_is_long, size_str, "sl", px, true, None, sz_decimals,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "tp", px, true, None,
+            asset, position_is_long, size_str, "tp", px, true, None, sz_decimals,
         ));
     }
 
@@ -237,18 +244,19 @@ pub fn build_bracketed_order_action(
     size_str: &str,
     sl_px: Option<&str>,
     tp_px: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let entry_is_long = position_is_long;
     let mut orders = vec![entry_order];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "sl", px, true, None,
+            asset, entry_is_long, size_str, "sl", px, true, None, sz_decimals,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "tp", px, true, None,
+            asset, entry_is_long, size_str, "tp", px, true, None, sz_decimals,
         ));
     }
 
@@ -256,6 +264,20 @@ pub fn build_bracketed_order_action(
         "type": "order",
         "orders": orders,
         "grouping": "normalTpsl"
+    })
+}
+
+// ─── Leverage ────────────────────────────────────────────────────────────────
+
+/// Build an updateLeverage action.
+/// is_cross=true → cross margin; false → isolated margin.
+/// leverage: integer multiplier (1–50).
+pub fn build_update_leverage_action(asset: usize, is_cross: bool, leverage: u32) -> serde_json::Value {
+    json!({
+        "type": "updateLeverage",
+        "asset": asset,
+        "isCross": is_cross,
+        "leverage": leverage
     })
 }
 


### PR DESCRIPTION
## Summary

- **New `leverage` command**: set cross or isolated margin leverage (1–50x) per coin with `--confirm` guard and preview
- **`order` command**: add `--slippage` (default 5%), `--post-only` (ALO TIF for maker rebate), `--reduce-only` flags
- **`close` command**: add `--slippage` (default 5%) flag
- **Tick-size rounding bugfix**: trigger prices and worst-fill limit prices now use `round_px(sz_decimals)` instead of `format_px`, fixing "Price must be divisible by tick size" rejection from the HL exchange API
- **`signing.rs`**: `market_slippage_px` gains `slippage_pct` param; `trigger_limit_px` uses `round_px`; `build_bracketed_order_action` / `build_standalone_tpsl_action` accept `sz_decimals`
- **SKILL.md**: add `orders` and `leverage` command documentation; document all new parameters; fix isolated margin note

## Test plan

- [x] `hyperliquid leverage --coin BTC --leverage 3 --mode cross --confirm` — verified on-chain (account now at 3x cross BTC)
- [x] `hyperliquid order --coin BTC --side buy --size 0.00016 --sl-px 58245 --tp-px 101930 --confirm` — filled on-chain with both TP/SL in `waitingForTrigger` state
- [x] `hyperliquid order` dry-run validates `--post-only` requires `--type limit`
- [x] `hyperliquid close --coin BTC --dry-run` — shows correct reduce-only IOC payload
- [x] `cargo build` passes at v0.2.2
- [x] `git diff upstream/main --name-only` shows only `skills/hyperliquid/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)