### PR TITLE
feat(lido): switch get-apy to DeFiLlama + fix get-withdrawals wait display (v0.2.3)

### DIFF
--- a/skills/lido/.claude-plugin/plugin.json
+++ b/skills/lido/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lido",
   "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/lido/Cargo.lock
+++ b/skills/lido/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "lido"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/lido/Cargo.toml
+++ b/skills/lido/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lido"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/lido/SKILL.md
+++ b/skills/lido/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lido
 description: Stake ETH with Lido liquid staking protocol to receive stETH, manage withdrawals, and track staking rewards. Supports staking, balance queries, withdrawal requests, withdrawal status, and claiming finalized withdrawals on Ethereum mainnet.
-version: 0.2.2
+version: 0.2.3
 author: GeoGu360
 ---
 
@@ -42,7 +42,7 @@ if ! command -v lido >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.2/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido@0.2.3/lido-${TARGET}${EXT}" -o ~/.local/bin/lido${EXT}
   chmod +x ~/.local/bin/lido${EXT}
 fi
 ```
@@ -154,9 +154,9 @@ lido stake --amount-eth 2.5 --dry-run
 
 ---
 
-### `get-apy` — Get Current stETH APR
+### `get-apy` — Get Current stETH APY
 
-Fetch the 7-day simple moving average APR for stETH staking. No wallet required.
+Fetch stETH APY, TVL, and trend data via DeFiLlama. No wallet required.
 
 **Usage:**
 ```
@@ -164,14 +164,25 @@ lido get-apy
 ```
 
 **Steps:**
-1. HTTP GET `https://eth-api.lido.fi/v1/protocol/steth/apr/sma` (with `Accept: application/json`)
-2. Falls back to `/v1/protocol/steth/apr/last` if `sma` endpoint returns non-2xx (CDN/geo variability)
-3. Display: "Current 7-day average stETH APR: X.XX%"
+1. HTTP GET `https://yields.llama.fi/pools`
+2. Filter: `project == "lido"`, `chain == "Ethereum"`, symbol contains `steth`
+3. Pick pool with highest TVL; display APY, TVL, 1D/7D/30D change, 30D average
+
+**Output fields:** APY, TVL, 1D change, 7D change, 30D change, 30D avg APY
 
 **Example output:**
 ```
-Current 7-day average stETH APR: 3.20%
-Note: This is post-10%-fee rate. Rewards are paid daily and compound automatically.
+=== Lido stETH APY (via DeFiLlama) ===
+Asset:       STETH
+APY:         2.378%
+TVL:         $21.17B
+1D change:   0.020%
+7D change:   -0.034%
+30D change:  -0.052%
+30D avg APY: 2.512%
+
+Note: Data sourced from DeFiLlama (third-party aggregator).
+      This is post-10%-fee rate. Rewards compound daily.
 ```
 
 **No onchainos command required** — pure REST API call.

--- a/skills/lido/plugin.yaml
+++ b/skills/lido/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: lido
-version: "0.2.2"
+version: "0.2.3"
 description: "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet"
 author:
   name: GeoGu360
@@ -20,6 +20,6 @@ build:
   lang: rust
   binary_name: lido
 api_calls:
-  - eth-api.lido.fi
+  - yields.llama.fi
   - wq-api.lido.fi
   - ethereum.publicnode.com

--- a/skills/lido/src/commands/get_apy.rs
+++ b/skills/lido/src/commands/get_apy.rs
@@ -1,68 +1,88 @@
-use crate::config;
+use serde::Deserialize;
 
