### PR TITLE
feat(morpho): v0.2.2 — confirm gate + APY anomaly warnings

### DIFF
--- a/skills/morpho/.claude-plugin/plugin.json
+++ b/skills/morpho/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morpho",
   "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/morpho/Cargo.lock
+++ b/skills/morpho/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "morpho"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/morpho/Cargo.toml
+++ b/skills/morpho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morpho"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/morpho/SKILL.md
+++ b/skills/morpho/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: morpho
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults."
-version: "0.2.1"
+version: "0.2.2"
 author: "GeoGu360"
 tags:
   - lending
@@ -48,7 +48,7 @@ if ! command -v morpho >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho@0.2.1/morpho-${TARGET}${EXT}" -o ~/.local/bin/morpho${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho@0.2.2/morpho-${TARGET}${EXT}" -o ~/.local/bin/morpho${EXT}
   chmod +x ~/.local/bin/morpho${EXT}
 fi
 ```
@@ -67,7 +67,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"morpho","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"morpho","version":"0.2.2"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"morpho","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -155,6 +155,7 @@ Please connect your wallet first: run `onchainos wallet login`
 - `--chain <CHAIN_ID>` — target chain: 1 (Ethereum, default) or 8453 (Base)
 - `--from <ADDRESS>` — wallet address (defaults to active onchainos wallet)
 - `--dry-run` — simulate without broadcasting
+- `--confirm` — required to actually execute write operations (supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, claim-rewards); omitting it prints a rich preview of pending transactions and exits safely
 
 ---
 
@@ -177,10 +178,14 @@ The health factor (HF) is a numeric value representing the safety of a borrowing
 
 For all write operations (supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, claim-rewards):
 
-1. Run with `--dry-run` first to preview the transaction
-2. **Ask user to confirm** before executing on-chain
-3. Execute only after receiving explicit user approval
-4. Report transaction hash(es) and outcome
+1. **Call without `--confirm`** first — the binary resolves all parameters, builds calldata, and prints a `preview` JSON showing exactly what will be executed (operation, asset, amount, pending transactions). No transactions are broadcast.
+2. **Show the preview to the user** and ask for explicit confirmation.
+3. **Re-run with `--confirm`** after the user approves. Only then are transactions broadcast.
+4. Report transaction hash(es) and outcome.
+
+> **Do NOT pass `--confirm` on the first call.** The preview mode is the safety net — it costs nothing and gives the user full visibility before any funds move.
+
+> **`--dry-run` vs `--confirm`**: `--dry-run` simulates the onchainos call and logs what would be sent, but does not show resolved token symbols or amounts. The confirm-gate preview (default without `--confirm`) resolves all values and is the recommended first step for agents.
 
 ---
 
@@ -192,10 +197,10 @@ For all write operations (supply, withdraw, borrow, repay, supply-collateral, wi
 
 **Usage:**
 ```bash
-# Always dry-run first, then ask user to confirm before proceeding
-morpho --chain 1 --dry-run supply --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 1000
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 supply --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 1000
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 supply --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 1000 --confirm
 ```
 
 **Key parameters:**
@@ -231,13 +236,13 @@ morpho --chain 1 supply --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --ass
 
 **Usage:**
 ```bash
-# Partial withdrawal — dry-run first, then ask user to confirm before proceeding
-morpho --chain 1 --dry-run withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 500
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 500
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --amount 500 --confirm
 
 # Full withdrawal — redeem all shares
-morpho --chain 1 withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --all
+morpho --chain 1 withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --asset USDC --all --confirm
 ```
 
 **Key parameters:**
@@ -272,14 +277,12 @@ morpho --chain 1 withdraw --vault 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB --a
 
 **Trigger phrases:** "borrow from morpho", "get a loan on morpho blue", "从Morpho借款", "Morpho Blue借贷"
 
-**IMPORTANT:** Always run with `--dry-run` first, then ask user to confirm before executing.
-
 **Usage:**
 ```bash
-# Dry-run first
-morpho --chain 1 --dry-run borrow --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 1000
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 borrow --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 1000
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 borrow --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 1000 --confirm
 ```
 
 **Key parameters:**
@@ -313,17 +316,15 @@ morpho --chain 1 borrow --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccf
 
 **Trigger phrases:** "repay morpho loan", "pay back morpho debt", "还Morpho款", "偿还Morpho"
 
-**IMPORTANT:** Always run with `--dry-run` first, then ask user to confirm before proceeding.
-
 **Usage:**
 ```bash
