### PR TITLE
fix(gmx-v2): pre-flight checks for balance, collateral, ETH fee (v0.2.1)

### DIFF
--- a/skills/gmx-v2/.claude-plugin/plugin.json
+++ b/skills/gmx-v2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gmx-v2",
   "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/GeoGu360/plugin-store/tree/main/skills/gmx-v2",
   "repository": "https://github.com/GeoGu360/plugin-store",

--- a/skills/gmx-v2/Cargo.lock
+++ b/skills/gmx-v2/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "gmx-v2"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/gmx-v2/Cargo.toml
+++ b/skills/gmx-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmx-v2"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/gmx-v2/SKILL.md
+++ b/skills/gmx-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmx-v2
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions. Trigger phrases: open position GMX, close position GMX, GMX trade, GMX leverage, GMX liquidity, deposit GM pool, withdraw GM pool, GMX stop loss, GMX take profit, cancel order GMX, claim funding fees GMX."
-version: 0.2.0
+version: 0.2.1
 author: "GeoGu360"
 tags:
   - perpetuals
@@ -49,7 +49,7 @@ if ! command -v gmx-v2 >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.2.0/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.2.1/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
   chmod +x ~/.local/bin/gmx-v2${EXT}
 fi
 ```
@@ -71,7 +71,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"gmx-v2","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"gmx-v2","version":"0.2.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -250,10 +250,24 @@ gmx-v2 --chain arbitrum open-position \
 
 **Flow:**
 1. Run `--dry-run` to preview calldata and estimated leverage
-2. **Ask user to confirm** market, direction, size, slippage, and execution fee
-3. If collateral allowance is insufficient, the binary prints a NOTE — re-run with `--confirm` flag to approve and open in one step
-4. Submits multicall via `onchainos wallet contract-call`
-5. Keeper executes position within 1–30 seconds
+2. Pre-flight: checks ERC-20 collateral token balance — returns `{"ok":false,"error":"INSUFFICIENT_TOKEN_BALANCE"}` JSON if wallet balance < `--collateral-amount`
+3. Pre-flight: checks GMX `minCollateralUsd` on-chain — returns `{"ok":false,"error":"INSUFFICIENT_COLLATERAL"}` JSON if post-fee collateral would fall below GMX minimum (keeper would cancel immediately)
+4. Pre-flight: checks wallet ETH balance — returns `{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION"}` JSON if ETH < execution fee + gas buffer
+5. **Ask user to confirm** market, direction, size, slippage, and execution fee
+6. If collateral allowance is insufficient, the binary prints a NOTE — re-run with `--confirm` flag to approve and open in one step
+7. Submits multicall via `onchainos wallet contract-call`
+8. Keeper executes position within 1–30 seconds
+
+**Pre-flight error JSON examples:**
+```json
+{"ok":false,"error":"INSUFFICIENT_TOKEN_BALANCE","reason":"Wallet collateral token balance is less than the requested collateral amount.","collateral_token":"0xaf88...","wallet_balance":"500000","wallet_balance_usd":"0.5000","required_amount":"1000000","required_amount_usd":"1.0000","suggestion":"Reduce --collateral-amount to at most 500000 or top up the collateral token."}
+```
+```json
+{"ok":false,"error":"INSUFFICIENT_COLLATERAL","reason":"Post-fee collateral is below GMX minimum. Keeper will cancel the order immediately.","collateral_usd":"1.0000","estimated_open_fee_usd":"0.0050","collateral_after_fee_usd":"0.9950","min_collateral_usd":"1.0000","suggestion":"Increase --collateral-amount so that collateral_after_fee_usd >= min_collateral_usd, or reduce --size-usd to lower the fee."}
+```
+```json
+{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION","reason":"Wallet does not have enough ETH to cover execution fee + gas.","eth_balance":"0.00050000","execution_fee_eth":"0.00100000","gas_buffer_eth":"0.00020000","eth_required":"0.00120000","suggestion":"Top up wallet 0xYourWallet with at least 0.000700 ETH on Arbitrum."}
+```
 
 ---
 

--- a/skills/gmx-v2/plugin.yaml
+++ b/skills/gmx-v2/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: gmx-v2
-version: "0.2.0"
+version: "0.2.1"
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche"
 author:
   name: GeoGu360

--- a/skills/gmx-v2/src/commands/get_orders.rs
+++ b/skills/gmx-v2/src/commands/get_orders.rs
@@ -56,8 +56,7 @@ pub async fn run(chain: &str, args: GetOrdersArgs) -> anyhow::Result<()> {
             "chain": chain,
             "wallet": wallet,
             "count": orders.len(),
-            "orders": orders,
-            "raw": raw
+            "orders": orders
         }))?
     );
     Ok(())

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -171,12 +171,79 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
         0.0
     };
 
