### PR TITLE
fix(polymarket): fix install block — version check, report version, remove duplicate section

### DIFF
--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -32,7 +32,9 @@ npx skills add okx/plugin-store --skill plugin-store --yes --global
 ### Install polymarket binary (auto-injected)
 
 ```bash
-if ! command -v polymarket >/dev/null 2>&1; then
+REQUIRED_VERSION="0.2.3"
+INSTALLED_VERSION=$(polymarket --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
   OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
@@ -46,9 +48,26 @@ if ! command -v polymarket >/dev/null 2>&1; then
     mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+    *) echo "Unsupported platform: ${OS}_${ARCH}"; exit 1 ;;
   esac
+  BASE_URL="https://github.com/okx/plugin-store/releases/download/plugins/polymarket@${REQUIRED_VERSION}"
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.3/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  curl -fsSL "${BASE_URL}/checksums.txt" -o /tmp/polymarket-checksums.txt
+  curl -fsSL "${BASE_URL}/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  EXPECTED=$(grep "polymarket-${TARGET}${EXT}" /tmp/polymarket-checksums.txt | awk '{print $1}')
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum ~/.local/bin/polymarket${EXT} | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 ~/.local/bin/polymarket${EXT} | awk '{print $1}')
+  else
+    echo "Warning: cannot verify checksum (no sha256sum or shasum found)" && ACTUAL="$EXPECTED"
+  fi
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Checksum mismatch for polymarket-${TARGET}${EXT} — aborting install"
+    rm -f ~/.local/bin/polymarket${EXT} /tmp/polymarket-checksums.txt
+    exit 1
+  fi
+  rm -f /tmp/polymarket-checksums.txt
   chmod +x ~/.local/bin/polymarket${EXT}
 fi
 ```
@@ -67,21 +86,13 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket","version":"0.2.3"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"polymarket","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
   touch "$REPORT_FLAG"
 fi
 ```
-
----
-
-## Pre-flight Dependencies
-
-> Run once per session before first use.
-
-### Install polymarket binary
 
 ---
 


### PR DESCRIPTION
## Summary

- **Install block**: replaced `if ! command -v` (presence-only check) with `REQUIRED_VERSION="0.2.3"` + version comparison — stale binaries are now upgraded instead of skipped. Also added checksum verification and unsupported-platform exit.
- **Report block**: `"version":"0.2.1"` → `"version":"0.2.3"` (was stale after the v0.2.1 → v0.2.3 bump).
- **Duplicate section**: removed leftover empty `## Pre-flight Dependencies` block.

## Test plan

- [ ] `polymarket --version` returns `0.2.3` after running the install block
- [ ] Running the install block when an older version is installed triggers a re-download
- [ ] Report curl fires once and sets the flag file

🤖 Generated with [Claude Code](https://claude.com/claude-code)