### PR TITLE
fix(meteora): on-chain positions, WSOL wrap, close fix, retry logic (v0.3.3)

### DIFF
--- a/skills/meteora/.claude-plugin/plugin.json
+++ b/skills/meteora/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "meteora",
   "description": "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/skills/meteora/Cargo.lock
+++ b/skills/meteora/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meteora"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/meteora/Cargo.toml
+++ b/skills/meteora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meteora"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/meteora/SKILL.md
+++ b/skills/meteora/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meteora
 description: "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity"
-version: "0.3.2"
+version: "0.3.3"
 tags:
   - solana
   - dex
@@ -44,7 +44,7 @@ if ! command -v meteora >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora@0.3.2/meteora-${TARGET}${EXT}" -o ~/.local/bin/meteora${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora@0.3.3/meteora-${TARGET}${EXT}" -o ~/.local/bin/meteora${EXT}
   chmod +x ~/.local/bin/meteora${EXT}
 fi
 ```
@@ -63,7 +63,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"meteora","version":"0.3.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"meteora","version":"0.3.3"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"meteora","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -76,10 +76,11 @@ fi
 
 ## Architecture
 
-- **Read operations** (`get-pools`, `get-pool-detail`, `get-swap-quote`, `get-user-positions`) → direct REST API calls to `https://dlmm.datapi.meteora.ag`; no wallet or confirmation needed
+- **Read operations** (`get-pools`, `get-pool-detail`, `get-swap-quote`) → direct REST API calls to `https://dlmm.datapi.meteora.ag`; no wallet or confirmation needed
+- **`get-user-positions`** → queries on-chain via Solana `getProgramAccounts` + BinArray accounts; computes token amounts directly from chain state; no wallet or confirmation needed
 - **Swap** (`swap`) → after user confirmation, executes via `onchainos swap execute --chain solana`; CLI handles signing and broadcast automatically
-- **Add liquidity** (`add-liquidity`) → builds a Solana transaction natively in Rust (initialize position + add liquidity instructions), submits via `onchainos wallet contract-call --chain 501`; uses SpotBalanced strategy distributing tokens across 70-bin position centered at active bin
-- **Remove liquidity** (`remove-liquidity`) → builds a `removeLiquidityByRange` instruction and optionally a `closePosition` instruction, submits via `onchainos wallet contract-call --chain 501`; 600k compute budget requested
+- **Add liquidity** (`add-liquidity`) → builds a Solana transaction natively in Rust (initialize position + add liquidity instructions), submits via `onchainos wallet contract-call --chain 501`; uses SpotBalanced strategy distributing tokens across 70-bin position centered at active bin; auto-wraps SOL to WSOL when needed; retries once on simulation errors
+- **Remove liquidity** (`remove-liquidity`) → builds `removeLiquidityByRange` + optional `claimFee` + `closePositionIfEmpty` instructions, submits via `onchainos wallet contract-call --chain 501`; 600k compute budget requested
 
 ## Supported Operations
 
@@ -133,13 +134,20 @@ meteora get-swap-quote --from-token So11111111111111111111111111111111111111112 
 
 ### get-user-positions — View LP positions
 
-View a user's DLMM LP positions including token amounts, bin ranges, and unclaimed fees.
+View a user's DLMM LP positions with token amounts computed from on-chain BinArray data.
 
 ```
 meteora get-user-positions [--wallet <address>] [--pool <pool_address>]
 ```
 
 If `--wallet` is omitted, uses the currently logged-in onchainos wallet.