-# Repay partial amount — dry-run first
-morpho --chain 1 --dry-run repay --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 500
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 repay --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 500
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 repay --market-id 0xb323495f7e4148be5643a4ea4a8221eef163e4bccfdedc2a6f4696baacbc86cc --amount 500 --confirm
 
 # Repay all outstanding debt
-morpho --chain 1 repay --market-id 0xb323... --all
+morpho --chain 1 repay --market-id 0xb323... --all --confirm
 ```
 
 **Key parameters:**
@@ -422,6 +423,8 @@ morpho --chain 8453 markets --asset WETH
 - Returns supply APY, borrow APY, utilization, and LLTV for each market
 - Read-only — no confirmation needed
 
+**APY anomaly warning:** When a market's `supplyApy` or `borrowApy` exceeds 500%, the entry includes a `"warning"` field. This typically indicates an expired Pendle PT collateral position (which inflates displayed APY to thousands of percent after maturity). **Do not recommend supplying to such markets** based on the APY figure alone; inform the user of the warning and advise verifying the market on-chain before proceeding.
+
 **Expected output:**
 <external-content>
 ```json
@@ -450,14 +453,12 @@ morpho --chain 8453 markets --asset WETH
 
 **Trigger phrases:** "supply collateral to morpho", "add collateral morpho blue", "Morpho存入抵押品"
 
-**IMPORTANT:** Always run with `--dry-run` first, then ask user to confirm before executing.
-
 **Usage:**
 ```bash
-# Dry-run first
-morpho --chain 1 --dry-run supply-collateral --market-id 0xb323... --amount 1.5
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 supply-collateral --market-id 0xb323... --amount 1.5
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 supply-collateral --market-id 0xb323... --amount 1.5 --confirm
 ```
 
 **Key parameters:**
@@ -490,17 +491,17 @@ morpho --chain 1 supply-collateral --market-id 0xb323... --amount 1.5
 
 **Trigger phrases:** "withdraw collateral from morpho", "remove collateral morpho blue", "get my collateral back from morpho", "取回Morpho抵押品"
 
-**IMPORTANT:** Always run with `--dry-run` first, then ask user to confirm before executing. Ensure all debt in the market is repaid (via `morpho repay --all`) before withdrawing collateral, or only withdraw an amount that keeps the health factor safe.
+**IMPORTANT:** Ensure all debt in the market is repaid (via `morpho repay --all --confirm`) before withdrawing all collateral, or only withdraw an amount that keeps the health factor safe.
 
 **Usage:**
 ```bash
-# Withdraw specific amount — dry-run first
-morpho --chain 1 --dry-run withdraw-collateral --market-id 0xb323... --amount 1.5
-# After user confirmation:
+# Step 1: Preview (no --confirm) — resolves all params, prints pending txs, exits safely
 morpho --chain 1 withdraw-collateral --market-id 0xb323... --amount 1.5
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 withdraw-collateral --market-id 0xb323... --amount 1.5 --confirm
 
 # Withdraw all collateral (must have zero debt first)
-morpho --chain 1 withdraw-collateral --market-id 0xb323... --all
+morpho --chain 1 withdraw-collateral --market-id 0xb323... --all --confirm
 ```
 
 **Key parameters:**
@@ -536,15 +537,13 @@ morpho --chain 1 withdraw-collateral --market-id 0xb323... --all
 
 **Trigger phrases:** "claim morpho rewards", "collect morpho rewards", "领取Morpho奖励", "领取Merkl奖励"
 
-**IMPORTANT:** Always run with `--dry-run` first, then ask user to confirm before executing.
-
 **Usage:**
 ```bash
-# Dry-run first
-morpho --chain 1 --dry-run claim-rewards
-# After user confirmation:
+# Step 1: Preview (no --confirm) — fetches claimable rewards, prints pending tx, exits safely
 morpho --chain 1 claim-rewards
-morpho --chain 8453 claim-rewards
+# Step 2: Show preview to user, ask for confirmation. After approval:
+morpho --chain 1 claim-rewards --confirm
+morpho --chain 8453 claim-rewards --confirm
 ```
 
 **What it does:**
