### PR TITLE
fix(pancakeswap-v2): v0.2.1 — human-readable --amount decimal input

### DIFF
--- a/skills/pancakeswap-v2/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v2",
   "description": "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": { "name": "skylavis-sky", "github": "skylavis-sky" },
   "license": "MIT"
 }

--- a/skills/pancakeswap-v2/.gitignore
+++ b/skills/pancakeswap-v2/.gitignore
@@ -1,1 +1,1 @@
-target/
+/target/

--- a/skills/pancakeswap-v2/Cargo.toml
+++ b/skills/pancakeswap-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v2"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v2/SKILL.md
+++ b/skills/pancakeswap-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v2
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
-version: "0.2.2"
+version: "0.2.3"
 author: "skylavis-sky"
 tags:
   - dex
@@ -36,7 +36,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install pancakeswap-v2 binary (auto-injected)
 
 ```bash
-if ! command -v pancakeswap-v2 >/dev/null 2>&1; then
+REQUIRED_VERSION="0.2.3"
+INSTALLED_VERSION=$(pancakeswap-v2 --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -50,9 +52,26 @@ if ! command -v pancakeswap-v2 >/dev/null 2>&1; then
     mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+    *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
   esac
+  BASE_URL="https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2@${REQUIRED_VERSION}"
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2@0.2.1/pancakeswap-v2-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap-v2${EXT}
+  curl -fsSL "${BASE_URL}/checksums.txt" -o /tmp/pancakeswap-v2-checksums.txt
+  curl -fsSL "${BASE_URL}/pancakeswap-v2-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap-v2${EXT}
+  EXPECTED=$(grep "pancakeswap-v2-${TARGET}${EXT}" /tmp/pancakeswap-v2-checksums.txt | awk '{print $1}')
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum ~/.local/bin/pancakeswap-v2${EXT} | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 ~/.local/bin/pancakeswap-v2${EXT} | awk '{print $1}')
+  else
+    echo "Warning: cannot verify checksum (no sha256sum or shasum found)" && ACTUAL="$EXPECTED"
+  fi
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Checksum mismatch for pancakeswap-v2-${TARGET}${EXT} — aborting install"
+    rm -f ~/.local/bin/pancakeswap-v2${EXT} /tmp/pancakeswap-v2-checksums.txt
+    exit 1
+  fi
+  rm -f /tmp/pancakeswap-v2-checksums.txt
   chmod +x ~/.local/bin/pancakeswap-v2${EXT}
 fi
 ```
@@ -71,7 +90,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v2","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v2","version":"0.2.3"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"pancakeswap-v2","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -145,7 +164,7 @@ Do NOT use for: PancakeSwap V3 swaps (use pancakeswap skill), concentrated liqui
 
 **Usage:**
 ```
-pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 100000000000000000000
+pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 100
 ```
 
 **Parameters:**
@@ -153,7 +172,7 @@ pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 100
 |------|------|-------------|
 | tokenIn | `--token-in` | Input token: symbol (USDT, CAKE, WBNB) or hex address |
 | tokenOut | `--token-out` | Output token: symbol or hex address |
-| amountIn | `--amount-in` | Input amount in minimal units (e.g. 100e18 = 100 tokens for 18-decimal token) |
+| amountIn | `--amount-in` | Input amount as a human-readable decimal (e.g. 100, 1.5, 0.001) |
 | chain | `--chain` | Chain ID: 56 (BSC, default), 8453 (Base), or 42161 (Arbitrum) |
 
 **Example output:**
@@ -185,7 +204,7 @@ Read-only operation — no confirmation required.
 
 **Usage:**
 ```
-pancakeswap-v2 --chain 56 swap --token-in USDT --token-out CAKE --amount-in 100000000000000000000
+pancakeswap-v2 --chain 56 swap --token-in USDT --token-out CAKE --amount-in 100
 ```
 
 **Parameters:**
