### PR TITLE
fix(pump-fun): v0.1.1 — friendly Borsh error, skip get_sell_price for graduated tokens

### DIFF
--- a/skills/pump-fun/.claude-plugin/plugin.json
+++ b/skills/pump-fun/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pump-fun",
   "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/pump-fun/.claude-plugin/plugin.json
+++ b/skills/pump-fun/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pump-fun",
   "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/pump-fun/Cargo.lock
+++ b/skills/pump-fun/Cargo.lock
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "pump-fun"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/pump-fun/Cargo.lock
+++ b/skills/pump-fun/Cargo.lock
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "pump-fun"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/pump-fun/Cargo.toml
+++ b/skills/pump-fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pump-fun"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/pump-fun/Cargo.toml
+++ b/skills/pump-fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pump-fun"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/pump-fun/SKILL.md
+++ b/skills/pump-fun/SKILL.md
@@ -28,7 +28,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install pump-fun binary (auto-injected)
 
 ```bash
-if ! command -v pump-fun >/dev/null 2>&1; then
+REQUIRED_VERSION="0.1.1"
+INSTALLED_VERSION=$(pump-fun --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -42,9 +44,26 @@ if ! command -v pump-fun >/dev/null 2>&1; then
     mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+    *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
   esac
+  BASE_URL="https://github.com/okx/plugin-store/releases/download/plugins/pump-fun@${REQUIRED_VERSION}"
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pump-fun@0.1.0/pump-fun-${TARGET}${EXT}" -o ~/.local/bin/pump-fun${EXT}
+  curl -fsSL "${BASE_URL}/checksums.txt" -o /tmp/pump-fun-checksums.txt
+  curl -fsSL "${BASE_URL}/pump-fun-${TARGET}${EXT}" -o ~/.local/bin/pump-fun${EXT}
+  EXPECTED=$(grep "pump-fun-${TARGET}${EXT}" /tmp/pump-fun-checksums.txt | awk '{print $1}')
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum ~/.local/bin/pump-fun${EXT} | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 ~/.local/bin/pump-fun${EXT} | awk '{print $1}')
+  else
+    echo "Warning: cannot verify checksum" && ACTUAL="$EXPECTED"
+  fi
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Checksum mismatch for pump-fun-${TARGET}${EXT} — aborting install"
+    rm -f ~/.local/bin/pump-fun${EXT} /tmp/pump-fun-checksums.txt
+    exit 1
+  fi
+  rm -f /tmp/pump-fun-checksums.txt
   chmod +x ~/.local/bin/pump-fun${EXT}
 fi
 ```
@@ -66,7 +85,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pump-fun","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"pump-fun","version":"0.1.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pump-fun/SKILL.md
+++ b/skills/pump-fun/SKILL.md
@@ -4,7 +4,7 @@ description: "Interact with pump.fun bonding curves on Solana: buy tokens, sell 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "1.3.0"
+  version: "0.1.2"
 ---
 
 
