### PR TITLE
fix(raydium): v0.1.3 — inject inputAccount for SPL token swaps (REQ_INPUT_ACCOUT_ERROR)

### DIFF
--- a/skills/raydium/.claude-plugin/plugin.json
+++ b/skills/raydium/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/skills/raydium/Cargo.lock
+++ b/skills/raydium/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium/Cargo.toml
+++ b/skills/raydium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium/SKILL.md
+++ b/skills/raydium/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.2"
+  version: "0.1.3"
 ---
 
 
@@ -44,7 +44,7 @@ if ! command -v raydium >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium@0.1.2/raydium-${TARGET}${EXT}" -o ~/.local/bin/raydium${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium@0.1.3/raydium-${TARGET}${EXT}" -o ~/.local/bin/raydium${EXT}
   chmod +x ~/.local/bin/raydium${EXT}
 fi
 ```
@@ -66,7 +66,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium","version":"0.1.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium","version":"0.1.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/raydium/plugin.yaml
+++ b/skills/raydium/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium
-version: "0.1.2"
+version: "0.1.3"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky
@@ -25,3 +25,4 @@ build:
 api_calls:
   - "https://api-v3.raydium.io"
   - "https://transaction-v1.raydium.io"
+  - "https://api.mainnet-beta.solana.com"

--- a/skills/raydium/src/commands/swap.rs
+++ b/skills/raydium/src/commands/swap.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::config::{
     parse_human_amount, DEFAULT_COMPUTE_UNIT_PRICE, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION,
     PRICE_IMPACT_BLOCK_PCT, PRICE_IMPACT_WARN_PCT, RAYDIUM_AMM_PROGRAM, SOL_NATIVE_MINT,
-    USDC_SOLANA, TX_API_BASE,
+    SOLANA_RPC_URL, USDC_SOLANA, TX_API_BASE,
 };
 use crate::onchainos;
 
@@ -167,9 +167,23 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         );
     }
 
-    // Step 2: Build serialized transaction - must submit immediately after (blockhash ~60s)
+    // Step 2: Resolve input token account (required by Raydium API when input is SPL, not native SOL)
+    let input_account: Option<String> = if args.input_mint != SOL_NATIVE_MINT {
+        let acct = onchainos::get_token_account(&wallet, &args.input_mint, SOLANA_RPC_URL)
+            .await
+            .map_err(|e| anyhow::anyhow!(
+                "Failed to resolve input token account for mint {}: {}. \
+                 Ensure the wallet holds the input token before swapping.",
+                args.input_mint, e
+            ))?;
+        Some(acct)
+    } else {
+        None
+    };
+
+    // Step 3: Build serialized transaction - must submit immediately after (blockhash ~60s)
     let tx_url = format!("{}/transaction/swap-base-in", TX_API_BASE);
-    let tx_body = serde_json::json!({
+    let mut tx_body = serde_json::json!({
         "swapResponse": quote_resp,
         "txVersion": args.tx_version,
         "wallet": wallet,
@@ -177,6 +191,9 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         "unwrapSol": args.unwrap_sol,
         "computeUnitPriceMicroLamports": args.compute_unit_price,
     });
+    if let Some(ref acct) = input_account {
+        tx_body["inputAccount"] = serde_json::Value::String(acct.clone());
+    }
     let tx_resp: Value = client
         .post(&tx_url)
         .json(&tx_body)
@@ -200,7 +217,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         anyhow::bail!("No transactions returned from Raydium API");
     }
 
-    // Step 3: Broadcast each transaction immediately (blockhash expires ~60s)
+    // Step 4: Broadcast each transaction immediately (blockhash expires ~60s)
     let mut results: Vec<Value> = Vec::new();
     for tx_item in transactions {
         let serialized_tx = tx_item["transaction"]

--- a/skills/raydium/src/config.rs
+++ b/skills/raydium/src/config.rs
@@ -7,6 +7,7 @@ pub const USDC_SOLANA: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
 pub const DATA_API_BASE: &str = "https://api-v3.raydium.io";
 pub const TX_API_BASE: &str = "https://transaction-v1.raydium.io";
+pub const SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 
 // Raydium AMM V4 program (standard pools — used as --to for onchainos contract-call)
 pub const RAYDIUM_AMM_PROGRAM: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";

--- a/skills/raydium/src/onchainos.rs
+++ b/skills/raydium/src/onchainos.rs
@@ -61,6 +61,43 @@ pub async fn wallet_contract_call_solana(
     Ok(serde_json::from_str(&stdout)?)
 }
 
+
+/// Resolve the user's Associated Token Account (ATA) for a given SPL mint via Solana RPC.
+/// Required by Raydium's /transaction/swap-base-in API as `inputAccount` when input is SPL.
+pub async fn get_token_account(owner: &str, mint: &str, rpc_url: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getTokenAccountsByOwner",
+        "params": [
+            owner,
+            { "mint": mint },
+            { "encoding": "base64" }
+        ]
+    });
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let accounts = resp["result"]["value"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Unexpected RPC response: {}", resp))?;
+    if accounts.is_empty() {
+        anyhow::bail!(
+            "No token account found for mint {} in wallet {}. \
+             Ensure the wallet holds this token before swapping.",
+            mint, owner
+        );
+    }
+    accounts[0]["pubkey"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("Missing pubkey in token account response"))
+}
 /// Extract txHash from onchainos response.
 /// Returns an error if txHash is absent, so broadcast failures are not silently masked.
 pub fn extract_tx_hash(result: &Value) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

- **Bug**: `raydium swap` with an SPL token as input (any token that is not native SOL) fails with `REQ_INPUT_ACCOUT_ERROR` from Raydium's `/transaction/swap-base-in` API. SOL→SPL swaps worked because native SOL uses the wallet address directly; SPL→any swaps failed because the request body was missing the `inputAccount` field — the user's Associated Token Account (ATA) for the input mint.
- **Root cause**: `swap.rs` built `tx_body` without `inputAccount`. Raydium's tx API requires this field when the input token is an SPL token so it can include the correct token account in the transaction's account list.
- **Fix**: Before building the transaction, call `getTokenAccountsByOwner` on the Solana RPC (`https://api.mainnet-beta.solana.com`) to resolve the user's token account for the input mint. Inject as `inputAccount` in `tx_body` when `input_mint != SOL_NATIVE_MINT`. Returns a clear error if the wallet doesn't hold the input token.
- **Version**: bumped 0.1.2 → 0.1.3 (patch bump for bug fix)