-pub async fn run() -> anyhow::Result<()> {
-    let url = format!("{}/v1/protocol/steth/apr/sma", config::API_BASE_URL);
+const DEFILLAMA_POOLS_URL: &str = "https://yields.llama.fi/pools";
 
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(&url)
-        .header("User-Agent", "Mozilla/5.0 (compatible; lido-plugin/0.1)")
-        .header("Accept", "application/json")
-        .send()
-        .await?;
-
-    // Fallback: /apr/sma was deprecated on some edge nodes; try /apr/last
-    let body: serde_json::Value = if resp.status().is_success() {
-        resp.json().await?
-    } else {
-        let fallback_url = format!("{}/v1/protocol/steth/apr/last", config::API_BASE_URL);
-        let resp2 = client
-            .get(&fallback_url)
-            .header("User-Agent", "Mozilla/5.0 (compatible; lido-plugin/0.1)")
-            .header("Accept", "application/json")
-            .send()
-            .await?;
-        if !resp2.status().is_success() {
-            anyhow::bail!("Failed to fetch APR: HTTP {}", resp2.status());
-        }
-        resp2.json().await?
-    };
-
-    // Try to extract APR from various response shapes
-    let apr = extract_apr(&body);
-
-    println!("=== Lido stETH APR ===");
-    match apr {
-        Some(v) => {
-            println!("Current 7-day average stETH APR: {:.2}%", v);
-            println!(
-                "Note: This is post-10%-fee rate. Rewards are paid daily and compound automatically."
-            );
-        }
-        None => {
-            println!("Raw response: {}", serde_json::to_string_pretty(&body)?);
-        }
-    }
-
-    Ok(())
+#[derive(Debug, Deserialize)]
+struct PoolsResponse {
+    data: Vec<PoolItem>,
 }
 
-fn extract_apr(body: &serde_json::Value) -> Option<f64> {
-    // Try data.smaApr first
-    if let Some(v) = body["data"]["smaApr"].as_f64() {
-        return Some(v);
+#[allow(non_snake_case)]
+#[derive(Debug, Deserialize)]
+struct PoolItem {
+    chain: Option<String>,
+    project: Option<String>,
+    symbol: Option<String>,
+    tvlUsd: Option<f64>,
+    apy: Option<f64>,
+    apyPct1D: Option<f64>,
+    apyPct7D: Option<f64>,
+    apyPct30D: Option<f64>,
+    apyMean30d: Option<f64>,
+}
+
+fn is_target_pool(pool: &PoolItem) -> bool {
+    let project = pool.project.as_deref().unwrap_or("").to_ascii_lowercase();
+    let symbol = pool.symbol.as_deref().unwrap_or("").to_ascii_lowercase();
+    let chain = pool.chain.as_deref().unwrap_or("").to_ascii_lowercase();
+
+    project == "lido"
+        && chain == "ethereum"
+        && (symbol.contains("steth") || symbol.contains("wsteth"))
+}
+
+fn pick_best_pool(mut pools: Vec<PoolItem>) -> Option<PoolItem> {
+    pools.sort_by(|a, b| {
+        let atvl = a.tvlUsd.unwrap_or(0.0);
+        let btvl = b.tvlUsd.unwrap_or(0.0);
+        btvl.partial_cmp(&atvl).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    pools.into_iter().next()
+}
+
+fn fmt_pct(v: Option<f64>) -> String {
+    v.map(|x| format!("{:.3}%", x)).unwrap_or_else(|| "N/A".to_string())
+}
+
+fn fmt_usd(v: Option<f64>) -> String {
+    match v {
+        Some(x) if x >= 1_000_000_000.0 => format!("${:.2}B", x / 1_000_000_000.0),
+        Some(x) if x >= 1_000_000.0 => format!("${:.2}M", x / 1_000_000.0),
+        Some(x) => format!("${:.0}", x),
+        None => "N/A".to_string(),
     }
-    // Try data.aprs[0].apr
-    if let Some(arr) = body["data"]["aprs"].as_array() {
-        if let Some(first) = arr.first() {
-            if let Some(v) = first["apr"].as_f64() {
-                return Some(v);
-            }
-        }
-    }
-    // Try data.apr directly
-    if let Some(v) = body["data"]["apr"].as_f64() {
-        return Some(v);
-    }
-    None
+}
+
+pub async fn run() -> anyhow::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()?;
+
+    let resp: PoolsResponse = client
+        .get(DEFILLAMA_POOLS_URL)
+        .header("Accept", "application/json")
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let matches: Vec<PoolItem> = resp.data.into_iter().filter(is_target_pool).collect();
+
+    let pool = pick_best_pool(matches)
+        .ok_or_else(|| anyhow::anyhow!("No Lido stETH pool found on DeFiLlama"))?;
+
+    println!("=== Lido stETH APY (via DeFiLlama) ===");
+    println!("Asset:       {}", pool.symbol.as_deref().unwrap_or("N/A"));
+    println!("APY:         {}", fmt_pct(pool.apy));
+    println!("TVL:         {}", fmt_usd(pool.tvlUsd));
+    println!("1D change:   {}", fmt_pct(pool.apyPct1D));
+    println!("7D change:   {}", fmt_pct(pool.apyPct7D));
+    println!("30D change:  {}", fmt_pct(pool.apyPct30D));
+    println!("30D avg APY: {}", fmt_pct(pool.apyMean30d));
+    println!();
+    println!("Note: Data sourced from DeFiLlama (third-party aggregator).");
+    println!("      This is post-10%-fee rate. Rewards compound daily.");
+
+    Ok(())
 }

--- a/skills/lido/src/commands/get_withdrawals.rs
+++ b/skills/lido/src/commands/get_withdrawals.rs
@@ -92,7 +92,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
                     "  Request #{}: {:.6} stETH — {}",
                     id, amount_steth, status
                 );
-                if let Some(wait) = wait_times.as_ref().and_then(|w| w.get(i)) {
+                if let Some(Some(wait)) = wait_times.as_ref().and_then(|w| w.get(i)) {
                     print!(" (est. wait: {})", wait);
                 }
                 println!();
@@ -109,7 +109,7 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn fetch_wait_times(ids: &[u128]) -> Option<Vec<String>> {
+async fn fetch_wait_times(ids: &[u128]) -> Option<Vec<Option<String>>> {
     if ids.is_empty() {
         return None;
     }
@@ -138,15 +138,18 @@ async fn fetch_wait_times(ids: &[u128]) -> Option<Vec<String>> {
     Some(
         arr.iter()
             .map(|entry| {
+                // Finalized requests have no wait — skip the label entirely
+                if entry["status"].as_str() == Some("finalized") {
+                    return None;
+                }
                 entry["requestInfo"]["finalizationIn"]
                     .as_str()
-                    .map(|s| s.to_string())
-                    .or_else(|| {
+                    .map(|s| Some(s.to_string()))
+                    .unwrap_or_else(|| {
                         entry["expectedWaitTimeSeconds"]
                             .as_u64()
                             .map(|s| format!("{}s", s))
                     })
-                    .unwrap_or_else(|| "unknown".to_string())
             })
             .collect(),
     )

--- a/skills/lido/src/config.rs
+++ b/skills/lido/src/config.rs
@@ -11,9 +11,6 @@ pub const WSTETH_ADDRESS: &str = "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0";
 /// WithdrawalQueueERC721 proxy
 pub const WITHDRAWAL_QUEUE_ADDRESS: &str = "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1";
 
-/// Lido REST API base URL
-pub const API_BASE_URL: &str = "https://eth-api.lido.fi";
-
 /// Withdrawal queue REST API base URL
 pub const WQ_API_BASE_URL: &str = "https://wq-api.lido.fi";
 


### PR DESCRIPTION
## Summary

- **get-apy**: replaces `eth-api.lido.fi` (which returns 403/404 on non-local CDN edge nodes) with DeFiLlama `yields.llama.fi/pools`. Filters `project=lido`, `chain=Ethereum`, picks the pool with highest TVL. Now outputs: APY, TVL, 1D/7D/30D change, 30D average APY.
- **get-withdrawals**: finalized requests no longer show `(est. wait: unknown)`. The wq-api returns `status: "finalized"` with `requestInfo: null` for ready-to-claim requests; the binary now suppresses the wait label for these.
- **config.rs**: remove unused `API_BASE_URL` constant (`eth-api.lido.fi`).
- **plugin.yaml**: swap `eth-api.lido.fi` → `yields.llama.fi` in `api_calls`.

## Example output

```
=== Lido stETH APY (via DeFiLlama) ===
Asset:       STETH
APY:         2.378%
TVL:         $21.17B
1D change:   0.020%
7D change:   -0.034%
30D change:  -0.052%
30D avg APY: 2.512%

Note: Data sourced from DeFiLlama (third-party aggregator).
      This is post-10%-fee rate. Rewards compound daily.
```

## Checklist

- [x] `cargo build --release` passes (v0.2.3)
- [x] `git diff upstream/main --name-only` — only lido files
- [x] All 4 version files bumped to 0.2.3
- [x] `api_calls` updated: `eth-api.lido.fi` → `yields.llama.fi`
- [x] SKILL.md updated for `get-apy` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)