@@ -28,7 +28,7 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install pump-fun binary (auto-injected)
 
 ```bash
-REQUIRED_VERSION="0.1.1"
+REQUIRED_VERSION="0.1.2"
 INSTALLED_VERSION=$(pump-fun --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
@@ -85,7 +85,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pump-fun","version":"0.1.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"pump-fun","version":"0.1.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pump-fun/plugin.yaml
+++ b/skills/pump-fun/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pump-fun
-version: "0.1.0"
+version: "0.1.1"
 description: "Buy and sell tokens on pump.fun bonding curves on Solana mainnet"
 author:
   name: skylavis-sky

--- a/skills/pump-fun/plugin.yaml
+++ b/skills/pump-fun/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pump-fun
-version: "0.1.1"
+version: "0.1.2"
 description: "Buy and sell tokens on pump.fun bonding curves on Solana mainnet"
 author:
   name: skylavis-sky

--- a/skills/pump-fun/src/commands/buy.rs
+++ b/skills/pump-fun/src/commands/buy.rs
@@ -51,7 +51,7 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
         onchainos::swap_execute_solana(SOL_MINT, &args.mint, &args.sol_amount, args.slippage_bps)
             .await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     println!(
         "{}",

--- a/skills/pump-fun/src/commands/get_price.rs
+++ b/skills/pump-fun/src/commands/get_price.rs
@@ -77,7 +77,19 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
     let curve = pumpfun
         .get_bonding_curve_account(&mint)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch bonding curve: {e}"))?;
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("Borsh") || msg.contains("serialization") || msg.contains("length") {
+                anyhow::anyhow!(
+                    "Failed to fetch bonding curve: {}. \
+                     This token may use an updated pump.fun contract layout not yet supported by the SDK. \
+                     Try `onchainos token search --mint {}` for token info instead.",
+                    msg, mint
+                )
+            } else {
+                anyhow::anyhow!("Failed to fetch bonding curve: {}", msg)
+            }
+        })?;
 
     let price_sol_per_token = if curve.virtual_token_reserves > 0 {
         curve.virtual_sol_reserves as f64 / curve.virtual_token_reserves as f64
@@ -92,6 +104,10 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
         // pump.fun tokens have 6 decimals
         let ui = tokens as f64 / 1_000_000.0;
         (tokens, ui)
+    } else if curve.complete {
+        // Graduated token — bonding curve is closed, get_sell_price returns "Curve is complete".
+        // Return ok:true with amount_out=0 and a graduated_warning instead of erroring out.
+        (0u64, 0.0f64)
     } else {
         let lamports = curve
             .get_sell_price(args.amount, args.fee_bps)

--- a/skills/pump-fun/src/commands/get_token_info.rs
+++ b/skills/pump-fun/src/commands/get_token_info.rs
@@ -67,7 +67,19 @@ pub async fn execute(args: &GetTokenInfoArgs) -> Result<()> {
     let curve = pumpfun
         .get_bonding_curve_account(&mint)
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to fetch bonding curve: {e}"))?;
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("Borsh") || msg.contains("serialization") || msg.contains("length") {
+                anyhow::anyhow!(
+                    "Failed to fetch bonding curve: {}. \
+                     This token may use an updated pump.fun contract layout not yet supported by the SDK. \
+                     Try `onchainos token search --mint {}` for token info instead.",
+                    msg, mint
+                )
+            } else {
+                anyhow::anyhow!("Failed to fetch bonding curve: {}", msg)
+            }
+        })?;
 
     let price_sol_per_token = if curve.virtual_token_reserves > 0 {
         curve.virtual_sol_reserves as f64 / curve.virtual_token_reserves as f64

--- a/skills/pump-fun/src/commands/sell.rs
+++ b/skills/pump-fun/src/commands/sell.rs
@@ -63,7 +63,7 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
     let result =
         onchainos::swap_execute_solana(&args.mint, SOL_MINT, &amount, args.slippage_bps).await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result).to_string();
+    let tx_hash = onchainos::extract_tx_hash(&result)?;
 
     println!(
         "{}",

--- a/skills/pump-fun/src/main.rs
+++ b/skills/pump-fun/src/main.rs
@@ -12,7 +12,7 @@ use commands::{
 #[command(
     name = "pump-fun",
     about = "Plugin for pump.fun — buy and sell tokens on Solana bonding curves via onchainos swap",
-    version = "0.1.0"
+    version
 )]
 struct Cli {
     /// Simulate without broadcasting (no on-chain transaction sent)

--- a/skills/pump-fun/src/onchainos.rs
+++ b/skills/pump-fun/src/onchainos.rs
@@ -87,7 +87,7 @@ pub fn get_token_balance(mint: &str) -> anyhow::Result<Option<String>> {
     for detail in details {
         if let Some(assets) = detail["tokenAssets"].as_array() {
             for asset in assets {
-                let addr = asset["tokenAddress"].as_str().unwrap_or("");
+                let addr = asset["tokenContractAddress"].as_str().unwrap_or("");
                 if addr.eq_ignore_ascii_case(mint) {
                     if let Some(bal) = asset["balance"].as_str()
                         .or_else(|| asset["readableBalance"].as_str())
@@ -102,10 +102,12 @@ pub fn get_token_balance(mint: &str) -> anyhow::Result<Option<String>> {
 }
 
 /// Extract the txHash from an onchainos swap response.
-pub fn extract_tx_hash(result: &Value) -> &str {
+/// Returns an error if txHash is absent, so broadcast failures are not silently masked.
+pub fn extract_tx_hash(result: &Value) -> anyhow::Result<String> {
     result["data"]["txHash"]
         .as_str()
         .or_else(|| result["data"]["swapTxHash"].as_str())
         .or_else(|| result["txHash"].as_str())
-        .unwrap_or("pending")
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("onchainos response missing txHash: {}", result))
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (medium)**: `get-token-info` and `get-price` return an unhelpful Borsh deserialization error for tokens whose bonding curve account uses an updated pump.fun contract layout. The `pumpfun` crate v4.6.0 hardcodes `BondingCurveAccount` fields that don't match the newer layout, producing `Unexpected length of input`.
- **Bug 2 (low)**: `get-price --direction sell` on a graduated token returns `ok:false` with `"Curve is complete"` error, even though the output struct already has a `graduated_warning` field designed for this case. The `get_sell_price()` call threw before the warning was ever built.
- **Fix 1**: Detect Borsh/serialization errors by message content and return a user-actionable error: explains the contract layout mismatch and suggests `onchainos token search --mint <addr>` as a fallback.
- **Fix 2**: Short-circuit `get_sell_price` when `curve.complete == true` — return `amount_out: 0` with `ok: true` and the existing `graduated_warning` instead of erroring out.
- **Also**: Upgraded install guard from existence-check to version-compare + SHA256 checksum verification. Fixed hardcoded `version = "0.1.0"` in clap attribute to use `version` (reads from Cargo.toml at compile time).
- **Version**: bumped 0.1.0 → 0.1.1 (patch bump)

## Technical Details

- **Language**: Rust
- **Binary**: `pump-fun`
- **Chains**: Solana (chain 501)
- **APIs**: `https://api.mainnet-beta.solana.com`, `https://frontend-api.pump.fun`
- **Wallet ops**: `buy`, `sell` (via `onchainos swap execute`)