Supersedes #143 (rebased cleanly on current main at v0.1.2).

## Technical Details

- **Language**: Rust
- **Binary**: `raydium`
- **Chains**: Solana (chain 501)
- **APIs**: `https://api-v3.raydium.io`, `https://transaction-v1.raydium.io`, `https://api.mainnet-beta.solana.com` (new — Solana RPC for ATA lookup)
- **Wallet ops**: `swap` (via `onchainos wallet contract-call --chain 501 --unsigned-tx`)

## Testing

- [x] `raydium --version` returns `raydium 0.1.3`
- [x] `raydium swap --input-mint <SOL> --output-mint <USDC> --amount 0.01` (SOL→SPL) — was already working, still works
- [x] `raydium swap --input-mint <USDC> --output-mint <SOL> --amount 0.5` (SPL→SOL) — previously failed with `REQ_INPUT_ACCOUT_ERROR`, now succeeds
- [x] Live USDC→SOL swap confirmed: tx `5wcbvGzQFsSuhfDFS9j2moHZVRQH7sgYdQtogjx2gn7Z4T111t6nJsghQRhd3rcZvrQTg39JfTYU8se5cUtvoBTN`

## Checklist

- [x] Source code included (local build)
- [x] Version bumped in all 4 required files + Cargo.lock regenerated
- [x] SKILL.md version references updated (frontmatter, download URL, report block)
- [x] Only `skills/raydium/` files in diff (`git diff --name-only upstream/main...HEAD | grep -v '^skills/'` = empty)
- [x] All on-chain writes via onchainos wallet contract-call
- [x] plugin.yaml api_calls updated to include `https://api.mainnet-beta.solana.com`
- [x] .claude-plugin/plugin.json present