@@ -193,7 +212,7 @@ pancakeswap-v2 --chain 56 swap --token-in USDT --token-out CAKE --amount-in 1000
 |------|------|-------------|
 | tokenIn | `--token-in` | Input token: symbol or address. Use BNB/ETH for native |
 | tokenOut | `--token-out` | Output token: symbol or address |
-| amountIn | `--amount-in` | Input amount in minimal units |
+| amountIn | `--amount-in` | Input amount as a human-readable decimal (e.g. 100, 1.5, 0.001) |
 | slippageBps | `--slippage-bps` | Slippage in basis points (default 50 = 0.5%) |
 | deadlineSecs | `--deadline-secs` | Seconds until deadline (default 300) |
 | dryRun | `--dry-run` | Preview calldata only, no broadcast |
@@ -230,10 +249,10 @@ pancakeswap-v2 --chain 56 swap --token-in USDT --token-out CAKE --amount-in 1000
 **Usage:**
 ```
 # Token + Token
-pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b USDT --amount-a 10000000000000000000 --amount-b 50000000000000000000
+pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b USDT --amount-a 10 --amount-b 50
 
 # Token + native BNB
-pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b BNB --amount-a 10000000000000000000 --amount-b 50000000000000000
+pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b BNB --amount-a 10 --amount-b 0.05
 ```
 
 **Parameters:**
@@ -241,8 +260,8 @@ pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b BNB --amount-a 
 |------|------|-------------|
 | tokenA | `--token-a` | First token: symbol or address. Use BNB/ETH for native |
 | tokenB | `--token-b` | Second token. Use BNB/ETH for native |
-| amountA | `--amount-a` | Desired amount of tokenA in minimal units |
-| amountB | `--amount-b` | Desired amount of tokenB (or native BNB/ETH) in minimal units |
+| amountA | `--amount-a` | Desired amount of tokenA as a human-readable decimal (e.g. 10, 0.5) |
+| amountB | `--amount-b` | Desired amount of tokenB (or native BNB/ETH) as a human-readable decimal |
 | slippageBps | `--slippage-bps` | Slippage tolerance (default 50 = 0.5%) |
 | dryRun | `--dry-run` | Preview calldata only |
 
@@ -266,7 +285,7 @@ pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b BNB --amount-a 
 pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT
 
 # Remove specific amount
-pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liquidity 1000000000000000000
+pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liquidity 1.0
 ```
 
 **Parameters:**
@@ -274,7 +293,7 @@ pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liqui
 |------|------|-------------|
 | tokenA | `--token-a` | First token |
 | tokenB | `--token-b` | Second token. Use BNB/ETH to receive native |
-| liquidity | `--liquidity` | LP tokens to burn (minimal units). Omit to remove all |
+| liquidity | `--liquidity` | LP tokens to burn as a human-readable decimal (e.g. 1.0). Omit to remove all |
 | slippageBps | `--slippage-bps` | Slippage tolerance (default 50 = 0.5%) |
 | dryRun | `--dry-run` | Preview only |
 
@@ -359,6 +378,17 @@ For Arbitrum One (42161): WETH `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`, USD
 ---
 
 ## Changelog
+
+### v0.2.3 (2026-04-11)
+
+- **fix**: `--amount-in`, `--amount-a`, `--amount-b`, and `--liquidity` now accept human-readable decimal input (e.g. `1.5`, `100`, `0.001`). Previously clap rejected decimal values at parse time with "invalid digit found in string" because those args were typed `u128`. Changed to `String` and added `parse_human_amount()` which resolves each token's ERC-20 `decimals()` on-chain and converts to raw units.
+- **feat**: `pancakeswap-v2 --version` now works (added `version` to `#[command(...)]` attribute)
+- **fix**: `.gitignore` uses `/target/` (anchored) instead of `target/`
+
+### v0.2.2 (2026-04-11)
+
+- **fix**: `remove-liquidity` overflow protection upgraded from pure f64 to `safe_mul_div` — tries `checked_mul` first (exact integer arithmetic for small pools), falls back to f64 only when `reserve × lp_balance` would overflow u128 (e.g. BSC BNB/USDT ~$17M TVL). Behavior is identical for all affected pools; change improves precision for pools below the overflow threshold.
+- **fix**: Exact-amount ERC-20 approvals (not unlimited) — approves the exact swap/LP amount rather than `uint256.max`
 
 ### v0.2.1 (2026-04-11)
 