+
+**Output fields per position:** `position_address`, `pool_address`, `owner`,
+  `token_x_mint`, `token_y_mint`, `token_x_amount`, `token_y_amount`,
+  `token_x_decimals`, `token_y_decimals`,
+  `bin_range` (lower_bin_id / upper_bin_id), `active_bins`, `source`
+
+> Use `position_address` directly as `--position` when calling `remove-liquidity`.
 
 **Examples:**
 ```

--- a/skills/meteora/plugin.yaml
+++ b/skills/meteora/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: meteora
-version: "0.3.2"
+version: "0.3.3"
 description: "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, executing swaps, and adding liquidity on Solana"
 author:
   name: "skylavis-sky"

--- a/skills/meteora/src/commands/add_liquidity.rs
+++ b/skills/meteora/src/commands/add_liquidity.rs
@@ -60,6 +60,10 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
     let reserve_x = Pubkey::from(pool.reserve_x);
     let reserve_y = Pubkey::from(pool.reserve_y);
 
+    // Native SOL mint — used to detect when WSOL wrap is needed
+    const WSOL_MINT: Pubkey =
+        solana_pubkey::pubkey!("So11111111111111111111111111111111111111112");
+
     // ── 3. Fetch token decimals ──────────────────────────────────────────────
     let mint_x_str = token_x_mint.to_string();
     let mint_y_str = token_y_mint.to_string();
@@ -183,99 +187,154 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
 
     // ATAs are created on-the-fly in the instruction list if missing.
 
-    // ── 10. Check bin array existence & get blockhash ───────────────────────
-    // Sequential to avoid saturating the public RPC rate limit
-    // (steps 3 and 7 already fired 5+ concurrent calls).
+    // ── 10-13. Build + submit with one automatic retry ───────────────────────
+    // After closing a position, the Solana RPC may briefly return stale account
+    // states (e.g. position still exists, or a bin array incorrectly missing).
+    // If the first attempt fails with a simulation error, we wait 2 s, re-check
+    // all mutable account states, rebuild the instruction list, and retry once.
     let bin_arr_lower_str = bin_array_lower.to_string();
     let bin_arr_upper_str = bin_array_upper.to_string();
-    let bin_arr_lower_exists = solana_rpc::account_exists(&client, &bin_arr_lower_str).await?;
-    let bin_arr_upper_exists = solana_rpc::account_exists(&client, &bin_arr_upper_str).await?;
-    let blockhash = solana_rpc::get_latest_blockhash(&client).await?;
 
-    // ── 11. Build instructions ───────────────────────────────────────────────
-    let mut instructions = Vec::new();
+    let mut last_result = serde_json::Value::Null;
+    let mut last_ok = false;
 
-    // Create ATAs if missing (idempotent — safe to include even if they exist)
-    if !ata_x_exists {
-        instructions.push(meteora_ix::ix_create_ata_idempotent(
-            &wallet, &user_token_x, &wallet, &token_x_mint,
-        ));
-    }
-    if !ata_y_exists {
-        instructions.push(meteora_ix::ix_create_ata_idempotent(
-            &wallet, &user_token_y, &wallet, &token_y_mint,
-        ));
-    }
+    for attempt in 0u32..2 {
+        if attempt > 0 {
+            eprintln!("[retry] Simulation failed — waiting 2 s then re-checking account states...");
+            tokio::time::sleep(std::time::Duration::from_millis(2_000)).await;
+        }
 
-    // Initialize bin arrays if they don't exist (required before adding liquidity)
-    if !bin_arr_lower_exists {
-        instructions.push(meteora_ix::ix_initialize_bin_array(
+        // Re-check mutable account states on every attempt so the instruction
+        // list always reflects the current on-chain reality.
+        let ba_lower_exists = solana_rpc::account_exists(&client, &bin_arr_lower_str).await?;
+        let ba_upper_exists = solana_rpc::account_exists(&client, &bin_arr_upper_str).await?;
+        let pos_exists_now = solana_rpc::account_exists(&client, &pos_str).await?;
+        let blockhash = solana_rpc::get_latest_blockhash(&client).await?;
+
+        eprintln!(
+            "[attempt {}] bin_array_lower_exists={} bin_array_upper_exists={} position_exists={}",
+            attempt + 1, ba_lower_exists, ba_upper_exists, pos_exists_now
+        );
+
+        let mut instructions = Vec::new();
+
+        // Request extra compute budget — add_liquidity_by_strategy with position
+        // init can exceed the default 200k CU limit.
+        instructions.push(meteora_ix::ix_set_compute_unit_limit(600_000));
+
+        // Create ATAs if missing (idempotent — safe to include even if they exist)
+        if !ata_x_exists {
+            instructions.push(meteora_ix::ix_create_ata_idempotent(
+                &wallet, &user_token_x, &wallet, &token_x_mint,
+            ));
+        }
+        if !ata_y_exists {
+            instructions.push(meteora_ix::ix_create_ata_idempotent(
+                &wallet, &user_token_y, &wallet, &token_y_mint,
+            ));
+        }
+
+        // Wrap SOL → WSOL if token_x is the native SOL mint and amount_x > 0.
+        // Transfers SOL to the WSOL ATA and syncs its token balance, ensuring
+        // add_liquidity_by_strategy can debit the correct token amount.
+        if token_x_mint == WSOL_MINT && amount_x_raw > 0 {
+            instructions.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_x, amount_x_raw));
+            instructions.push(meteora_ix::ix_sync_native(&user_token_x));
+        }
+        if token_y_mint == WSOL_MINT && amount_y_raw > 0 {
+            instructions.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_y, amount_y_raw));
+            instructions.push(meteora_ix::ix_sync_native(&user_token_y));
+        }
+
+        // Initialize bin arrays only if they genuinely don't exist.
+        if !ba_lower_exists {
+            instructions.push(meteora_ix::ix_initialize_bin_array(
+                &lb_pair,
+                &bin_array_lower,
+                &wallet,
+                lower_idx,
+            ));
+        }
+        if lower_idx != upper_idx && !ba_upper_exists {
+            instructions.push(meteora_ix::ix_initialize_bin_array(
+                &lb_pair,
+                &bin_array_upper,
+                &wallet,
+                upper_idx,
+            ));
+        }
+
+        if !pos_exists_now {
+            instructions.push(meteora_ix::ix_initialize_position_pda(
+                &wallet,
+                &lb_pair,
+                &position,
+                pos_lower,
+                width,
+            ));
+        }
+
+        instructions.push(meteora_ix::ix_add_liquidity_by_strategy(
+            &position,
             &lb_pair,
+            &user_token_x,
+            &user_token_y,
+            &reserve_x,
+            &reserve_y,
+            &token_x_mint,
+            &token_y_mint,
             &bin_array_lower,
-            &wallet,
-            lower_idx,
-        ));
-    }
-    // Only add upper if it's a different bin array
-    if lower_idx != upper_idx && !bin_arr_upper_exists {
-        instructions.push(meteora_ix::ix_initialize_bin_array(
-            &lb_pair,
             &bin_array_upper,
             &wallet,
-            upper_idx,
+            amount_x_raw,
+            amount_y_raw,
+            pool.active_id,
+            args.bin_range, // max_active_bin_slippage
+            effective_liq_lower,
+            effective_liq_upper,
         ));
+
+        let tx_b58 = meteora_ix::build_tx_b58(&instructions, &wallet, blockhash)?;
+        eprintln!("[debug] unsigned_tx_b58={}", &tx_b58[..32]);
+        eprintln!("[debug] num_instructions={}", instructions.len());
+
+        let result = onchainos::contract_call_solana(&tx_b58, &meteora_ix::DLMM_PROGRAM.to_string())?;
+        let ok = result["ok"].as_bool().unwrap_or(false)
+            || result["data"]["ok"].as_bool().unwrap_or(false);
+
+        if ok {
+            last_result = result;
+            last_ok = true;
+            break;
+        }
+
+        // Check if this is a simulation/transient error worth retrying.
+        let err_str = result
+            .get("error")
+            .or_else(|| result["data"].get("error"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let is_retryable = err_str.contains("simulation")
+            || err_str.contains("ProgramAccountNotFound")
+            || err_str.contains("BlockhashNotFound")
+            || err_str.contains("stale");
+
+        last_result = result;
+        if !is_retryable || attempt >= 1 {
+            break;
+        }
+        eprintln!("[retry] Retryable error detected: {err_str}");
     }
 
-    if !position_exists {
-        instructions.push(meteora_ix::ix_initialize_position_pda(
-            &wallet,
-            &lb_pair,
-            &position,
-            pos_lower,
-            width,
-        ));
-    }
-
-    instructions.push(meteora_ix::ix_add_liquidity_by_strategy(
-        &position,
-        &lb_pair,
-        &user_token_x,
-        &user_token_y,
-        &reserve_x,
-        &reserve_y,
-        &token_x_mint,
-        &token_y_mint,
-        &bin_array_lower,
-        &bin_array_upper,
-        &wallet,
-        amount_x_raw,
-        amount_y_raw,
-        pool.active_id,
-        args.bin_range, // max_active_bin_slippage
-        effective_liq_lower,
-        effective_liq_upper,
-    ));
-
-    // ── 12. Build & encode transaction ───────────────────────────────────────
-    let tx_b58 = meteora_ix::build_tx_b58(&instructions, &wallet, blockhash)?;
-
-    // Debug: print tx for manual simulation if needed
-    eprintln!("[debug] unsigned_tx_b58={}", &tx_b58[..32]);
-    eprintln!("[debug] num_instructions={}", instructions.len());
-
-    // ── 13. Send via onchainos ───────────────────────────────────────────────
-    let result = onchainos::contract_call_solana(&tx_b58, &meteora_ix::DLMM_PROGRAM.to_string())?;
-
-    let tx_hash = result["data"]["txHash"]
+    let tx_hash = last_result["data"]["txHash"]
         .as_str()
-        .or_else(|| result["txHash"].as_str())
+        .or_else(|| last_result["txHash"].as_str())
         .unwrap_or("pending")
         .to_string();
 
-    let ok = result["ok"].as_bool().unwrap_or(false);
-
     let output = json!({
-        "ok": ok,
+        "ok": last_ok,
         "pool": args.pool,
         "wallet": wallet_str,
         "position": position.to_string(),
@@ -287,7 +346,7 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
         } else {
             String::new()
         },
-        "raw_result": result,
+        "raw_result": last_result,
     });
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())

--- a/skills/meteora/src/commands/get_user_positions.rs
+++ b/skills/meteora/src/commands/get_user_positions.rs
@@ -1,8 +1,11 @@
 use clap::Args;
 use reqwest::Client;
 use serde_json::json;
+use solana_pubkey::Pubkey;
+use std::collections::HashMap;
+use std::str::FromStr;
 
-use crate::api::MeteoraClient;
+use crate::meteora_ix;
 use crate::meteora_ix::DLMM_PROGRAM;
 use crate::onchainos;
 use crate::solana_rpc;
@@ -19,12 +22,13 @@ pub struct GetUserPositionsArgs {
 }
 
 pub async fn execute(args: &GetUserPositionsArgs) -> anyhow::Result<()> {
-    // Resolve wallet address
     let wallet = if let Some(w) = &args.wallet {
         w.clone()
     } else {
         onchainos::resolve_wallet_solana().map_err(|e| {
-            anyhow::anyhow!("Cannot resolve wallet address. Pass --wallet <address> or log in via onchainos.\nError: {e}")
+            anyhow::anyhow!(
+                "Cannot resolve wallet address. Pass --wallet <address> or log in via onchainos.\nError: {e}"
+            )
         })?
     };
 
@@ -32,63 +36,11 @@ pub async fn execute(args: &GetUserPositionsArgs) -> anyhow::Result<()> {
         anyhow::bail!("Wallet address is empty. Pass --wallet <address> or log in via onchainos.");
     }
 
-    // ── 1. Try Meteora REST API ──────────────────────────────────────────────
-    let api_client = MeteoraClient::new();
-    let mut api_positions = api_client.get_positions(&wallet).await?;
+    let client = Client::new();
 
-    // Filter by pool if specified
-    if let Some(pool_addr) = &args.pool {
-        api_positions.retain(|p| p.pair_address == *pool_addr);
-    }
-
-    if !api_positions.is_empty() {
-        // API returned data — use it (has USD values, fees, bin amounts)
-        let total_value_usd: f64 = api_positions.iter().map(|p| p.total_value_usd).sum();
-        let total_fee_usd: f64 = api_positions.iter().map(|p| p.total_fee_usd).sum();
-
-        let positions_out: Vec<serde_json::Value> = api_positions
-            .iter()
-            .map(|p| {
-                json!({
-                    "position_address": p.address,
-                    "pool_address": p.pair_address,
-                    "owner": p.owner,
-                    "token_x_amount": p.total_x_amount,
-                    "token_y_amount": p.total_y_amount,
-                    "fee_x_unclaimed": p.fee_x,
-                    "fee_y_unclaimed": p.fee_y,
-                    "total_fee_usd": p.total_fee_usd,
-                    "total_value_usd": p.total_value_usd,
-                    "bin_range": {
-                        "lower_bin_id": p.lower_bin_id,
-                        "upper_bin_id": p.upper_bin_id,
-                    },
-                    "bin_data_count": p.data.len(),
-                    "source": "api",
-                })
-            })
-            .collect();
-
-        let output = json!({
-            "ok": true,
-            "wallet": wallet,
-            "positions_count": positions_out.len(),
-            "summary": {
-                "total_value_usd": total_value_usd,
-                "total_unclaimed_fees_usd": total_fee_usd,
-            },
-            "positions": positions_out,
-        });
-        println!("{}", serde_json::to_string_pretty(&output)?);
-        return Ok(());
-    }
-
-    // ── 2. API returned empty — fall back to on-chain RPC ───────────────────
-    eprintln!("[info] Meteora API returned no positions; querying on-chain via getProgramAccounts...");
-
-    let rpc_client = Client::new();
+    eprintln!("[info] Querying on-chain positions via getProgramAccounts...");
     let chain_positions = solana_rpc::get_dlmm_positions_by_owner(
-        &rpc_client,
+        &client,
         &DLMM_PROGRAM.to_string(),
         &wallet,
         args.pool.as_deref(),
@@ -99,39 +51,143 @@ pub async fn execute(args: &GetUserPositionsArgs) -> anyhow::Result<()> {
         let output = json!({
             "ok": true,
             "wallet": wallet,
+            "positions_count": 0,
             "positions": [],
-            "message": "No positions found for this wallet (checked API and on-chain)",
+            "message": "No DLMM positions found for this wallet.",
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
         return Ok(());
     }
 
-    // On-chain data has no USD values — return structural info only
-    let positions_out: Vec<serde_json::Value> = chain_positions
-        .iter()
-        .map(|p| {
-            json!({
-                "position_address": p.address,
-                "pool_address": p.lb_pair,
-                "owner": p.owner,
-                "bin_range": {
-                    "lower_bin_id": p.lower_bin_id,
-                    "upper_bin_id": p.upper_bin_id,
-                },
-                "source": "on-chain",
-                "note": "USD values unavailable (API indexing delay); use position_address with remove-liquidity --position",
-            })
-        })
-        .collect();
+    let mut positions_out: Vec<serde_json::Value> = Vec::new();
+    for pos in &chain_positions {
+        match enrich_position(&client, pos).await {
+            Ok(v) => positions_out.push(v),
+            Err(e) => {
+                eprintln!("[warn] Failed to enrich position {}: {e}", pos.address);
+                positions_out.push(json!({
+                    "position_address": pos.address,
+                    "pool_address": pos.lb_pair,
+                    "owner": pos.owner,
+                    "bin_range": {
+                        "lower_bin_id": pos.lower_bin_id,
+                        "upper_bin_id": pos.upper_bin_id,
+                    },
+                    "error": e.to_string(),
+                    "source": "on-chain",
+                }));
+            }
+        }
+    }
 
     let output = json!({
         "ok": true,
         "wallet": wallet,
         "positions_count": positions_out.len(),
-        "source": "on-chain",
-        "note": "Meteora API has not yet indexed these positions. Bin range and addresses are accurate.",
+        "note": "Token amounts are estimated from on-chain BinArray state and may differ slightly from exact withdrawable amounts due to rounding and in-flight trades.",
         "positions": positions_out,
     });
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
+}
+
+async fn enrich_position(
+    client: &Client,
+    pos: &solana_rpc::OnChainPosition,
+) -> anyhow::Result<serde_json::Value> {
+    // Fetch LbPair and position account data concurrently
+    let (pool_data, pos_data) = tokio::try_join!(
+        solana_rpc::get_account_data(client, &pos.lb_pair),
+        solana_rpc::get_account_data(client, &pos.address),
+    )?;
+
+    let pool = solana_rpc::parse_lb_pair(&pool_data)?;
+    let shares = solana_rpc::parse_position_shares(&pos_data);
+
+    let mint_x = bs58::encode(&pool.token_x_mint).into_string();
+    let mint_y = bs58::encode(&pool.token_y_mint).into_string();
+
+    // Fetch token decimals concurrently
+    let (mint_x_data, mint_y_data) = tokio::try_join!(
+        solana_rpc::get_account_data(client, &mint_x),
+        solana_rpc::get_account_data(client, &mint_y),
+    )?;
+    let decimals_x = solana_rpc::parse_mint_decimals(&mint_x_data);
+    let decimals_y = solana_rpc::parse_mint_decimals(&mint_y_data);
+
+    let lower_bin_id = pos.lower_bin_id;
+
+    // Identify which BinArray accounts are needed
+    let mut needed_arrays: Vec<i64> = Vec::new();
+    for i in 0..70usize {
+        if shares[i] == 0 {
+            continue;
+        }
+        let bin_id = lower_bin_id + i as i32;
+        let arr_idx = meteora_ix::bin_array_index(bin_id);
+        if !needed_arrays.contains(&arr_idx) {
+            needed_arrays.push(arr_idx);
+        }
+    }
+
+    // Fetch each BinArray (typically 1-2 per position)
+    let lb_pair_key = Pubkey::from_str(&pos.lb_pair)?;
+    let mut bin_arrays: HashMap<i64, Vec<u8>> = HashMap::new();
+    for arr_idx in &needed_arrays {
+        let ba_addr = meteora_ix::bin_array_pda(&lb_pair_key, *arr_idx).to_string();
+        match solana_rpc::get_account_data(client, &ba_addr).await {
+            Ok(data) => {
+                bin_arrays.insert(*arr_idx, data);
+            }
+            Err(e) => {
+                eprintln!("[warn] BinArray index {arr_idx} fetch failed: {e}");
+            }
+        }
+    }
+
+    // Compute user token amounts via proportional share formula:
+    //   user_amount = bin_amount × user_shares / bin_liquidity_supply
+    let mut total_x: f64 = 0.0;
+    let mut total_y: f64 = 0.0;
+    let mut active_bins: u32 = 0;
+
+    for i in 0..70usize {
+        if shares[i] == 0 {
+            continue;
+        }
+        let bin_id = lower_bin_id + i as i32;
+        let arr_idx = meteora_ix::bin_array_index(bin_id);
+        let pos_in_array = (bin_id as i64 - arr_idx * 70) as usize;
+
+        if let Some(ba_data) = bin_arrays.get(&arr_idx) {
+            let (amount_x, amount_y, supply) = solana_rpc::parse_bin_at(ba_data, pos_in_array);
+            if supply > 0 {
+                let fraction = shares[i] as f64 / supply as f64;
+                total_x += amount_x as f64 * fraction;
+                total_y += amount_y as f64 * fraction;
+                active_bins += 1;
+            }
+        }
+    }
+
+    let token_x_amount = total_x / 10f64.powi(decimals_x as i32);
+    let token_y_amount = total_y / 10f64.powi(decimals_y as i32);
+
+    Ok(json!({
+        "position_address": pos.address,
+        "pool_address": pos.lb_pair,
+        "owner": pos.owner,
+        "token_x_mint": mint_x,
+        "token_y_mint": mint_y,
+        "token_x_amount": token_x_amount,
+        "token_y_amount": token_y_amount,
+        "token_x_decimals": decimals_x,
+        "token_y_decimals": decimals_y,
+        "bin_range": {
+            "lower_bin_id": lower_bin_id,
+            "upper_bin_id": pos.upper_bin_id,
+        },
+        "active_bins": active_bins,
+        "source": "on-chain",
+    }))
 }

--- a/skills/meteora/src/commands/remove_liquidity.rs
+++ b/skills/meteora/src/commands/remove_liquidity.rs
@@ -183,7 +183,7 @@ pub async fn execute(args: &RemoveLiquidityArgs, dry_run: bool) -> anyhow::Resul
             "upper_bin_id": upper_bin_id,
             "pct": args.pct,
             "bps_to_remove": bps_to_remove,
-            "will_close_position": args.close,
+            "will_claim_fees_then_close": args.close && bps_to_remove == 10000,
             "token_x_mint": token_x_mint.to_string(),
             "token_y_mint": token_y_mint.to_string(),
             "user_token_x": user_token_x,
@@ -235,13 +235,15 @@ pub async fn execute(args: &RemoveLiquidityArgs, dry_run: bool) -> anyhow::Resul
     ));
 
     if args.close && bps_to_remove == 10000 {
-        instructions.push(meteora_ix::ix_close_position(
-            &wallet,
-            &position,
-            &lb_pair,
-            &bin_array_lower,
-            &bin_array_upper,
+        // Claim pending fees first — close_position_if_empty requires fee_infos == 0,
+        // which removeLiquidityByRange does NOT clear automatically.
+        instructions.push(meteora_ix::ix_claim_fee(
+            &lb_pair, &position, &bin_array_lower, &bin_array_upper,
+            &wallet, &reserve_x, &reserve_y,
+            &user_token_x_pk, &user_token_y_pk,
+            &token_x_mint, &token_y_mint,
         ));
+        instructions.push(meteora_ix::ix_close_position_if_empty(&wallet, &position));
     }
 
     // Request 600k CUs — placed last so onchainos sees the DLMM instruction first.

--- a/skills/meteora/src/meteora_ix.rs
+++ b/skills/meteora/src/meteora_ix.rs
@@ -216,13 +216,14 @@ pub fn ix_add_liquidity_by_strategy(
 
     let ev_auth = event_authority();
 
-    // bin_array_bitmap_extension is OPTIONAL; pass DLMM_PROGRAM as sentinel (unused)
+    // bin_array_bitmap_extension is OPTIONAL; pass DLMM_PROGRAM as sentinel (unused).
+    // Must be readonly — passing an executable account as writable causes ProgramAccountNotFound.
     Instruction {
         program_id: DLMM_PROGRAM,
         accounts: vec![
             AccountMeta::new(*position, false),
             AccountMeta::new(*lb_pair, false),
-            AccountMeta::new(DLMM_PROGRAM, false), // bin_array_bitmap_extension (optional sentinel)
+            AccountMeta::new_readonly(DLMM_PROGRAM, false), // bin_array_bitmap_extension (optional sentinel)
             AccountMeta::new(*user_token_x, false),
             AccountMeta::new(*user_token_y, false),
             AccountMeta::new(*reserve_x, false),
@@ -409,6 +410,34 @@ pub fn ix_set_compute_unit_limit(units: u32) -> Instruction {
         program_id: COMPUTE_BUDGET,
         accounts: vec![],
         data,
+    }
+}
+
+/// Transfer native SOL from `from` to `to` via the System program.
+/// Used to fund a WSOL ATA before syncing, ensuring the token balance reflects
+/// the deposited SOL (required when token_x is the native SOL mint).
+pub fn ix_sol_transfer(from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
+    // SystemInstruction::Transfer discriminant = 2 (u32 LE) + lamports (u64 LE)
+    let mut data = vec![2u8, 0, 0, 0];
+    data.extend_from_slice(&lamports.to_le_bytes());
+    Instruction {
+        program_id: SYSTEM_PROGRAM,
+        accounts: vec![
+            AccountMeta::new(*from, true),
+            AccountMeta::new(*to, false),
+        ],
+        data,
+    }
+}
+
+/// Sync a WSOL (native SOL) token account so its token balance matches its lamport balance.
+/// Must be called after `ix_sol_transfer` to make newly deposited SOL spendable as tokens.
+pub fn ix_sync_native(wsol_account: &Pubkey) -> Instruction {
+    // SyncNative SPL token instruction discriminant = 17
+    Instruction {
+        program_id: TOKEN_PROGRAM,
+        accounts: vec![AccountMeta::new(*wsol_account, false)],
+        data: vec![17],
     }
 }
 

--- a/skills/meteora/src/solana_rpc.rs
+++ b/skills/meteora/src/solana_rpc.rs
@@ -93,7 +93,19 @@ pub async fn account_exists(client: &Client, address: &str) -> anyhow::Result<bo
     if let Some(err) = resp.get("error") {
         anyhow::bail!("RPC error checking account {address}: {err}");
     }
-    Ok(resp["result"]["value"].is_object())
+    if resp["result"]["value"].is_object() {
+        return Ok(true);
+    }
+    // Primary returned null (may be stale/rate-limited). Cross-check with fallback.
+    // If fallback confirms existence, trust it to avoid spurious init instructions.
+    if let Ok(resp2) = client.post(SOLANA_RPC_FALLBACK).json(&body).send().await {
+        if let Ok(v) = resp2.json::<Value>().await {
+            if v["result"]["value"].is_object() {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
 }
 
 pub async fn get_latest_blockhash(client: &Client) -> anyhow::Result<[u8; 32]> {
@@ -165,6 +177,51 @@ pub fn parse_lb_pair(data: &[u8]) -> anyhow::Result<LbPairInfo> {
         reserve_x,
         reserve_y,
     })
+}
+
+/// Parse the 70 liquidity shares from a DLMM PositionV2 account.
+/// Shares are stored at [72..1192] as 70 × u128 LE.
+/// shares[i] corresponds to the bin at (lower_bin_id + i) within the position.
+pub fn parse_position_shares(data: &[u8]) -> [u128; 70] {
+    let mut shares = [0u128; 70];
+    if data.len() < 1192 {
+        return shares;
+    }
+    for (i, chunk) in data[72..1192].chunks_exact(16).enumerate().take(70) {
+        shares[i] = u128::from_le_bytes(chunk.try_into().unwrap_or([0u8; 16]));
+    }
+    shares
+}
+
+/// Parse (amount_x, amount_y, liquidity_supply) for one bin within a BinArray.
+///
+/// BinArray account layout (10136 bytes):
+///   [0..8]   Anchor discriminator
+///   [8..16]  index (i64 LE)
+///   [16..24] version_info (u64)
+///   [24..56] lb_pair (Pubkey, 32 bytes)
+///   [56..]   bins: [Bin; 70], each Bin = 144 bytes
+///
+/// Bin struct (Meteora DLMM source, 144 bytes total):
+///   [+0..+8]   amount_x     (u64 LE)
+///   [+8..+16]  amount_y     (u64 LE)
+///   [+16..+32] price        (u128 LE, Q64.64 fixed-point)
+///   [+32..+48] liquidity_supply (u128 LE)
+///   [+48..+144] reward/fee fields (not used here)
+pub fn parse_bin_at(data: &[u8], pos_in_array: usize) -> (u64, u64, u128) {
+    const HEADER: usize = 56;
+    const BIN_SIZE: usize = 144;
+    let base = HEADER + pos_in_array * BIN_SIZE;
+    if data.len() < base + 48 {
+        return (0, 0, 0);
+    }
+    let amount_x =
+        u64::from_le_bytes(data[base..base + 8].try_into().unwrap_or([0u8; 8]));
+    let amount_y =
+        u64::from_le_bytes(data[base + 8..base + 16].try_into().unwrap_or([0u8; 8]));
+    let liquidity_supply =
+        u128::from_le_bytes(data[base + 32..base + 48].try_into().unwrap_or([0u8; 16]));
+    (amount_x, amount_y, liquidity_supply)
 }
 
 /// Check whether a DLMM PositionV2 account has any non-zero liquidity shares.


### PR DESCRIPTION
## Summary

- **get-user-positions**: Remove Meteora REST API dependency; compute token amounts purely from on-chain BinArray proportional shares (`user_amount = bin_amount × shares / supply`)
- **add-liquidity**: Auto-wrap SOL→WSOL via `sol_transfer + sync_native`; 600k compute budget; automatic retry on simulation errors (re-checks account states before retry)
- **add-liquidity**: Fix `bin_array_bitmap_extension` sentinel from `AccountMeta::new` → `AccountMeta::new_readonly` (was causing `ProgramAccountNotFound` simulation failure)
- **remove-liquidity `--close`**: Replace `ix_close_position` with `ix_claim_fee + ix_close_position_if_empty` to satisfy `fee_infos == 0` requirement before closing
- **solana_rpc**: Add `parse_position_shares`, `parse_bin_at`; dual-RPC fallback in `account_exists` to prevent spurious bin array init instructions

## Test plan

- [x] `get-user-positions` returns token amounts from on-chain BinArray state (verified on mainnet)
- [x] `add-liquidity --amount-x 0.001 --amount-y 0.1` succeeds with WSOL wrap on SOL/USDC pool
- [x] `remove-liquidity --pct 100 --close` successfully claims fees and closes position, reclaims ~0.057 SOL rent
- [x] Retry logic handles `ProgramAccountNotFound` after rapid close→add sequence
- [x] `cargo build --release` passes
- [x] All 4 version files bumped to `0.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)