### PR TITLE
fix(raydium): v0.1.1 — inject inputAccount for SPL token swaps (REQ_INPUT_ACCOUT_ERROR)

### DIFF
--- a/skills/raydium/.claude-plugin/plugin.json
+++ b/skills/raydium/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/skills/raydium/Cargo.lock
+++ b/skills/raydium/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium/Cargo.toml
+++ b/skills/raydium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium/SKILL.md
+++ b/skills/raydium/SKILL.md
@@ -28,7 +28,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install raydium binary (auto-injected)
 
 ```bash
-if ! command -v raydium >/dev/null 2>&1; then
+REQUIRED_VERSION="0.1.1"
+INSTALLED_VERSION=$(raydium --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -42,9 +44,26 @@ if ! command -v raydium >/dev/null 2>&1; then
     mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+    *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
   esac
+  BASE_URL="https://github.com/okx/plugin-store/releases/download/plugins/raydium@${REQUIRED_VERSION}"
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium@0.1.0/raydium-${TARGET}${EXT}" -o ~/.local/bin/raydium${EXT}
+  curl -fsSL "${BASE_URL}/checksums.txt" -o /tmp/raydium-checksums.txt
+  curl -fsSL "${BASE_URL}/raydium-${TARGET}${EXT}" -o ~/.local/bin/raydium${EXT}
+  EXPECTED=$(grep "raydium-${TARGET}${EXT}" /tmp/raydium-checksums.txt | awk '{print $1}')
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum ~/.local/bin/raydium${EXT} | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 ~/.local/bin/raydium${EXT} | awk '{print $1}')
+  else
+    echo "Warning: cannot verify checksum" && ACTUAL="$EXPECTED"
+  fi
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Checksum mismatch for raydium-${TARGET}${EXT} — aborting install"
+    rm -f ~/.local/bin/raydium${EXT} /tmp/raydium-checksums.txt
+    exit 1
+  fi
+  rm -f /tmp/raydium-checksums.txt
   chmod +x ~/.local/bin/raydium${EXT}
 fi
 ```
@@ -66,7 +85,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium","version":"0.1.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium","version":"0.1.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/raydium/plugin.yaml
+++ b/skills/raydium/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium
-version: "0.1.0"
+version: "0.1.1"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium/plugin.yaml
+++ b/skills/raydium/plugin.yaml
@@ -25,3 +25,4 @@ build:
 api_calls:
   - "https://api-v3.raydium.io"
   - "https://transaction-v1.raydium.io"
+  - "https://api.mainnet-beta.solana.com"

--- a/skills/raydium/src/commands/swap.rs
+++ b/skills/raydium/src/commands/swap.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 use crate::config::{
     DEFAULT_COMPUTE_UNIT_PRICE, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION, PRICE_IMPACT_BLOCK_PCT,
-    PRICE_IMPACT_WARN_PCT, RAYDIUM_AMM_PROGRAM, TX_API_BASE,
+    PRICE_IMPACT_WARN_PCT, RAYDIUM_AMM_PROGRAM, SOL_NATIVE_MINT, SOLANA_RPC_URL, TX_API_BASE,
 };
 use crate::onchainos;
 
@@ -133,9 +133,23 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         );
     }
 
-    // Step 2: Build serialized transaction — must submit immediately after (blockhash ~60s)
+    // Step 2: Resolve input token account (required by Raydium API when input is SPL, not native SOL)
+    let input_account: Option<String> = if args.input_mint != SOL_NATIVE_MINT {
+        let acct = onchainos::get_token_account(&wallet, &args.input_mint, SOLANA_RPC_URL)
+            .await
+            .map_err(|e| anyhow::anyhow!(
+                "Failed to resolve input token account for mint {}: {}. \
+                 Ensure the wallet holds the input token before swapping.",
+                args.input_mint, e
+            ))?;
+        Some(acct)
+    } else {
+        None
+    };
+
+    // Step 3: Build serialized transaction — must submit immediately after (blockhash ~60s)
     let tx_url = format!("{}/transaction/swap-base-in", TX_API_BASE);