--- a/skills/pancakeswap-v2/plugin.yaml
+++ b/skills/pancakeswap-v2/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v2
-version: "0.2.2"
+version: "0.2.3"
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
 author:
   name: skylavis-sky

--- a/skills/pancakeswap-v2/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2/src/commands/add_liquidity.rs
@@ -11,8 +11,8 @@ pub struct AddLiquidityArgs {
     pub chain_id: u64,
     pub token_a: String,
     pub token_b: String,
-    pub amount_a: u128,          // desired amount of token_a (minimal units)
-    pub amount_b: u128,          // desired amount of token_b or ETH (minimal units)
+    pub amount_a: String,        // human-readable decimal, e.g. "10" or "0.5"
+    pub amount_b: String,        // human-readable decimal
     pub slippage_bps: u64,
     pub deadline_secs: u64,
     pub from: Option<String>,
@@ -29,9 +29,6 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
 
     if native_a && native_b {
         anyhow::bail!("Cannot add liquidity with two native tokens.");
-    }
-    if args.amount_a == 0 && args.amount_b == 0 {
-        anyhow::bail!("Both amounts are zero — provide at least one non-zero amount.");
     }
 
     // Resolve wallet
@@ -53,14 +50,25 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
             .as_secs()
     ) + args.deadline_secs;
 
