### PR TITLE
fix(pancakeswap): add Pre-flight Dependencies section with onchainos install guidance (v0.2.3)

### DIFF
--- a/skills/pancakeswap/.claude-plugin/plugin.json
+++ b/skills/pancakeswap/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/pancakeswap/Cargo.toml
+++ b/skills/pancakeswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap/SKILL.md
+++ b/skills/pancakeswap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
-version: "0.2.2"
+version: "0.2.3"
 author: "GeoGu360"
 tags:
   - dex
@@ -37,12 +37,77 @@ Do NOT use for: PancakeSwap V2 AMM swaps (use pancakeswap-v2 skill), concentrate
 
 
 
+## Pre-flight Dependencies (auto-injected by Plugin Store CI)
+
+> Run once per session before first use. These checks ensure required tools are installed.
+
+### Install onchainos CLI + Skills (auto-injected)
+
+```bash
+# 1. Install onchainos CLI
+onchainos --version 2>/dev/null || curl -fsSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
+
+# 2. Install onchainos skills (enables AI agent to use onchainos commands)
+npx skills add okx/onchainos-skills --yes --global
+
+# 3. Install plugin-store skills (enables plugin discovery and management)
+npx skills add okx/plugin-store --skill plugin-store --yes --global
+```
+
+### Install pancakeswap binary (auto-injected)
+
+```bash
+if ! command -v pancakeswap >/dev/null 2>&1; then
+  OS=$(uname -s | tr A-Z a-z)
+  ARCH=$(uname -m)
+  EXT=""
+  case "${OS}_${ARCH}" in
+    darwin_arm64)  TARGET="aarch64-apple-darwin" ;;
+    darwin_x86_64) TARGET="x86_64-apple-darwin" ;;
+    linux_x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+    linux_i686)    TARGET="i686-unknown-linux-gnu" ;;
+    linux_aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+    linux_armv7l)  TARGET="armv7-unknown-linux-gnueabihf" ;;
+    mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
+    mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
+    mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+  esac
+  mkdir -p ~/.local/bin
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap@0.2.3/pancakeswap-${TARGET}${EXT}" -o ~/.local/bin/pancakeswap${EXT}
+  chmod +x ~/.local/bin/pancakeswap${EXT}
+fi
+```
+
+### Report install (auto-injected, runs once)
+
+```bash
+REPORT_FLAG="$HOME/.plugin-store/reported/pancakeswap"
+if [ ! -f "$REPORT_FLAG" ]; then
+  mkdir -p "$HOME/.plugin-store/reported"
+  DEV_RAW="$(hostname):$(uname -s):$(uname -m):$HOME"
+  DEV_ID=$(echo -n "$DEV_RAW" | shasum -a 256 | head -c 32)
+  _K=$(echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | base64 -d 2>/dev/null || echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | openssl base64 -d)
+  HMAC_SIG=$(echo -n "${_K}${DEV_ID}" | shasum -a 256 | head -c 8)
+  DIV_ID="${DEV_ID}${HMAC_SIG}"
+  unset _K
+  curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"pancakeswap","version":"0.2.3"}' >/dev/null 2>&1 || true
+  curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
+    -H "Content-Type: application/json" \
+    -d '{"pluginName":"pancakeswap","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
+  touch "$REPORT_FLAG"
+fi
+```
+
+---
+
 ## Pre-flight Checks
 
 Before executing any write command, verify:
 
-1. **Binary installed**: `pancakeswap --version` — if not found, install the plugin via the OKX plugin store
-2. **Wallet connected**: `onchainos wallet status` — confirm wallet is logged in and active address is set
+1. **Binary installed**: `pancakeswap --version` — if not found, run the install script above
+2. **Wallet connected**: `onchainos wallet addresses` — confirm wallet is logged in and active address is set
 3. **Chain supported**: target chain must be BNB Chain (56), Base (8453), or Arbitrum (42161)
 
 If the wallet is not connected, output:

--- a/skills/pancakeswap/plugin.yaml
+++ b/skills/pancakeswap/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap
-version: "0.2.2"
+version: "0.2.3"
 description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360


### PR DESCRIPTION
## Summary

- Add missing `## Pre-flight Dependencies (auto-injected by Plugin Store CI)` section to `SKILL.md` — this section was present in all other skills (lido, hyperliquid, etherfi, morpho, pendle) but completely absent in pancakeswap
- Fix `onchainos wallet status` → `onchainos wallet addresses` in Pre-flight Checks (consistent with other skills)

## What was missing

Without this section, users installing pancakeswap for the first time had no guidance to:
1. Install the `onchainos` CLI (`install.sh` bootstrap script)
2. Download the `pancakeswap` binary (9-platform download script)
3. Run the install report (HMAC-signed device token)

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | Add Pre-flight Dependencies section (onchainos install + binary download + report) |
| `SKILL.md` | Fix `onchainos wallet status` → `onchainos wallet addresses` |
| `plugin.yaml` / `Cargo.toml` / `plugin.json` | Version bump 0.2.2 → 0.2.3 |

## Test plan

- [x] Pre-flight Dependencies section matches structure used by lido, hyperliquid, etherfi
- [x] Binary download script covers all 9 CI target platforms
- [x] Version bumped to 0.2.3 in all 4 files
- [x] `git diff upstream/main --name-only` shows only pancakeswap files

🤖 Generated with [Claude Code](https://claude.com/claude-code)