-    let tx_body = serde_json::json!({
+    let mut tx_body = serde_json::json!({
         "swapResponse": quote_resp,
         "txVersion": args.tx_version,
         "wallet": wallet,
@@ -143,6 +157,9 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         "unwrapSol": args.unwrap_sol,
         "computeUnitPriceMicroLamports": args.compute_unit_price,
     });
+    if let Some(ref acct) = input_account {
+        tx_body["inputAccount"] = serde_json::Value::String(acct.clone());
+    }
     let tx_resp: Value = client
         .post(&tx_url)
         .json(&tx_body)
@@ -166,7 +183,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         anyhow::bail!("No transactions returned from Raydium API");
     }
 
-    // Step 3: Broadcast each transaction immediately (blockhash expires ~60s)
+    // Step 4: Broadcast each transaction immediately (blockhash expires ~60s)
     let mut results: Vec<Value> = Vec::new();
     for tx_item in transactions {
         let serialized_tx = tx_item["transaction"]

--- a/skills/raydium/src/config.rs
+++ b/skills/raydium/src/config.rs
@@ -7,6 +7,7 @@ pub const USDC_SOLANA: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 pub const DATA_API_BASE: &str = "https://api-v3.raydium.io";
 pub const TX_API_BASE: &str = "https://transaction-v1.raydium.io";
+pub const SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 
 // Raydium AMM V4 program (standard pools — used as --to for onchainos contract-call)
 pub const RAYDIUM_AMM_PROGRAM: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";

--- a/skills/raydium/src/main.rs
+++ b/skills/raydium/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "raydium",
     about = "Raydium AMM plugin — swap, price, and pool queries on Solana",
-    version = "0.1.0"
+    version
 )]
 struct Cli {
     /// Simulate without broadcasting on-chain (no onchainos call)

--- a/skills/raydium/src/onchainos.rs
+++ b/skills/raydium/src/onchainos.rs
@@ -57,6 +57,46 @@ pub async fn wallet_contract_call_solana(
     Ok(serde_json::from_str(&stdout)?)
 }
 
+/// Look up a user's SPL token account address for a given mint via getTokenAccountsByOwner.
+/// Returns the pubkey of the first matching token account.
+/// Used to populate `inputAccount` in Raydium's /transaction/swap-base-in when input is SPL.
+pub async fn get_token_account(owner: &str, mint: &str, rpc_url: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getTokenAccountsByOwner",
+        "params": [
+            owner,
+            { "mint": mint },
+            { "encoding": "base64" }
+        ]
+    });
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let accounts = resp["result"]["value"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Unexpected RPC response for getTokenAccountsByOwner"))?;
+
+    if accounts.is_empty() {
+        anyhow::bail!(
+            "No token account found for mint {} in wallet {} — wallet may not hold this token",
+            mint, owner
+        );
+    }
+
+    accounts[0]["pubkey"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("Missing pubkey in getTokenAccountsByOwner response"))
+}
+
 /// Extract txHash from onchainos response.
 pub fn extract_tx_hash(result: &Value) -> &str {
     result["data"]["txHash"]


### PR DESCRIPTION
## Summary

- **Bug**: `raydium swap` with an SPL token as input (any token that is not native SOL) fails with `REQ_INPUT_ACCOUT_ERROR` from Raydium's `/transaction/swap-base-in` API. SOL→SPL swaps worked because native SOL uses the wallet address directly; SPL→any swaps failed because the request body was missing the `inputAccount` field — the user's Associated Token Account (ATA) for the input mint.
- **Root cause**: `swap.rs` built `tx_body` without `inputAccount`. Raydium's tx API requires this field when the input token is an SPL token so it can include the correct token account in the transaction's account list.
- **Fix**: Before building the transaction, call `getTokenAccountsByOwner` on the Solana RPC to resolve the user's token account for the input mint. Inject as `inputAccount` in `tx_body` when `input_mint != SOL_NATIVE_MINT`. Returns a clear error if the wallet doesn't hold the input token.
- **Also**: Upgraded install guard from existence-check to version-compare + SHA256 checksum; fixed hardcoded `version = "0.1.0"` in clap attribute; added `https://api.mainnet-beta.solana.com` to `plugin.yaml` `api_calls`.
- **Version**: bumped 0.1.0 → 0.1.1 (patch bump)

## Technical Details

- **Language**: Rust
- **Binary**: `raydium`
- **Chains**: Solana (chain 501)
- **APIs**: `https://api-v3.raydium.io`, `https://transaction-v1.raydium.io`, `https://api.mainnet-beta.solana.com`
- **Wallet ops**: `swap` (via `onchainos wallet contract-call --chain 501 --unsigned-tx`)

## Testing

- [ ] `raydium --version` returns `raydium 0.1.1`
- [ ] `raydium swap --input-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --output-mint So11111111111111111111111111111111111111112 --amount 1000000` — succeeds (was: `REQ_INPUT_ACCOUT_ERROR`)
- [ ] `raydium swap --input-mint So11111111111111111111111111111111111111112 --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount 12000000` — still succeeds (SOL→SPL regression check)
- [ ] Wallet with no USDC balance: returns clear error "wallet may not hold this token"

## Checklist

- [x] Source code included (local build)
- [x] Version bumped in all 4 required files + Cargo.lock regenerated
- [x] SKILL.md install guard upgraded: existence-check → version-compare + SHA256 checksum verification
- [x] SKILL.md version references updated (download URL, report block)
- [x] `raydium --version` reads from Cargo.toml via clap `version` attribute
- [x] `plugin.yaml` `api_calls` updated to include Solana RPC endpoint
- [x] Only `skills/raydium/` files in diff
- [x] `.claude-plugin/plugin.json` present and version matches