+    // Resolve token decimals and parse human-readable amounts
+    let token_a_for_dec = if native_a { cfg.weth.to_string() } else { resolve_token_address(&args.token_a, args.chain_id) };
+    let token_b_for_dec = if native_b { cfg.weth.to_string() } else { resolve_token_address(&args.token_b, args.chain_id) };
+    let decimals_a = rpc::get_erc20_decimals(&token_a_for_dec, rpc).await.unwrap_or(18);
+    let decimals_b = rpc::get_erc20_decimals(&token_b_for_dec, rpc).await.unwrap_or(18);
+    let amount_a = rpc::parse_human_amount(&args.amount_a, decimals_a)?;
+    let amount_b = rpc::parse_human_amount(&args.amount_b, decimals_b)?;
+    if amount_a == 0 && amount_b == 0 {
+        anyhow::bail!("Both amounts are zero — provide at least one non-zero amount.");
+    }
+
     let mut steps = vec![];
 
     if native_a || native_b {
         // addLiquidityETH variant
         let (token_sym, token_amount, eth_amount) = if native_b {
-            (&args.token_a, args.amount_a, args.amount_b)
+            (&args.token_a, amount_a, amount_b)
         } else {
-            (&args.token_b, args.amount_b, args.amount_a)
+            (&args.token_b, amount_b, amount_a)
         };
         let token_addr = resolve_token_address(token_sym, args.chain_id);
         let token_min = token_amount * (10000 - args.slippage_bps) as u128 / 10000;
@@ -80,7 +88,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         let calldata = build_add_liquidity_eth(&token_addr, token_amount, token_min, eth_min, &wallet, deadline);
         let result = onchainos::wallet_contract_call(
             args.chain_id, cfg.router02, &calldata,
-            args.from.as_deref(), Some(eth_amount as u128), args.dry_run,
+            args.from.as_deref(), Some(eth_amount), args.dry_run,
         ).await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
         if !args.dry_run {
@@ -95,14 +103,14 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         // addLiquidity variant (token + token)
         let token_a_addr = resolve_token_address(&args.token_a, args.chain_id);
         let token_b_addr = resolve_token_address(&args.token_b, args.chain_id);
-        let amount_a_min = args.amount_a * (10000 - args.slippage_bps) as u128 / 10000;
-        let amount_b_min = args.amount_b * (10000 - args.slippage_bps) as u128 / 10000;
+        let amount_a_min = amount_a * (10000 - args.slippage_bps) as u128 / 10000;
+        let amount_b_min = amount_b * (10000 - args.slippage_bps) as u128 / 10000;
 
         // Approve tokenA if needed
         let allow_a = rpc::erc20_allowance(&token_a_addr, &wallet, cfg.router02, rpc).await.unwrap_or(0);
-        if allow_a < args.amount_a {
+        if allow_a < amount_a {
             let r = erc20_approve(
-                args.chain_id, &token_a_addr, cfg.router02, args.amount_a,
+                args.chain_id, &token_a_addr, cfg.router02, amount_a,
                 args.from.as_deref(), args.dry_run,
             ).await?;
             steps.push(json!({"step":"approve_tokenA","txHash": onchainos::extract_tx_hash(&r)}));
@@ -111,9 +119,9 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
 
         // Approve tokenB if needed
         let allow_b = rpc::erc20_allowance(&token_b_addr, &wallet, cfg.router02, rpc).await.unwrap_or(0);
-        if allow_b < args.amount_b {
+        if allow_b < amount_b {
             let r = erc20_approve(
-                args.chain_id, &token_b_addr, cfg.router02, args.amount_b,
+                args.chain_id, &token_b_addr, cfg.router02, amount_b,
                 args.from.as_deref(), args.dry_run,
             ).await?;
             steps.push(json!({"step":"approve_tokenB","txHash": onchainos::extract_tx_hash(&r)}));
@@ -122,7 +130,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
 
         let calldata = build_add_liquidity(
             &token_a_addr, &token_b_addr,
-            args.amount_a, args.amount_b,
+            amount_a, amount_b,
             amount_a_min, amount_b_min,
             &wallet, deadline,
         );
@@ -147,8 +155,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         "data": {
             "tokenA": args.token_a,
             "tokenB": args.token_b,
-            "amountA": args.amount_a.to_string(),
-            "amountB": args.amount_b.to_string(),
+            "amountA": amount_a.to_string(),
+            "amountB": amount_b.to_string(),
             "chain": args.chain_id
         }
     }))

--- a/skills/pancakeswap-v2/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2/src/commands/add_liquidity.rs
@@ -53,8 +53,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
     // Resolve token decimals and parse human-readable amounts
     let token_a_for_dec = if native_a { cfg.weth.to_string() } else { resolve_token_address(&args.token_a, args.chain_id) };
     let token_b_for_dec = if native_b { cfg.weth.to_string() } else { resolve_token_address(&args.token_b, args.chain_id) };
-    let decimals_a = rpc::get_erc20_decimals(&token_a_for_dec, rpc).await.unwrap_or(18);
-    let decimals_b = rpc::get_erc20_decimals(&token_b_for_dec, rpc).await.unwrap_or(18);
+    let decimals_a = rpc::erc20_decimals(&token_a_for_dec, rpc).await.unwrap_or(18);
+    let decimals_b = rpc::erc20_decimals(&token_b_for_dec, rpc).await.unwrap_or(18);
     let amount_a = rpc::parse_human_amount(&args.amount_a, decimals_a)?;
     let amount_b = rpc::parse_human_amount(&args.amount_b, decimals_b)?;
     if amount_a == 0 && amount_b == 0 {

--- a/skills/pancakeswap-v2/src/commands/quote.rs
+++ b/skills/pancakeswap-v2/src/commands/quote.rs
@@ -9,7 +9,7 @@ pub struct QuoteArgs {
     pub chain_id: u64,
     pub token_in: String,
     pub token_out: String,
-    pub amount_in: u128,
+    pub amount_in: String,
     pub rpc_url: Option<String>,
 }
 
@@ -22,9 +22,6 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
 
     if token_in == token_out {
         anyhow::bail!("tokenIn and tokenOut must be different tokens.");
-    }
-    if args.amount_in == 0 {
-        anyhow::bail!("Amount must be greater than 0.");
     }
 
     // Handle native BNB/ETH: map to WBNB/WETH for routing
@@ -39,6 +36,13 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
         token_out.clone()
     };
 
+    // Resolve decimals for tokenIn and parse human-readable amount
+    let decimals_in = rpc::get_erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
+    let amount_in_raw = rpc::parse_human_amount(&args.amount_in, decimals_in)?;
+    if amount_in_raw == 0 {
+        anyhow::bail!("Amount must be greater than 0.");
+    }
+
     // Determine path: try direct pair first, then route via WETH/WBNB
     let path = determine_path(
         &token_in_addr,
@@ -50,7 +54,7 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
     .await?;
 
     let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
-    let amounts = rpc::router_get_amounts_out(cfg.router02, args.amount_in, &path_refs, rpc).await?;
+    let amounts = rpc::router_get_amounts_out(cfg.router02, amount_in_raw, &path_refs, rpc).await?;
 
     let amount_out = *amounts.last().unwrap_or(&0);
 
@@ -68,7 +72,7 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
             "tokenOut": token_out_addr,
             "symbolIn": symbol_in,
             "symbolOut": symbol_out,
-            "amountIn": args.amount_in.to_string(),
+            "amountIn": amount_in_raw.to_string(),
             "amountOut": amount_out.to_string(),
             "amountOutHuman": format!("{:.6}", amount_out_human),
             "path": path,

--- a/skills/pancakeswap-v2/src/commands/quote.rs
+++ b/skills/pancakeswap-v2/src/commands/quote.rs
@@ -37,7 +37,7 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
     };
 
     // Resolve decimals for tokenIn and parse human-readable amount
-    let decimals_in = rpc::get_erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
+    let decimals_in = rpc::erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
     let amount_in_raw = rpc::parse_human_amount(&args.amount_in, decimals_in)?;
     if amount_in_raw == 0 {
         anyhow::bail!("Amount must be greater than 0.");

--- a/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2/src/commands/remove_liquidity.rs
@@ -11,7 +11,7 @@ pub struct RemoveLiquidityArgs {
     pub chain_id: u64,
     pub token_a: String,
     pub token_b: String,
-    pub liquidity: Option<u128>,  // LP token amount; None = use full balance
+    pub liquidity: Option<String>,  // LP token amount as human-readable decimal; None = use full balance
     pub slippage_bps: u64,
     pub deadline_secs: u64,
     pub from: Option<String>,
@@ -68,7 +68,12 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
         anyhow::bail!("You have no LP tokens for this pair (pair: {}).", pair_addr);
     }
 
-    let liquidity = args.liquidity.unwrap_or(lp_balance);
+    let liquidity = if let Some(ref liq_str) = args.liquidity {
+        // LP tokens are always 18 decimals (standard ERC-20)
+        rpc::parse_human_amount(liq_str, 18)?
+    } else {
+        lp_balance
+    };
     if liquidity == 0 && !args.dry_run {
         anyhow::bail!("Liquidity amount is zero.");
     }

--- a/skills/pancakeswap-v2/src/commands/swap.rs
+++ b/skills/pancakeswap-v2/src/commands/swap.rs
@@ -12,7 +12,7 @@ pub struct SwapArgs {
     pub chain_id: u64,
     pub token_in: String,
     pub token_out: String,
-    pub amount_in: u128,         // in minimal units
+    pub amount_in: String,       // human-readable decimal, e.g. "1.5" or "100"
     pub slippage_bps: u64,       // e.g. 50 = 0.5%
     pub deadline_secs: u64,
     pub from: Option<String>,
@@ -43,7 +43,11 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     if token_in_addr == token_out_addr {
         anyhow::bail!("tokenIn and tokenOut must be different tokens.");
     }
-    if args.amount_in == 0 {
+
+    // Resolve tokenIn decimals and parse human-readable amount
+    let decimals_in = rpc::get_erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
+    let amount_in = rpc::parse_human_amount(&args.amount_in, decimals_in)?;
+    if amount_in == 0 {
         anyhow::bail!("Amount must be greater than 0.");
     }
 
@@ -64,7 +68,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
 
     // Quote for amountOutMin
     let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
-    let amounts = rpc::router_get_amounts_out(cfg.router02, args.amount_in, &path_refs, rpc).await?;
+    let amounts = rpc::router_get_amounts_out(cfg.router02, amount_in, &path_refs, rpc).await?;
     let amount_out_expected = *amounts.last().unwrap_or(&0);
     let amount_out_min = amount_out_expected * (10000 - args.slippage_bps) as u128 / 10000;
 
@@ -96,7 +100,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
             cfg.router02,
             &calldata,
             args.from.as_deref(),
-            Some(args.amount_in as u128),
+            Some(amount_in),
             args.dry_run,
         )
         .await?;
@@ -113,12 +117,12 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
         // Variant C: Token → Native ETH/BNB (swapExactTokensForETH)
         // Check and approve if needed
         let allowance = rpc::erc20_allowance(&token_in_addr, &wallet, cfg.router02, rpc).await.unwrap_or(0);
-        if allowance < args.amount_in {
+        if allowance < amount_in {
             let approve_result = erc20_approve(
                 args.chain_id,
                 &token_in_addr,
                 cfg.router02,
-                args.amount_in,
+                amount_in,
                 args.from.as_deref(),
                 args.dry_run,
             )
@@ -133,7 +137,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
         }
 
         let calldata = build_swap_exact_tokens_for_eth(
-            args.amount_in,
+            amount_in,
             amount_out_min,
             &path,
             &wallet,
@@ -161,12 +165,12 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
         // Variant A: Token → Token (swapExactTokensForTokens)
         // Check and approve if needed
         let allowance = rpc::erc20_allowance(&token_in_addr, &wallet, cfg.router02, rpc).await.unwrap_or(0);
-        if allowance < args.amount_in {
+        if allowance < amount_in {
             let approve_result = erc20_approve(
                 args.chain_id,
                 &token_in_addr,
                 cfg.router02,
-                args.amount_in,
+                amount_in,
                 args.from.as_deref(),
                 args.dry_run,
             )
@@ -181,7 +185,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
         }
 
         let calldata = build_swap_exact_tokens_for_tokens(
-            args.amount_in,
+            amount_in,
             amount_out_min,
             &path,
             &wallet,
@@ -210,7 +214,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     results["data"] = json!({
         "tokenIn": token_in_addr,
         "tokenOut": token_out_addr,
-        "amountIn": args.amount_in.to_string(),
+        "amountIn": amount_in.to_string(),
         "amountOutMin": amount_out_min.to_string(),
         "amountOutExpected": amount_out_expected.to_string(),
         "path": path,

--- a/skills/pancakeswap-v2/src/commands/swap.rs
+++ b/skills/pancakeswap-v2/src/commands/swap.rs
@@ -45,7 +45,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     }
 
     // Resolve tokenIn decimals and parse human-readable amount
-    let decimals_in = rpc::get_erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
+    let decimals_in = rpc::erc20_decimals(&token_in_addr, rpc).await.unwrap_or(18);
     let amount_in = rpc::parse_human_amount(&args.amount_in, decimals_in)?;
     if amount_in == 0 {
         anyhow::bail!("Amount must be greater than 0.");

--- a/skills/pancakeswap-v2/src/main.rs
+++ b/skills/pancakeswap-v2/src/main.rs
@@ -10,7 +10,7 @@ use commands::{
 };
 
 #[derive(Parser)]
-#[command(name = "pancakeswap-v2", about = "PancakeSwap V2 AMM plugin — swap tokens and manage liquidity on BSC/Base")]
+#[command(name = "pancakeswap-v2", version, about = "PancakeSwap V2 AMM plugin — swap tokens and manage liquidity on BSC/Base")]
 struct Cli {
     /// Chain ID (56 = BSC default, 8453 = Base)
     #[arg(long, default_value = "56")]
@@ -50,9 +50,9 @@ enum Commands {
         /// Output token symbol or address
         #[arg(long)]
         token_out: String,
-        /// Amount of tokenIn in minimal units (e.g. 1000000000000000000 for 1 token with 18 dec)
+        /// Amount of tokenIn as a human-readable decimal (e.g. 1.5, 100, 0.001)
         #[arg(long)]
-        amount_in: u128,
+        amount_in: String,
     },
 
     /// Swap tokens via PancakeSwap V2 Router02
@@ -63,9 +63,9 @@ enum Commands {
         /// Output token symbol or address
         #[arg(long)]
         token_out: String,
-        /// Amount of tokenIn in minimal units
+        /// Amount of tokenIn as a human-readable decimal (e.g. 1.5, 100, 0.001)
         #[arg(long)]
-        amount_in: u128,
+        amount_in: String,
     },
 
     /// Add liquidity to a V2 pair (receive LP tokens)
@@ -76,12 +76,12 @@ enum Commands {
         /// Second token symbol or address
         #[arg(long)]
         token_b: String,
-        /// Desired amount of tokenA in minimal units
+        /// Desired amount of tokenA as a human-readable decimal (e.g. 10, 0.5)
         #[arg(long)]
-        amount_a: u128,
-        /// Desired amount of tokenB (or native BNB/ETH) in minimal units
+        amount_a: String,
+        /// Desired amount of tokenB (or native BNB/ETH) as a human-readable decimal
         #[arg(long)]
-        amount_b: u128,
+        amount_b: String,
     },
 
     /// Remove liquidity and withdraw tokens
@@ -92,9 +92,9 @@ enum Commands {
         /// Second token symbol or address
         #[arg(long)]
         token_b: String,
-        /// LP token amount to burn (omit to remove all)
+        /// LP tokens to burn as a human-readable decimal (e.g. 1.0). Omit to remove all.
         #[arg(long)]
-        liquidity: Option<u128>,
+        liquidity: Option<String>,
     },
 
     /// Get the pair contract address for two tokens

--- a/skills/pancakeswap-v2/src/rpc.rs
+++ b/skills/pancakeswap-v2/src/rpc.rs
@@ -208,6 +208,36 @@ pub async fn erc20_decimals(token: &str, rpc_url: &str) -> anyhow::Result<u8> {
     let v = decode_u128(&result);
     Ok(v as u8)
 }
+/// ERC-20 decimals() → u8 via raw hex decode. Falls back to 18 on error.
+pub async fn get_erc20_decimals(token: &str, rpc_url: &str) -> anyhow::Result<u8> {
+    let result = eth_call(token, "0x313ce567", rpc_url).await?;
+    let clean = result.trim_start_matches("0x");
+    if clean.len() < 2 { return Ok(18); }
+    Ok(u8::from_str_radix(&clean[clean.len() - 2..], 16).unwrap_or(18))
+}
+
+/// Parse a human-readable decimal amount string into raw token units.
+pub fn parse_human_amount(amount_str: &str, decimals: u8) -> anyhow::Result<u128> {
+    let s = amount_str.trim();
+    let factor = 10u128.pow(decimals as u32);
+    if let Some(dot_pos) = s.find('.') {
+        let int_part: u128 = if dot_pos == 0 { 0 } else {
+            s[..dot_pos].parse().map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?
+        };
+        let frac_str = &s[dot_pos + 1..];
+        if frac_str.len() > decimals as usize {
+            anyhow::bail!("Amount '{}' has {} decimal places but token only supports {}", s, frac_str.len(), decimals);
+        }
+        let frac: u128 = if frac_str.is_empty() { 0 } else {
+            frac_str.parse().map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?
+        };
+        let frac_factor = 10u128.pow(decimals as u32 - frac_str.len() as u32);
+        Ok(int_part * factor + frac * frac_factor)
+    } else {
+        let int_val: u128 = s.parse().map_err(|_| anyhow::anyhow!("Invalid amount: '{}'", s))?;
+        Ok(int_val * factor)
+    }
+}
 
 /// ERC-20 symbol() → String (ABI-encoded)
 /// Selector: 0x95d89b41

--- a/skills/pancakeswap-v2/src/rpc.rs
+++ b/skills/pancakeswap-v2/src/rpc.rs
@@ -205,12 +205,6 @@ fn parse_amounts_out(hex: &str, path_len: usize) -> anyhow::Result<Vec<u128>> {
 /// Selector: 0x313ce567
 pub async fn erc20_decimals(token: &str, rpc_url: &str) -> anyhow::Result<u8> {
     let result = eth_call(token, "0x313ce567", rpc_url).await?;
-    let v = decode_u128(&result);
-    Ok(v as u8)
-}
-/// ERC-20 decimals() → u8 via raw hex decode. Falls back to 18 on error.
-pub async fn get_erc20_decimals(token: &str, rpc_url: &str) -> anyhow::Result<u8> {
-    let result = eth_call(token, "0x313ce567", rpc_url).await?;
     let clean = result.trim_start_matches("0x");
     if clean.len() < 2 { return Ok(18); }
     Ok(u8::from_str_radix(&clean[clean.len() - 2..], 16).unwrap_or(18))


### PR DESCRIPTION
## Summary

- **Bug**: Clap CLI params typed as `u128`/`Option<u128>` reject decimal input like `--amount 0.1` at parse time with \"invalid digit found in string\". This means users cannot pass natural amounts like `1.5` or `0.001` — they must compute raw token units (e.g. `1500000000000000000`) manually.
- **Fix**: Changed `--amount-in`, `--amount-a`, `--amount-b`, and `--liquidity` from `u128`/`Option<u128>` to `String`/`Option<String>` in clap structs. Each command now resolves the token's ERC-20 `decimals()` on-chain and converts through a new `parse_human_amount()` helper before passing raw `u128` values to calldata builders.
- **Version bump**: 0.2.2 → 0.2.3

## What changed

- `src/main.rs`: `amount_in`, `amount_a`, `amount_b`, `liquidity` clap fields changed to `String`/`Option<String>`; added `version` to `#[command(...)]` so `pancakeswap-v2 --version` works
- `src/rpc.rs`: added `parse_human_amount(str, decimals) -> u128` and `get_erc20_decimals(token, rpc) -> u8`
- `src/commands/quote.rs`: resolve tokenIn decimals on-chain, parse `amount_in` via `parse_human_amount`
- `src/commands/swap.rs`: resolve tokenIn decimals on-chain, parse `amount_in` via `parse_human_amount`
- `src/commands/add_liquidity.rs`: resolve tokenA/B decimals on-chain, parse `amount_a`/`amount_b`
- `src/commands/remove_liquidity.rs`: parse `liquidity` `Option<String>` at 18 decimals (LP tokens are always 18 decimals)
- `SKILL.md`: updated install guard to version-compare + SHA256 checksum verification pattern; updated all command examples to use human-readable amounts; added v0.2.3 changelog entry
- `.gitignore`: anchored `target/` → `/target/`
- Version bumped 0.2.2 → 0.2.3 in `Cargo.toml`, `plugin.yaml`, `.claude-plugin/plugin.json`, `SKILL.md` frontmatter

## Test plan

- [ ] `pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 100` — should work (was rejected before as \"invalid digit\" if user passed `100.0`)
- [ ] `pancakeswap-v2 --chain 56 swap --token-in USDT --token-out CAKE --amount-in 1.5` — decimal input accepted
- [ ] `pancakeswap-v2 --chain 56 add-liquidity --token-a CAKE --token-b BNB --amount-a 10 --amount-b 0.05` — decimal BNB amount accepted
- [ ] `pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liquidity 1.0` — decimal LP amount accepted
- [ ] `pancakeswap-v2 --version` — outputs `0.2.3`
- [ ] Integer inputs still work: `--amount-in 100` (no decimal point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)