+    // Pre-flight check 1 — ERC-20 token balance
+    let token_balance = crate::rpc::check_erc20_balance(
+        cfg.rpc_url, &args.collateral_token, &wallet,
+    ).await.unwrap_or(u128::MAX);
+    if token_balance < args.collateral_amount {
+        let collateral_price_for_check = crate::api::find_price(&tickers, &args.collateral_token)
+            .and_then(|t| t.min_price.as_deref().and_then(|p| p.parse::<u128>().ok()))
+            .unwrap_or(0);
+        let collateral_usd_have = token_balance as f64 * collateral_price_for_check as f64 / 1e30;
+        let collateral_usd_need = args.collateral_amount as f64 * collateral_price_for_check as f64 / 1e30;
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": false,
+            "error": "INSUFFICIENT_TOKEN_BALANCE",
+            "reason": "Wallet collateral token balance is less than the requested collateral amount.",
+            "collateral_token": args.collateral_token,
+            "wallet_balance": token_balance.to_string(),
+            "wallet_balance_usd": format!("{:.4}", collateral_usd_have),
+            "required_amount": args.collateral_amount.to_string(),
+            "required_amount_usd": format!("{:.4}", collateral_usd_need),
+            "suggestion": format!("Reduce --collateral-amount to at most {} or top up the collateral token.", token_balance)
+        }))?);
+        return Ok(());
+    }
+
+    // Pre-flight check 2 — GMX minimum collateral
+    let min_collateral_usd_key = "6497f0f2c47edc68f06ede1c06d3475f939eb1a8341362460277bcd8ee7419f4";
+    let min_collateral_usd_30 = crate::rpc::datastore_get_uint(
+        cfg.datastore, min_collateral_usd_key, cfg.rpc_url,
+    ).await;
+    let collateral_price_raw = crate::api::find_price(&tickers, &args.collateral_token)
+        .and_then(|t| t.min_price.as_deref().and_then(|p| p.parse::<u128>().ok()))
+        .unwrap_or(0);
+    let collateral_usd_30 = (args.collateral_amount as u128).saturating_mul(collateral_price_raw);
+    let estimated_fee_30 = size_delta_usd / 1000; // 0.1% conservative open fee
+    if min_collateral_usd_30 > 0 && collateral_usd_30 < min_collateral_usd_30.saturating_add(estimated_fee_30) {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": false,
+            "error": "INSUFFICIENT_COLLATERAL",
+            "reason": "Post-fee collateral is below GMX minimum. Keeper will cancel the order immediately.",
+            "collateral_usd": format!("{:.4}", collateral_usd_30 as f64 / 1e30),
+            "estimated_open_fee_usd": format!("{:.4}", estimated_fee_30 as f64 / 1e30),
+            "collateral_after_fee_usd": format!("{:.4}", collateral_usd_30.saturating_sub(estimated_fee_30) as f64 / 1e30),
+            "min_collateral_usd": format!("{:.4}", min_collateral_usd_30 as f64 / 1e30),
+            "suggestion": "Increase --collateral-amount so that collateral_after_fee_usd >= min_collateral_usd, or reduce --size-usd to lower the fee."
+        }))?);
+        return Ok(());
+    }
+
+    // Pre-flight check 3 — ETH execution fee
+    let eth_balance = crate::rpc::get_eth_balance(&wallet, cfg.rpc_url).await;
+    let gas_margin: u128 = 200_000_000_000_000; // 0.0002 ETH conservative gas buffer
+    let eth_required = execution_fee.saturating_add(gas_margin);
+    if eth_balance < eth_required {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": false,
+            "error": "INSUFFICIENT_ETH_FOR_EXECUTION",
+            "reason": "Wallet does not have enough ETH to cover execution fee + gas.",
+            "eth_balance": format!("{:.8}", eth_balance as f64 / 1e18),
+            "execution_fee_eth": format!("{:.8}", execution_fee as f64 / 1e18),
+            "gas_buffer_eth": format!("{:.8}", gas_margin as f64 / 1e18),
+            "eth_required": format!("{:.8}", eth_required as f64 / 1e18),
+            "suggestion": format!("Top up wallet {} with at least {:.6} ETH on Arbitrum.",
+                wallet, (eth_required.saturating_sub(eth_balance)) as f64 / 1e18)
+        }))?);
+        return Ok(());
+    }
+
     // Preview
     eprintln!("=== Open Position Preview ===");
     eprintln!("Market: {}", market.name.as_deref().unwrap_or("?"));
     eprintln!("Direction: {}", if args.long { "LONG" } else { "SHORT" });
     eprintln!("Size: ${:.2} USD", args.size_usd);