## Testing

- [ ] `pump-fun --version` returns `pump-fun 0.1.1`
- [ ] `pump-fun get-token-info --mint C47scuyDpx36kRzWKvd9992PaVcApAC9GrCg3rMdXL1v` — returns actionable error with fallback suggestion (was: unhelpful Borsh error)
- [ ] `pump-fun get-price --mint Dj2JhqEaKgPDo9se3A1dtSBVV1FFCxAfFa9SBBWmpump --direction sell --amount 42946229070` — returns `ok:true` with `graduated_warning` (was: `ok:false` error)
- [ ] `pump-fun get-token-info --mint Dj2JhqEaKgPDo9se3A1dtSBVV1FFCxAfFa9SBBWmpump` — still works for compatible tokens

## Checklist

- [x] Source code included (local build)
- [x] Version bumped in all 4 required files + Cargo.lock regenerated
- [x] SKILL.md install guard upgraded: existence-check → version-compare + SHA256 checksum verification
- [x] SKILL.md version references updated (download URL, report block)
- [x] `pump-fun --version` now reads from Cargo.toml via clap `version` attribute
- [x] Only `skills/pump-fun/` files in diff
- [x] `plugin.yaml` `api_calls` match source code
- [x] `.claude-plugin/plugin.json` present and version matches