@@ -584,6 +583,8 @@ morpho --chain 8453 vaults --asset WETH
 - Queries the Morpho GraphQL API for MetaMorpho vaults ordered by TVL
 - Returns APY, total assets, and curator info for each vault
 - Read-only — no confirmation needed
+
+**APY anomaly warning:** When a vault's `apy` exceeds 500%, the entry includes a `"warning"` field. This typically indicates an expired Pendle PT position within the vault's underlying markets. **Do not recommend supplying to such vaults** based on the APY figure alone; inform the user of the warning and advise verifying the vault on-chain before proceeding.
 
 **Expected output:**
 <external-content>
@@ -654,8 +655,8 @@ morpho --chain 8453 vaults --asset WETH
 
 ## Safety Rules
 
-1. **Dry-run first**: Always simulate with `--dry-run` before any on-chain write
-2. **Ask user to confirm**: Show the user what will happen and wait for explicit confirmation before executing
+1. **Preview before executing**: Always call write commands without `--confirm` first. The binary resolves all parameters, builds calldata, and prints a `preview` JSON — no transactions are broadcast. Show this to the user and wait for explicit confirmation before re-running with `--confirm`.
+2. **`--confirm` is required to broadcast**: Omitting `--confirm` is always safe; adding it is the explicit approval step.
 3. **Never borrow without checking collateral**: Ensure sufficient collateral is supplied first
 4. **Warn at low HF**: Explicitly warn user when health factor < 1.1 after simulated borrow
 5. **Full repay with shares**: Use `--all` for full repayment to avoid dust from interest rounding
@@ -678,4 +679,19 @@ morpho --chain 8453 vaults --asset WETH
 | `Unknown asset symbol` | Provide the ERC-20 contract address instead of symbol |
 | `execution reverted: transferFrom reverted` on supply/repay | The approve tx was not yet confirmed when the main operation ran. This should not occur in v0.2.0+ (the plugin waits for approve confirmation). If it does, retry after a few seconds. |
 | `--all` withdraw-collateral fails with `insufficient collateral` | The GraphQL API may lag behind on-chain state by a few blocks. Use `--amount` with the exact balance from `morpho positions` instead. |
+
+---
+
+## Changelog
+
+### v0.2.2
+- **Safety: `--confirm` gate for all write operations** — Supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, and claim-rewards now require `--confirm` to broadcast. Calling without `--confirm` prints a rich `preview` JSON (operation, asset, amount, pending transactions) and exits safely. This prevents accidental on-chain execution.
+- **APY anomaly warnings** — `morpho markets` and `morpho vaults` now emit a `"warning"` field on any entry where supply or borrow APY exceeds 500%. This surfaces expired Pendle PT positions (which inflate APY to thousands of percent after maturity) so agents and users are not misled.
+
+### v0.2.1
+- Initial public release
+- Supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, claim-rewards
+- MetaMorpho vault listing and Morpho Blue market listing with APY/utilization data
+- Positions view with Blue and vault balances
+- Ethereum Mainnet and Base support
 

--- a/skills/morpho/plugin.yaml
+++ b/skills/morpho/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: morpho
-version: "0.2.1"
+version: "0.2.2"
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol"
 author:
   name: GeoGu360