-    eprintln!("Collateral: {} units", args.collateral_amount);
+    eprintln!("Collateral: {} units (${:.4} USD)", args.collateral_amount, collateral_usd_30 as f64 / 1e30);
     eprintln!("Current price: ${:.4}", mid_price_usd);
     eprintln!("Acceptable price: {}", acceptable_price);
     eprintln!("Execution fee: {} wei", execution_fee);

--- a/skills/gmx-v2/src/rpc.rs
+++ b/skills/gmx-v2/src/rpc.rs
@@ -33,6 +33,42 @@ pub async fn eth_call(to: &str, data: &str, rpc_url: &str) -> anyhow::Result<Str
     Ok(result)
 }
 
+/// Query ERC-20 balanceOf(address) — returns None on RPC failure
+pub async fn check_erc20_balance(rpc_url: &str, token: &str, owner: &str) -> Option<u128> {
+    let owner_clean = owner.trim_start_matches("0x");
+    let calldata = format!("0x70a08231{:0>64}", owner_clean);
+    let result = eth_call(token, &calldata, rpc_url).await.ok()?;
+    let hex = result.trim_start_matches("0x");
+    u128::from_str_radix(hex, 16).ok()
+}
+
+/// Query GMX DataStore getUint(bytes32) — returns 0 on failure
+pub async fn datastore_get_uint(datastore: &str, key: &str, rpc_url: &str) -> u128 {
+    let calldata = format!("0xbd02d0f5{:0>64}", key);
+    match eth_call(datastore, &calldata, rpc_url).await {
+        Ok(result) => {
+            let hex = result.trim_start_matches("0x");
+            u128::from_str_radix(&hex[hex.len().saturating_sub(32)..], 16).unwrap_or(0)
+        }
+        Err(_) => 0,
+    }
+}
+
+/// Query native ETH balance (wei) for an address — returns 0 on failure
+pub async fn get_eth_balance(address: &str, rpc_url: &str) -> u128 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "method": "eth_getBalance",
+        "params": [address, "latest"], "id": 1
+    });
+    let resp: serde_json::Value = match client.post(rpc_url).json(&body).send().await {
+        Ok(r) => match r.json().await { Ok(v) => v, Err(_) => return 0 },
+        Err(_) => return 0,
+    };
+    let hex = resp["result"].as_str().unwrap_or("0x0").trim_start_matches("0x");
+    u128::from_str_radix(hex, 16).unwrap_or(0)
+}
+
 /// Decode a bytes32 from eth_call result at a given 32-byte slot offset
 pub fn decode_bytes32(hex_data: &str, slot: usize) -> Option<String> {
     let data = hex_data.trim_start_matches("0x");


### PR DESCRIPTION
## Problem

Orders were silently created on-chain then immediately cancelled by the GMX keeper because post-fee collateral fell below the `minCollateralUsd` threshold ($1.00 on Arbitrum). The error (`0xc4bc1211`) was visible in the `OrderCancelled` event but not surfaced to the user — the skill returned `ok: true` with a tx hash, misleading agents into thinking the position had opened.

## Changes

### Pre-flight checks in `open-position` (fail fast with structured JSON)

1. **ERC-20 token balance** — checks wallet holds enough collateral token before building any calldata
2. **GMX minCollateralUsd** — queries DataStore on-chain (`getUint(0x6497f0...)`), estimates 0.1% open fee, aborts if `collateral_after_fee < minCollateralUsd`
3. **ETH execution fee** — checks wallet ETH balance ≥ `execution_fee + 0.0002 ETH` gas buffer

All three return `{"ok": false, "error": "<CODE>", "reason": "...", "suggestion": "..."}` instead of throwing exceptions, so calling agents can parse and act on them.

### `get-orders` cleanup

Removed `"raw"` hex field from output (was leaking the full RPC response).

## Error codes

| Code | Trigger |
|---|---|
| `INSUFFICIENT_TOKEN_BALANCE` | wallet collateral balance < `--collateral-amount` |
| `INSUFFICIENT_COLLATERAL` | post-fee collateral < GMX `minCollateralUsd` |
| `INSUFFICIENT_ETH_FOR_EXECUTION` | ETH balance < execution fee + gas buffer |

## Version

`0.2.0` → `0.2.1` (patch: bugfix + pre-flight guards)

## Checklist

- [x] `cargo build` passes (no warnings)
- [x] `plugin-store lint` passes
- [x] Version bumped in all 4 files
- [x] SKILL.md updated with new Flow steps and error JSON examples
- [x] `api_calls` unchanged (no new external domains)
- [x] diff scoped to `skills/gmx-v2/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)