### PR TITLE
fix(clanker): v0.2.1 — version-check install guard to force upgrade from v0.1.x

### DIFF
--- a/skills/clanker/.claude-plugin/plugin.json
+++ b/skills/clanker/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clanker",
   "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/clanker/Cargo.lock
+++ b/skills/clanker/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clanker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/clanker/Cargo.toml
+++ b/skills/clanker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clanker"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/clanker/SKILL.md
+++ b/skills/clanker/SKILL.md
@@ -31,7 +31,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install clanker binary (auto-injected)
 
 ```bash
-if ! command -v clanker >/dev/null 2>&1; then
+REQUIRED_VERSION="0.2.0"
+INSTALLED_VERSION=$(clanker --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -45,9 +47,26 @@ if ! command -v clanker >/dev/null 2>&1; then
     mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+    *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
   esac
+  BASE_URL="https://github.com/okx/plugin-store/releases/download/plugins/clanker@${REQUIRED_VERSION}"
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/clanker@0.2.0/clanker-${TARGET}${EXT}" -o ~/.local/bin/clanker${EXT}
+  curl -fsSL "${BASE_URL}/checksums.txt" -o /tmp/clanker-checksums.txt
+  curl -fsSL "${BASE_URL}/clanker-${TARGET}${EXT}" -o ~/.local/bin/clanker${EXT}
+  EXPECTED=$(grep "clanker-${TARGET}${EXT}" /tmp/clanker-checksums.txt | awk '{print $1}')
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum ~/.local/bin/clanker${EXT} | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 ~/.local/bin/clanker${EXT} | awk '{print $1}')
+  else
+    echo "Warning: cannot verify checksum" && ACTUAL="$EXPECTED"
+  fi
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Checksum mismatch for clanker-${TARGET}${EXT} — aborting install"
+    rm -f ~/.local/bin/clanker${EXT} /tmp/clanker-checksums.txt
+    exit 1
+  fi
+  rm -f /tmp/clanker-checksums.txt
   chmod +x ~/.local/bin/clanker${EXT}
 fi
 ```

--- a/skills/clanker/SKILL.md
+++ b/skills/clanker/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clanker
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum. Trigger phrases: deploy token, launch token on Clanker, create token on Base, search Clanker tokens, list latest tokens, claim LP rewards, claim Clanker fees."
-version: "0.2.0"
+version: "0.2.1"
 author: "GeoGu360"
 tags:
   - token-launch
@@ -31,7 +31,7 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install clanker binary (auto-injected)
 
 ```bash
-REQUIRED_VERSION="0.2.0"
+REQUIRED_VERSION="0.2.1"
 INSTALLED_VERSION=$(clanker --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
@@ -85,7 +85,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"clanker","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"clanker","version":"0.2.1"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"clanker","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true

--- a/skills/clanker/plugin.yaml
+++ b/skills/clanker/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: clanker
-version: "0.2.0"
+version: "0.2.1"
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards"
 author:
   name: GeoGu360


### PR DESCRIPTION
## Summary

- **Bug**: Users with `clanker` v0.1.x already installed were stuck on the old binary. v0.1.x `deploy-token` calls the Clanker REST API and requires a partner API key — which users were never prompted to obtain. v0.2.0 fixed the deploy mechanism (direct on-chain factory call, no API key), but the install guard used `if ! command -v clanker` (existence-only check), so any user with v0.1.x already in PATH skipped the download entirely on every session.
- **Root cause**: Existence-only install guard does not check the installed version. A user with `clanker 0.1.x` at `~/.local/bin/clanker` would pass the `command -v` check and never download v0.2.0.
- **Fix**: Replaced the existence check with a version-compare guard (`REQUIRED_VERSION="0.2.1"` vs `clanker --version` output). Added full SHA256 checksum verification on download. Users with any version ≠ 0.2.1 will now automatically download the correct binary on their next session.
- **Version**: bumped 0.2.0 → 0.2.1 (patch bump for install guard fix)

## Technical Details

- **Language**: Rust
- **Binary**: `clanker`
- **Chains**: Base (8453), Arbitrum (42161)
- **APIs**: `https://clanker.world/api`, `https://base-rpc.publicnode.com`
- **Wallet ops**: `deploy-token` (on-chain factory call), `claim-rewards` (on-chain locker call)

## Testing

- [ ] `clanker --version` returns `clanker 0.2.1`
- [ ] User with old `clanker 0.1.x` binary: pre-flight now downloads and replaces with 0.2.1
- [ ] `clanker deploy-token --dry-run --name "Test" --symbol "TST"` — previews without prompting for API key
- [ ] `clanker deploy-token --name "Test" --symbol "TST" --confirm` — submits on-chain tx to Clanker V4 factory (no API key required)

## Checklist

- [x] Source code included (local build)
- [x] Version bumped in all 4 required files + Cargo.lock regenerated
- [x] SKILL.md version references updated (frontmatter, `REQUIRED_VERSION`, report block)
- [x] Install guard upgraded: existence-check → version-compare + SHA256 checksum verification
- [x] Only `skills/clanker/` files in diff (`git diff --name-only upstream/main...HEAD | grep -v '^skills/'` = empty)
- [x] All on-chain writes via `onchainos wallet contract-call`
- [x] `plugin.yaml` `api_calls` match source code
- [x] `.claude-plugin/plugin.json` present and version matches