--- a/skills/morpho/src/commands/borrow.rs
+++ b/skills/morpho/src/commands/borrow.rs
@@ -12,6 +12,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     let borrower_string = onchainos::resolve_wallet(from, chain_id).await?;
@@ -31,12 +32,34 @@ pub async fn run(
     // borrow(marketParams, assets, 0, onBehalf, receiver)
     let borrow_calldata = calldata::encode_borrow(&mp, raw_amount, 0, borrower, borrower);
 
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "borrow",
+            "marketId": market_id,
+            "loanAsset": symbol,
+            "loanAssetAddress": loan_token,
+            "amount": amount,
+            "rawAmount": raw_amount.to_string(),
+            "chainId": chain_id,
+            "morphoBlue": cfg.morpho_blue,
+            "pendingTransactions": 1,
+            "transactions": [
+                {"step": 1, "description": format!("Borrow {} {} from Morpho Blue market {}", amount, symbol, market_id), "to": cfg.morpho_blue},
+            ],
+            "note": "Re-run with --confirm to execute this transaction on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
     eprintln!("[morpho] Borrowing {} {} from Morpho Blue market {}...", amount, symbol, market_id);
     if dry_run {
         eprintln!("[morpho] [dry-run] Would call: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, cfg.morpho_blue, borrow_calldata);
     }
 
-    // Ask user to confirm before executing on-chain
     let result = onchainos::wallet_contract_call(
         chain_id,
         cfg.morpho_blue,

--- a/skills/morpho/src/commands/claim_rewards.rs
+++ b/skills/morpho/src/commands/claim_rewards.rs
@@ -8,6 +8,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     let user_string = onchainos::resolve_wallet(from, chain_id).await?;
@@ -37,12 +38,29 @@ pub async fn run(
         &merkl_data.proofs,
     );
 
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "claim-rewards",
+            "user": user,
+            "chainId": chain_id,
+            "rewardTokens": merkl_data.tokens,
+            "claimable": merkl_data.claimable,
+            "merklDistributor": cfg.merkl_distributor,
+            "pendingTransactions": 1,
+            "note": "Re-run with --confirm to execute this transaction on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
     eprintln!("[morpho] Claiming {} reward token(s) from Merkl...", merkl_data.tokens.len());
     if dry_run {
         eprintln!("[morpho] [dry-run] Would claim: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, cfg.merkl_distributor, claim_calldata);
     }
 
-    // Ask user to confirm before executing on-chain
     let result = onchainos::wallet_contract_call(
         chain_id,
         cfg.merkl_distributor,

--- a/skills/morpho/src/commands/markets.rs
+++ b/skills/morpho/src/commands/markets.rs
@@ -5,6 +5,9 @@ use crate::config::chain_name;
 pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()> {
     let markets = api::list_markets(chain_id, asset_filter).await?;
 
+    // Threshold above which an APY is considered anomalous (e.g. expired Pendle PT collateral)
+    const APY_ANOMALY_THRESHOLD: f64 = 5.0; // 500%
+
     let items: Vec<serde_json::Value> = markets.iter().map(|m| {
         let loan_symbol = m.loan_asset.as_ref().map(|a| a.symbol.as_str()).unwrap_or("?");
         let collateral_symbol = m.collateral_asset.as_ref().map(|a| a.symbol.as_str()).unwrap_or("?");
@@ -14,7 +17,13 @@ pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()
         let lltv = m.lltv.as_deref().unwrap_or("0");
         let lltv_val: f64 = lltv.parse::<u128>().unwrap_or(0) as f64 / 1e18 * 100.0;
 
-        serde_json::json!({
+        let apy_warning: Option<&str> = if supply_apy > APY_ANOMALY_THRESHOLD || borrow_apy > APY_ANOMALY_THRESHOLD {
+            Some("APY exceeds 500% — likely an expired Pendle PT collateral position or stale data. Do not supply based on this APY alone; verify the market on-chain before proceeding.")
+        } else {
+            None
+        };
+
+        let mut entry = serde_json::json!({
             "marketId": m.unique_key,
             "loanAsset": loan_symbol,
             "collateralAsset": collateral_symbol,
@@ -22,7 +31,11 @@ pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()
             "supplyApy": format!("{:.4}%", supply_apy * 100.0),
             "borrowApy": format!("{:.4}%", borrow_apy * 100.0),
             "utilization": format!("{:.2}%", utilization * 100.0),
-        })
+        });
+        if let Some(w) = apy_warning {
+            entry["warning"] = serde_json::Value::String(w.to_string());
+        }
+        entry
     }).collect();
 
     let output = serde_json::json!({

--- a/skills/morpho/src/commands/repay.rs
+++ b/skills/morpho/src/commands/repay.rs
@@ -15,6 +15,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     let borrower_string = onchainos::resolve_wallet(from, chain_id).await?;
@@ -67,7 +68,31 @@ pub async fn run(
         eprintln!("[morpho] Repaying {} {} to Morpho Blue market {}...", amt_str, symbol, market_id);
     }
 
-    // Step 1: Approve Morpho Blue to spend loan token (ask user to confirm before executing)
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "repay",
+            "marketId": market_id,
+            "loanAsset": symbol,
+            "loanAssetAddress": loan_token,
+            "amount": display_amount,
+            "repayAll": all,
+            "chainId": chain_id,
+            "morphoBlue": cfg.morpho_blue,
+            "pendingTransactions": 2,
+            "transactions": [
+                {"step": 1, "description": format!("Approve Morpho Blue to spend {} {}", display_amount, symbol), "to": loan_token},
+                {"step": 2, "description": format!("Repay {} {} to Morpho Blue market {}", display_amount, symbol, market_id), "to": cfg.morpho_blue},
+            ],
+            "note": "Re-run with --confirm to execute these transactions on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
+    // Step 1: Approve Morpho Blue to spend loan token
     // Add a small buffer (0.5%) to the approval amount to cover accrued interest
     let approve_amount = if all && repay_assets == 0 {
         // For full repay via shares, approve actual borrow amount + 1% buffer for accrued interest

--- a/skills/morpho/src/commands/supply.rs
+++ b/skills/morpho/src/commands/supply.rs
@@ -13,6 +13,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
 
@@ -27,18 +28,43 @@ pub async fn run(
     // Resolve the caller's wallet address (used as receiver in deposit)
     let wallet_addr = onchainos::resolve_wallet(from, chain_id).await?;
 
-    // Step 1: Approve vault to spend asset (ask user to confirm before executing)
+    // Build calldatas (needed for both preview and execution)
     let approve_calldata = calldata::encode_approve(vault, raw_amount);
+    let deposit_calldata = calldata::encode_vault_deposit(raw_amount, &wallet_addr);
+
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "supply",
+            "vault": vault,
+            "asset": symbol,
+            "assetAddress": asset_addr,
+            "amount": amount,
+            "rawAmount": raw_amount.to_string(),
+            "chainId": chain_id,
+            "pendingTransactions": 2,
+            "transactions": [
+                {"step": 1, "description": format!("Approve {} to spend {} {}", vault, amount, symbol), "to": asset_addr},
+                {"step": 2, "description": format!("Deposit {} {} into vault {}", amount, symbol, vault), "to": vault},
+            ],
+            "note": "Re-run with --confirm to execute these transactions on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
+    // Step 1: Approve vault to spend asset
     eprintln!("[morpho] Step 1/2: Approving {} to spend {} {}...", vault, amount, symbol);
     if dry_run {
         eprintln!("[morpho] [dry-run] Would approve: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, asset_addr, approve_calldata);
     }
-    let approve_result = onchainos::wallet_contract_call(chain_id, &asset_addr, &approve_calldata, from, None, dry_run, true).await?;  // --force: approval is a prerequisite step
+    let approve_result = onchainos::wallet_contract_call(chain_id, &asset_addr, &approve_calldata, from, None, dry_run, true).await?;
     let approve_tx = onchainos::extract_tx_hash_or_err(&approve_result)?;
     onchainos::wait_for_tx(&approve_tx, cfg.rpc_url, chain_id).await?;
 
-    // Step 2: Deposit to vault (ask user to confirm before executing)
-    let deposit_calldata = calldata::encode_vault_deposit(raw_amount, &wallet_addr);
+    // Step 2: Deposit to vault
     eprintln!("[morpho] Step 2/2: Depositing {} {} into vault {}...", amount, symbol, vault);
     if dry_run {
         eprintln!("[morpho] [dry-run] Would deposit: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, vault, deposit_calldata);

--- a/skills/morpho/src/commands/supply_collateral.rs
+++ b/skills/morpho/src/commands/supply_collateral.rs
@@ -12,6 +12,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     let supplier_string = onchainos::resolve_wallet(from, chain_id).await?;
@@ -30,7 +31,31 @@ pub async fn run(
 
     let raw_amount = calldata::parse_amount(amount, decimals)?;
 
-    // Step 1: Approve Morpho Blue to spend collateral token (ask user to confirm before executing)
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "supply-collateral",
+            "marketId": market_id,
+            "collateralAsset": symbol,
+            "collateralAssetAddress": collateral_token,
+            "amount": amount,
+            "rawAmount": raw_amount.to_string(),
+            "chainId": chain_id,
+            "morphoBlue": cfg.morpho_blue,
+            "pendingTransactions": 2,
+            "transactions": [
+                {"step": 1, "description": format!("Approve Morpho Blue to spend {} {}", amount, symbol), "to": collateral_token},
+                {"step": 2, "description": format!("Supply {} {} as collateral to market {}", amount, symbol, market_id), "to": cfg.morpho_blue},
+            ],
+            "note": "Re-run with --confirm to execute these transactions on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
+    // Step 1: Approve Morpho Blue to spend collateral token
     let approve_calldata = calldata::encode_approve(cfg.morpho_blue, raw_amount);
     eprintln!("[morpho] Step 1/2: Approving Morpho Blue to spend {} {}...", amount, symbol);
     if dry_run {

--- a/skills/morpho/src/commands/vaults.rs
+++ b/skills/morpho/src/commands/vaults.rs
@@ -6,6 +6,9 @@ use crate::config::chain_name;
 pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()> {
     let vaults = api::list_vaults(chain_id, asset_filter).await?;
 
+    // Threshold above which an APY is considered anomalous (e.g. expired Pendle PT position)
+    const APY_ANOMALY_THRESHOLD: f64 = 5.0; // 500%
+
     let items: Vec<serde_json::Value> = vaults.iter().map(|v| {
         let asset_symbol = v.asset.as_ref().map(|a| a.symbol.as_str()).unwrap_or("?");
         let asset_addr = v.asset.as_ref().map(|a| a.address.as_str()).unwrap_or("");
@@ -16,7 +19,13 @@ pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
-        serde_json::json!({
+        let apy_warning: Option<&str> = if apy > APY_ANOMALY_THRESHOLD {
+            Some("APY exceeds 500% — likely an expired Pendle PT position or stale data. Do not supply based on this APY alone; verify the vault on-chain before proceeding.")
+        } else {
+            None
+        };
+
+        let mut entry = serde_json::json!({
             "address": v.address,
             "name": v.name,
             "symbol": v.symbol,
@@ -24,7 +33,11 @@ pub async fn run(chain_id: u64, asset_filter: Option<&str>) -> anyhow::Result<()
             "assetAddress": asset_addr,
             "apy": format!("{:.4}%", apy * 100.0),
             "totalAssets": calldata::format_amount(total_assets_raw, asset_decimals),
-        })
+        });
+        if let Some(w) = apy_warning {
+            entry["warning"] = serde_json::Value::String(w.to_string());
+        }
+        entry
     }).collect();
 
     let output = serde_json::json!({

--- a/skills/morpho/src/commands/withdraw.rs
+++ b/skills/morpho/src/commands/withdraw.rs
@@ -15,6 +15,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     // Resolve the active wallet address (used as owner/receiver)
@@ -44,11 +45,32 @@ pub async fn run(
         eprintln!("[morpho] Withdrawing {} {} from vault {}...", amt_str, symbol, vault);
     }
 
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "withdraw",
+            "vault": vault,
+            "asset": symbol,
+            "assetAddress": asset_addr,
+            "amount": display_amount,
+            "withdrawAll": all,
+            "chainId": chain_id,
+            "pendingTransactions": 1,
+            "transactions": [
+                {"step": 1, "description": format!("Withdraw {} {} from vault {}", display_amount, symbol, vault), "to": vault},
+            ],
+            "note": "Re-run with --confirm to execute this transaction on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
+
     if dry_run {
         eprintln!("[morpho] [dry-run] Would call: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, vault, calldata_hex);
     }
 
-    // Ask user to confirm before executing on-chain
     let result = onchainos::wallet_contract_call(chain_id, vault, &calldata_hex, from, None, dry_run, false).await?;
     let tx_hash = onchainos::extract_tx_hash_or_err(&result)?;
 

--- a/skills/morpho/src/commands/withdraw_collateral.rs
+++ b/skills/morpho/src/commands/withdraw_collateral.rs
@@ -13,6 +13,7 @@ pub async fn run(
     chain_id: u64,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<()> {
     let cfg = get_chain_config(chain_id)?;
     let owner_string = onchainos::resolve_wallet(from, chain_id).await?;
@@ -51,6 +52,29 @@ pub async fn run(
 
     // withdrawCollateral(marketParams, assets, onBehalf, receiver)
     let withdraw_calldata = calldata::encode_withdraw_collateral(&mp, raw_amount, owner, owner);
+
+    // Confirm gate: show preview and exit if --confirm not given
+    if !dry_run && !confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "withdraw-collateral",
+            "marketId": market_id,
+            "collateralAsset": symbol,
+            "collateralAssetAddress": collateral_token,
+            "amount": display_amount,
+            "withdrawAll": all,
+            "chainId": chain_id,
+            "morphoBlue": cfg.morpho_blue,
+            "pendingTransactions": 1,
+            "transactions": [
+                {"step": 1, "description": format!("Withdraw {} {} collateral from market {}", display_amount, symbol, market_id), "to": cfg.morpho_blue},
+            ],
+            "note": "Re-run with --confirm to execute this transaction on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
+    }
 
     if dry_run {
         eprintln!("[morpho] [dry-run] Would call: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, cfg.morpho_blue, withdraw_calldata);

--- a/skills/morpho/src/main.rs
+++ b/skills/morpho/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     #[arg(long, global = true)]
     dry_run: bool,
 
+    /// Confirm and broadcast on-chain (required for write operations; omit to preview)
+    #[arg(long, global = true)]
+    confirm: bool,
+
     /// Wallet address (defaults to active onchainos wallet)
     #[arg(long, global = true)]
     from: Option<String>,
@@ -49,6 +53,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// Withdraw from a MetaMorpho vault (ERC-4626)
@@ -76,6 +84,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// Borrow from a Morpho Blue market
@@ -95,6 +107,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// Repay Morpho Blue debt
@@ -118,6 +134,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// View user positions and health factors
@@ -147,6 +167,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// Withdraw collateral from a Morpho Blue market
@@ -170,6 +194,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// Claim Merkl rewards (P1)
@@ -181,6 +209,10 @@ enum Commands {
         /// Simulate without broadcasting (overrides global --dry-run)
         #[arg(long)]
         dry_run: bool,
+
+        /// Confirm and broadcast on-chain (overrides global --confirm)
+        #[arg(long)]
+        confirm: bool,
     },
 
     /// List MetaMorpho vaults with APYs (P1)
@@ -196,28 +228,33 @@ async fn main() {
     let cli = Cli::parse();
     let global_chain = cli.chain;
     let global_dry_run = cli.dry_run;
+    let global_confirm = cli.confirm;
     let from = cli.from.as_deref();
 
     let result = match cli.command {
-        Commands::Supply { vault, asset, amount, chain, dry_run } => {
+        Commands::Supply { vault, asset, amount, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::supply::run(&vault, &asset, &amount, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::supply::run(&vault, &asset, &amount, chain_id, from, dry_run, confirm).await
         }
-        Commands::Withdraw { vault, asset, amount, all, chain, dry_run } => {
+        Commands::Withdraw { vault, asset, amount, all, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::withdraw::run(&vault, &asset, amount.as_deref(), all, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::withdraw::run(&vault, &asset, amount.as_deref(), all, chain_id, from, dry_run, confirm).await
         }
-        Commands::Borrow { market_id, amount, chain, dry_run } => {
+        Commands::Borrow { market_id, amount, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::borrow::run(&market_id, &amount, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::borrow::run(&market_id, &amount, chain_id, from, dry_run, confirm).await
         }
-        Commands::Repay { market_id, amount, all, chain, dry_run } => {
+        Commands::Repay { market_id, amount, all, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::repay::run(&market_id, amount.as_deref(), all, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::repay::run(&market_id, amount.as_deref(), all, chain_id, from, dry_run, confirm).await
         }
         Commands::Positions => {
             commands::positions::run(global_chain, from).await
@@ -225,20 +262,23 @@ async fn main() {
         Commands::Markets { asset } => {
             commands::markets::run(global_chain, asset.as_deref()).await
         }
-        Commands::SupplyCollateral { market_id, amount, chain, dry_run } => {
+        Commands::SupplyCollateral { market_id, amount, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::supply_collateral::run(&market_id, &amount, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::supply_collateral::run(&market_id, &amount, chain_id, from, dry_run, confirm).await
         }
-        Commands::WithdrawCollateral { market_id, amount, all, chain, dry_run } => {
+        Commands::WithdrawCollateral { market_id, amount, all, chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::withdraw_collateral::run(&market_id, amount.as_deref(), all, chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::withdraw_collateral::run(&market_id, amount.as_deref(), all, chain_id, from, dry_run, confirm).await
         }
-        Commands::ClaimRewards { chain, dry_run } => {
+        Commands::ClaimRewards { chain, dry_run, confirm } => {
             let chain_id = chain.unwrap_or(global_chain);
             let dry_run = dry_run || global_dry_run;
-            commands::claim_rewards::run(chain_id, from, dry_run).await
+            let confirm = confirm || global_confirm;
+            commands::claim_rewards::run(chain_id, from, dry_run, confirm).await
         }
         Commands::Vaults { asset } => {
             commands::vaults::run(global_chain, asset.as_deref()).await

--- a/skills/morpho/src/onchainos.rs
+++ b/skills/morpho/src/onchainos.rs
@@ -80,7 +80,12 @@ pub async fn wait_for_tx(tx_hash: &str, rpc_url: &str, chain_id: u64) -> anyhow:
             }
         }
     }
-    Ok(()) // proceed anyway after timeout
+    anyhow::bail!(
+        "Approval tx {} not confirmed within {}s — network may be congested. \
+         Check the tx on-chain and retry the command once it confirms.",
+        tx_hash,
+        max_attempts * 2
+    )
 }
 
 /// Extract txHash from wallet contract-call response, returning an error if the call failed.
@@ -123,16 +128,6 @@ pub async fn wallet_balance(chain_id: u64) -> anyhow::Result<Value> {
     let chain_str = chain_id.to_string();
     let output = tokio::process::Command::new("onchainos")
         .args(["wallet", "balance", "--chain", &chain_str])
-        .output()
-        .await?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(serde_json::from_str(&stdout)?)
-}
-
-/// Query wallet status to get the active address.
-pub async fn wallet_status() -> anyhow::Result<Value> {
-    let output = tokio::process::Command::new("onchainos")
-        .args(["wallet", "status", "--output", "json"])
         .output()
         .await?;
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Plugin Submission

**Plugin name:** morpho
**Version:** 0.2.2
**Type:** update

### Checklist

- [x] `plugin-store lint` passes locally with no errors
- [x] I have read the [Development Guide](../PLUGIN_DEVELOPMENT_GUIDE.md)
- [x] My plugin does NOT use reserved prefixes (`okx-`, `official-`, `plugin-store-`)
- [x] LICENSE file is included
- [x] SKILL.md has YAML frontmatter with `name` and `description`

### What does this plugin do?

Morpho is a permissionless lending protocol with $5B+ TVL. This plugin allows agents to supply/withdraw from MetaMorpho vaults, borrow/repay from Morpho Blue markets, supply/withdraw collateral, and claim Merkl rewards on Ethereum Mainnet and Base.

This update adds two safety improvements:

1. **`--confirm` gate for all write operations** — all write commands now require `--confirm` to broadcast. Without it, the binary resolves parameters, builds calldata, and prints a preview JSON (operation, asset, amount, pending transactions) then exits safely. Prevents accidental on-chain execution.

2. **APY anomaly warnings** — `morpho markets` and `morpho vaults` now emit a `"warning"` field on entries where APY exceeds 500%. This surfaces expired Pendle PT positions (which inflate APY to thousands of percent post-maturity) so agents don't mislead users with these figures.

### Which onchainos commands does it use?

- `onchainos wallet status` — check wallet connection
- `onchainos wallet contract-call --chain <id> --to <addr> --input-data <hex>` — ERC-20 approvals (with `--force`) and main protocol writes (without `--force`)

### Security Considerations

- Accesses active wallet; initiates ERC-20 approve and protocol write transactions
- ERC-20 approve txs are sent with `--force` (broadcast immediately as prerequisite steps)
- All other protocol transactions go through onchainos's normal confirmation flow
- New `--confirm` gate ensures agents must explicitly pass `--confirm` to broadcast; omitting it always exits safely after preview

### Testing

- Built locally with `cargo build --release` — clean build, no warnings
- Dry-run tested all write commands: preview JSON output verified for supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, claim-rewards
- `morpho markets` tested against Ethereum mainnet API — warning field present on anomalous APY entries, absent on normal entries
- `morpho vaults` tested similarly