### PR TITLE
fix(gmx-v2): pre-flight checks, complete order fields, orderKey/claimed return (v0.2.2)

### DIFF
--- a/skills/gmx-v2/.claude-plugin/plugin.json
+++ b/skills/gmx-v2/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gmx-v2",
   "description": "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/GeoGu360/plugin-store/tree/main/skills/gmx-v2",
   "repository": "https://github.com/GeoGu360/plugin-store",

--- a/skills/gmx-v2/Cargo.lock
+++ b/skills/gmx-v2/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "gmx-v2"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/gmx-v2/Cargo.toml
+++ b/skills/gmx-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmx-v2"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/gmx-v2/SKILL.md
+++ b/skills/gmx-v2/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmx-v2
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions. Trigger phrases: open position GMX, close position GMX, GMX trade, GMX leverage, GMX liquidity, deposit GM pool, withdraw GM pool, GMX stop loss, GMX take profit, cancel order GMX, claim funding fees GMX."
-version: 0.2.1
+version: 0.2.2
 author: "GeoGu360"
 tags:
   - perpetuals
@@ -49,7 +49,7 @@ if ! command -v gmx-v2 >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.2.1/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2@0.2.2/gmx-v2-${TARGET}${EXT}" -o ~/.local/bin/gmx-v2${EXT}
   chmod +x ~/.local/bin/gmx-v2${EXT}
 fi
 ```
@@ -71,7 +71,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"gmx-v2","version":"0.2.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"gmx-v2","version":"0.2.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -101,11 +101,11 @@ fi
 
 ## Architecture
 
-**Source code**: https://github.com/GeoGu360/plugin-store/tree/main/skills/gmx-v2
+**Source code**: https://github.com/okx/plugin-store/tree/main/skills/gmx-v2
 
 - Read ops (list-markets, get-prices, get-positions, get-orders) → direct `eth_call` via public RPC or GMX REST API; no confirmation needed
 - Write ops (open-position, close-position, place-order, cancel-order, deposit-liquidity, withdraw-liquidity, claim-funding-fees) → after user confirmation, submits via `onchainos wallet contract-call`
-- Write commands use `--force` flag internally — the binary broadcasts immediately once invoked; **agent confirmation is the sole safety gate** before calling any write command
+- Write commands require `--confirm` flag to broadcast — without `--confirm` (or `--dry-run`), the binary returns a preview JSON only; **agent confirmation is the sole safety gate** before passing `--confirm` to any write command
 - All write ops support `--dry-run` to preview calldata without broadcasting
 
 ## Supported Chains
@@ -126,10 +126,11 @@ Default: `--chain arbitrum`
 
 ## Execution Flow for Write Operations
 
-1. Run with `--dry-run` first to preview calldata
-2. **Ask user to confirm** the operation details (market, direction, size, fees) before executing
-3. Execute only after explicit user approval
-4. Report transaction hash and note that keeper execution follows within 1–30 seconds
+1. Run with `--dry-run` first to preview calldata (no broadcast, no approval needed)
+2. Without `--dry-run` and without `--confirm`: binary returns a preview JSON (`"status":"preview"`) — **never broadcasts**
+3. **Ask user to confirm** the operation details (market, direction, size, fees) before executing
+4. Execute with `--confirm` flag only after explicit user approval
+5. Report transaction hash and note that keeper execution follows within 1–30 seconds
 
 ---
 
@@ -158,7 +159,7 @@ gmx-v2 --chain arbitrum list-markets
 gmx-v2 --chain avalanche list-markets --trading-only false
 ```
 
-**Output fields:** name, marketToken, indexToken, longToken, shortToken, availableLiquidityLong_usd, availableLiquidityShort_usd, openInterestLong_usd, openInterestShort_usd, fundingRateLong, fundingRateShort
+**Output fields:** name, marketToken, indexToken, longToken, shortToken, availableLiquidityLong_usd, availableLiquidityShort_usd, openInterestLong_usd, openInterestShort_usd, fundingRateLong_annual (e.g. "0.0123%"), fundingRateShort_annual, borrowingRateLong_annual, borrowingRateShort_annual
 
 No confirmation needed (read-only).
 
@@ -208,7 +209,7 @@ gmx-v2 --chain arbitrum get-orders
 gmx-v2 --chain arbitrum get-orders --address 0xYourWallet
 ```
 
-**Output fields per order:** index, orderKey (bytes32), market (address), marketName, orderType (e.g. "LimitIncrease", "StopLossDecrease")
+**Output fields per order:** index, orderKey (bytes32), market (address), marketName, orderType (e.g. "LimitIncrease", "StopLossDecrease"), direction (LONG/SHORT), sizeUsd, collateralDelta, triggerPrice_usd, acceptablePrice_usd, collateralToken
 
 > Use `orderKey` directly as `--key` when calling `cancel-order`.
 
@@ -301,10 +302,13 @@ gmx-v2 --chain arbitrum close-position \
 - `--slippage-bps`: Acceptable slippage in basis points (default: 100 = 1%)
 
 **Flow:**
-1. Run `--dry-run` to preview
-2. **Ask user to confirm** position details before closing
-3. Submits via `onchainos wallet contract-call`
-4. Position closes within 1–30 seconds via keeper
+1. Run `--dry-run` to preview calldata, acceptable price, and execution fee
+2. Pre-flight: checks wallet ETH balance — returns `{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION"}` if ETH < execution fee + gas buffer
+3. **Ask user to confirm** position details before closing
+4. Submits with `--confirm` via `onchainos wallet contract-call`
+5. Position closes within 1–30 seconds via keeper
+
+**Output fields:** ok, dry_run, chain, txHash, market, collateralToken, sizeDeltaUsd, collateralToWithdraw (human-readable), isLong, acceptablePrice_usd, executionFee_eth, calldata (dry_run only)
 
 ---
 
@@ -342,9 +346,14 @@ gmx-v2 --chain arbitrum place-order \
 
 **Flow:**
 1. Run `--dry-run` to preview trigger and acceptable prices
-2. **Ask user to confirm** order type, trigger price, and size before placing
-3. Submits via `onchainos wallet contract-call`
-4. Order monitored by keeper and executed when trigger is reached
+2. Pre-flight: checks wallet ETH balance — returns `{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION"}` if insufficient
+3. Pre-flight (increase orders): checks collateral token balance — returns `{"ok":false,"error":"INSUFFICIENT_TOKEN_BALANCE"}` if insufficient
+4. **Ask user to confirm** order type, trigger price, and size before placing
+5. Submits with `--confirm` via `onchainos wallet contract-call`
+6. Returns `orderKey` (bytes32) of the newly created order — use with `cancel-order --key`
+7. Order monitored by keeper and executed when trigger is reached
+
+**Output fields:** ok, dry_run, chain, txHash, orderKey (null on dry-run), orderType, market, collateralToken, sizeDeltaUsd, triggerPrice_usd, acceptablePrice_usd, isLong, executionFee_eth, calldata (dry_run only)
 
 ---
 
@@ -358,9 +367,10 @@ gmx-v2 --chain arbitrum cancel-order \
 ```
 
 **Flow:**
-1. Run `--dry-run` to verify the key
+1. Run `--dry-run` to verify the key and preview calldata
 2. **Ask user to confirm** the order key before cancellation
-3. Submits `cancelOrder(bytes32)` via `onchainos wallet contract-call`
+3. Submits `cancelOrder(bytes32)` with `--confirm` via `onchainos wallet contract-call`
+4. Waits for tx confirmation on-chain before reporting `ok:true`
 
 ---
 
@@ -383,11 +393,14 @@ gmx-v2 --chain arbitrum deposit-liquidity \
 ```
 
 **Flow:**
-1. Run `--dry-run` to preview GM tokens to receive
-2. **Ask user to confirm** deposit amounts, market, and execution fee
-3. Plugin auto-approves tokens if allowance insufficient
-4. Submits multicall via `onchainos wallet contract-call`
-5. GM tokens minted within 1–30 seconds by keeper
+1. Run `--dry-run` to preview GM tokens to receive and execution fee
+2. Pre-flight: checks wallet ETH balance — returns `{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION"}` if insufficient
+3. Pre-flight: checks long token balance (if `--long-amount > 0`) — returns `{"ok":false,"error":"INSUFFICIENT_LONG_TOKEN_BALANCE"}` if insufficient
+4. Pre-flight: checks short token balance (if `--short-amount > 0`) — returns `{"ok":false,"error":"INSUFFICIENT_SHORT_TOKEN_BALANCE"}` if insufficient
+5. **Ask user to confirm** deposit amounts, market, and execution fee
+6. If token allowance is insufficient, binary prints a NOTE — re-run with `--confirm` to approve and deposit in one step
+7. Submits multicall with `--confirm` via `onchainos wallet contract-call`
+8. GM tokens minted within 1–30 seconds by keeper
 
 ---
 
@@ -404,11 +417,13 @@ gmx-v2 --chain arbitrum withdraw-liquidity \
 ```
 
 **Flow:**
-1. Run `--dry-run` to preview calldata
-2. **Ask user to confirm** GM amount to burn and minimum output amounts
-3. Plugin auto-approves GM token if allowance insufficient
-4. Submits multicall via `onchainos wallet contract-call`
-5. Underlying tokens returned within 1–30 seconds by keeper
+1. Run `--dry-run` to preview calldata and execution fee
+2. Pre-flight: checks wallet ETH balance — returns `{"ok":false,"error":"INSUFFICIENT_ETH_FOR_EXECUTION"}` if insufficient
+3. Pre-flight: checks GM token balance — returns `{"ok":false,"error":"INSUFFICIENT_GM_TOKEN_BALANCE"}` if wallet GM balance < `--gm-amount`
+4. **Ask user to confirm** GM amount to burn and minimum output amounts
+5. If GM token allowance is insufficient, binary prints a NOTE — re-run with `--confirm` to approve and withdraw in one step
+6. Submits multicall with `--confirm` via `onchainos wallet contract-call`
+7. Underlying tokens returned within 1–30 seconds by keeper
 
 ---
 
@@ -433,7 +448,10 @@ No execution fee ETH value needed for claims.
 **Flow:**
 1. Run `--dry-run` to verify the markets and tokens arrays
 2. **Ask user to confirm** the markets and receiver address before claiming
-3. Submits `claimFundingFees(address[],address[],address)` via `onchainos wallet contract-call`
+3. Submits `claimFundingFees(address[],address[],address)` with `--confirm` via `onchainos wallet contract-call`
+4. Returns `claimed` array — each entry has the token address and raw amount delta detected via pre/post ERC-20 balance diff
+
+**Output fields:** ok, dry_run, chain, txHash, claimed (array of `{token, claimedRaw}`, empty on dry-run)
 
 ---
 

--- a/skills/gmx-v2/plugin.yaml
+++ b/skills/gmx-v2/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: gmx-v2
-version: "0.2.1"
+version: "0.2.2"
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche"
 author:
   name: GeoGu360
@@ -24,6 +24,5 @@ api_calls:
   - "https://arbitrum-api.gmxinfra2.io"
   - "https://avalanche-api.gmxinfra.io"
   - "https://avalanche-api.gmxinfra2.io"
-  - "https://gmx.squids.live"
   - "https://arbitrum.publicnode.com"
   - "https://avalanche-c-chain-rpc.publicnode.com"

--- a/skills/gmx-v2/src/api.rs
+++ b/skills/gmx-v2/src/api.rs
@@ -210,6 +210,20 @@ pub async fn fetch_tokens(cfg: &crate::config::ChainConfig) -> anyhow::Result<Ve
     Ok(vec![])
 }
 
+/// Format a raw token amount into human-readable form (up to 6 decimal places).
+pub fn format_token_amount(amount: u128, decimals: u8) -> String {
+    if decimals == 0 {
+        return amount.to_string();
+    }
+    let display_decimals = (decimals as u32).min(6);
+    let divisor = 10u128.pow(decimals as u32);
+    let whole = amount / divisor;
+    let frac_full = amount % divisor;
+    let scale = (decimals as u32).saturating_sub(display_decimals);
+    let frac_display = frac_full / 10u128.pow(scale);
+    format!("{}.{:0>width$}", whole, frac_display, width = display_decimals as usize)
+}
+
 /// Convert raw GMX price to USD given token decimals.
 /// GMX stores prices as: price_usd * 10^(30 - token_decimals)
 /// So: price_usd = raw / 10^(30 - token_decimals)

--- a/skills/gmx-v2/src/commands/cancel_order.rs
+++ b/skills/gmx-v2/src/commands/cancel_order.rs
@@ -34,7 +34,22 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: CancelOrderArg
     eprintln!("=== Cancel Order Preview ===");
     eprintln!("Order key: {}", args.key);
     eprintln!("Exchange router: {}", cfg.exchange_router);
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "orderKey": args.key,
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
 
     let result = crate::onchainos::wallet_contract_call_with_gas(
         cfg.chain_id,
@@ -48,6 +63,24 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: CancelOrderArg
     ).await?;
 
     let tx_hash = crate::onchainos::extract_tx_hash(&result);
+
+    // G17: verify the cancel tx actually landed on-chain before reporting ok:true
+    if !dry_run {
+        if tx_hash == "pending" || tx_hash.is_empty() {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "ok": false,
+                    "error": "TX_NOT_SUBMITTED",
+                    "reason": "onchainos did not return a tx hash — transaction may not have been submitted",
+                    "chain": chain,
+                    "orderKey": args.key
+                }))?
+            );
+            return Ok(());
+        }
+        crate::onchainos::wait_for_tx(cfg.chain_id, &tx_hash, &wallet, 60)?;
+    }
 
     println!(
         "{}",

--- a/skills/gmx-v2/src/commands/claim_funding_fees.rs
+++ b/skills/gmx-v2/src/commands/claim_funding_fees.rs
@@ -55,7 +55,36 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClaimFundingFe
     eprintln!("Tokens: {:?}", token_addrs);
     eprintln!("Receiver: {}", receiver);
     eprintln!("Note: No execution fee needed for claims.");
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "markets": market_addrs,
+                "tokens": token_addrs,
+                "receiver": receiver,
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
+
+    // G20: snapshot balances before tx so we can report claimed amounts
+    let pre_balances: Vec<u128> = if confirm && !dry_run {
+        let mut bals = Vec::new();
+        for token in &token_addrs {
+            let bal = crate::rpc::check_erc20_balance(cfg.rpc_url, token, &receiver).await.unwrap_or(0);
+            bals.push(bal);
+        }
+        bals
+    } else {
+        vec![0u128; token_addrs.len()]
+    };
 
     let result = crate::onchainos::wallet_contract_call_with_gas(
         cfg.chain_id,
@@ -70,6 +99,20 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClaimFundingFe
 
     let tx_hash = crate::onchainos::extract_tx_hash(&result);
 
+    // G20: post-tx balance delta = claimed amounts
+    let claimed: Vec<serde_json::Value> = if confirm && !dry_run {
+        crate::onchainos::wait_for_tx(cfg.chain_id, &tx_hash, &wallet, 60)?;
+        let mut out = Vec::new();
+        for (i, token) in token_addrs.iter().enumerate() {
+            let post = crate::rpc::check_erc20_balance(cfg.rpc_url, token, &receiver).await.unwrap_or(0);
+            let delta = post.saturating_sub(pre_balances[i]);
+            out.push(json!({ "token": token, "claimedRaw": delta.to_string() }));
+        }
+        out
+    } else {
+        vec![]
+    };
+
     println!(
         "{}",
         serde_json::to_string_pretty(&json!({
@@ -80,6 +123,7 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClaimFundingFe
             "markets": market_addrs,
             "tokens": token_addrs,
             "receiver": receiver,
+            "claimed": claimed,
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?
     );

--- a/skills/gmx-v2/src/commands/close_position.rs
+++ b/skills/gmx-v2/src/commands/close_position.rs
@@ -45,6 +45,7 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
     // Fetch current prices for acceptable price calculation
     let markets = crate::api::fetch_markets(cfg).await?;
     let tickers = crate::api::fetch_prices(cfg).await?;
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
 
     // Find market to get index token
     let market_info = markets.iter().find(|m| {
@@ -75,11 +76,10 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
     // For decrease orders, GMX executes at:
     //   LONG close: min_price (selling at bid)   → need floor:   acceptable = min_price × (1 - slip)
     //   SHORT close: max_price (buying at ask)   → need ceiling: acceptable = max_price × (1 + slip)
-    // Use the actual execution-side price as the base in both cases.
     let (base_price, is_floor) = if args.long {
-        (min_price_raw, true)   // floor: price × (1 - slip)
+        (min_price_raw, true)
     } else {
-        (max_price_raw, false)  // ceiling: price × (1 + slip)
+        (max_price_raw, false)
     };
     let acceptable_price = crate::abi::compute_acceptable_price(base_price, is_floor, args.slippage_bps);
 
@@ -105,27 +105,74 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
     let multicall_hex = crate::abi::encode_multicall(&[send_wnt, create_order]);
     let calldata = format!("0x{}", multicall_hex);
 
-    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
     let index_decimals = market_info
         .and_then(|m| m.index_token.as_deref())
         .and_then(|addr| token_infos.iter().find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase())))
         .and_then(|t| t.decimals)
         .unwrap_or(18u8);
+    let collateral_decimals = token_infos.iter()
+        .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(args.collateral_token.to_lowercase()))
+        .and_then(|t| t.decimals)
+        .unwrap_or(6u8);
     let mid_price_usd = if min_price_raw == 0 && max_price_raw == 0 {
         0.0
     } else {
         (crate::api::raw_price_to_usd(min_price_raw, index_decimals) + crate::api::raw_price_to_usd(max_price_raw, index_decimals)) / 2.0
     };
 
+    let acceptable_price_usd = crate::api::raw_price_to_usd(acceptable_price, index_decimals);
+    let execution_fee_eth = execution_fee as f64 / 1e18;
+    let collateral_fmt = crate::api::format_token_amount(args.collateral_amount, collateral_decimals);
+
+    // Pre-flight: ETH balance for execution fee + gas
+    let eth_balance = crate::rpc::get_eth_balance(&wallet, cfg.rpc_url).await;
+    let gas_margin: u128 = 200_000_000_000_000; // 0.0002 ETH
+    let eth_required = execution_fee.saturating_add(gas_margin);
+    if eth_balance < eth_required {
+        println!("{}", serde_json::to_string_pretty(&json!({
+            "ok": false,
+            "error": "INSUFFICIENT_ETH_FOR_EXECUTION",
+            "reason": "Wallet does not have enough ETH to cover execution fee + gas.",
+            "eth_balance": format!("{:.8}", eth_balance as f64 / 1e18),
+            "execution_fee_eth": format!("{:.8}", execution_fee as f64 / 1e18),
+            "gas_buffer_eth": format!("{:.8}", gas_margin as f64 / 1e18),
+            "eth_required": format!("{:.8}", eth_required as f64 / 1e18),
+            "suggestion": format!("Top up wallet {} with at least {:.6} ETH.", wallet, (eth_required.saturating_sub(eth_balance)) as f64 / 1e18)
+        }))?);
+        return Ok(());
+    }
+
     eprintln!("=== Close Position Preview ===");
     eprintln!("Market token: {}", args.market_token);
     eprintln!("Direction: {}", if args.long { "LONG (closing)" } else { "SHORT (closing)" });
     eprintln!("Size to close: ${:.2} USD", args.size_usd);
-    eprintln!("Collateral to withdraw: {} units", args.collateral_amount);
+    eprintln!("Collateral to withdraw: {}", collateral_fmt);
     eprintln!("Current price: ${:.4}", mid_price_usd);
-    eprintln!("Acceptable price: {}", acceptable_price);
+    eprintln!("Acceptable price: ${:.4}", acceptable_price_usd);
     eprintln!("⚠ GMX V2 keeper model: position closes 1-30s after tx lands.");
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "marketToken": args.market_token,
+                "collateralToken": args.collateral_token,
+                "direction": if args.long { "long" } else { "short" },
+                "sizeToClose_usd": args.size_usd,
+                "collateralToWithdraw": collateral_fmt,
+                "currentPrice_usd": format!("{:.4}", mid_price_usd),
+                "acceptablePrice_usd": format!("{:.4}", acceptable_price_usd),
+                "executionFee_eth": format!("{:.6}", execution_fee_eth),
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
 
     let result = crate::onchainos::wallet_contract_call(
         cfg.chain_id,
@@ -147,12 +194,13 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: ClosePositionA
             "chain": chain,
             "txHash": tx_hash,
             "marketToken": args.market_token,
+            "collateralToken": args.collateral_token,
             "direction": if args.long { "long" } else { "short" },
             "sizeToClose_usd": args.size_usd,
-            "collateralToWithdraw": args.collateral_amount.to_string(),
+            "collateralToWithdraw": collateral_fmt,
             "currentPrice_usd": format!("{:.4}", mid_price_usd),
-            "acceptablePrice": acceptable_price.to_string(),
-            "executionFeeWei": execution_fee,
+            "acceptablePrice_usd": format!("{:.4}", acceptable_price_usd),
+            "executionFee_eth": format!("{:.6}", execution_fee_eth),
             "note": "GMX V2 keeper model: position closes within 1-30s after tx confirmation",
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?

--- a/skills/gmx-v2/src/commands/deposit_liquidity.rs
+++ b/skills/gmx-v2/src/commands/deposit_liquidity.rs
@@ -50,10 +50,76 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
     let short_token = market.short_token.as_deref()
         .ok_or_else(|| anyhow::anyhow!("Market has no shortToken"))?;
 
-    let execution_fee = cfg.execution_fee_wei;
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
+    let long_decimals = token_infos.iter()
+        .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(long_token.to_lowercase()))
+        .and_then(|t| t.decimals).unwrap_or(18u8);
+    let short_decimals = token_infos.iter()
+        .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(short_token.to_lowercase()))
+        .and_then(|t| t.decimals).unwrap_or(6u8);
+    let long_fmt = crate::api::format_token_amount(args.long_amount, long_decimals);
+    let short_fmt = crate::api::format_token_amount(args.short_amount, short_decimals);
+    let min_gm_fmt = crate::api::format_token_amount(args.min_market_tokens, 18);
 
-    // Approve long token if needed
-    if !dry_run && args.long_amount > 0 {
+    let execution_fee = cfg.execution_fee_wei;
+    let execution_fee_eth = execution_fee as f64 / 1e18;
+
+    // Pre-flight: ETH balance for execution fee + gas
+    let eth_balance = crate::rpc::get_eth_balance(&wallet, cfg.rpc_url).await;
+    let gas_margin: u128 = 200_000_000_000_000; // 0.0002 ETH
+    let eth_required = execution_fee.saturating_add(gas_margin);
+    if eth_balance < eth_required {
+        println!("{}", serde_json::to_string_pretty(&json!({
+            "ok": false,
+            "error": "INSUFFICIENT_ETH_FOR_EXECUTION",
+            "reason": "Wallet does not have enough ETH to cover execution fee + gas.",
+            "eth_balance": format!("{:.8}", eth_balance as f64 / 1e18),
+            "execution_fee_eth": format!("{:.8}", execution_fee as f64 / 1e18),
+            "gas_buffer_eth": format!("{:.8}", gas_margin as f64 / 1e18),
+            "eth_required": format!("{:.8}", eth_required as f64 / 1e18),
+            "suggestion": format!("Top up wallet {} with at least {:.6} ETH.", wallet, (eth_required.saturating_sub(eth_balance)) as f64 / 1e18)
+        }))?);
+        return Ok(());
+    }
+
+    // Pre-flight: token balance checks
+    if args.long_amount > 0 {
+        let bal = crate::rpc::check_erc20_balance(cfg.rpc_url, long_token, &wallet).await.unwrap_or(u128::MAX);
+        if bal < args.long_amount {
+            println!("{}", serde_json::to_string_pretty(&json!({
+                "ok": false,
+                "error": "INSUFFICIENT_LONG_TOKEN_BALANCE",
+                "reason": "Wallet long token balance is less than --long-amount.",
+                "token": long_token,
+                "wallet_balance": bal.to_string(),
+                "wallet_balance_formatted": crate::api::format_token_amount(bal, long_decimals),
+                "required_amount": args.long_amount.to_string(),
+                "required_formatted": long_fmt,
+                "suggestion": format!("Reduce --long-amount to at most {} or top up the token.", bal)
+            }))?);
+            return Ok(());
+        }
+    }
+    if args.short_amount > 0 {
+        let bal = crate::rpc::check_erc20_balance(cfg.rpc_url, short_token, &wallet).await.unwrap_or(u128::MAX);
+        if bal < args.short_amount {
+            println!("{}", serde_json::to_string_pretty(&json!({
+                "ok": false,
+                "error": "INSUFFICIENT_SHORT_TOKEN_BALANCE",
+                "reason": "Wallet short token balance is less than --short-amount.",
+                "token": short_token,
+                "wallet_balance": bal.to_string(),
+                "wallet_balance_formatted": crate::api::format_token_amount(bal, short_decimals),
+                "required_amount": args.short_amount.to_string(),
+                "required_formatted": short_fmt,
+                "suggestion": format!("Reduce --short-amount to at most {} or top up the token.", bal)
+            }))?);
+            return Ok(());
+        }
+    }
+
+    // Approve long token if needed (only when about to execute)
+    if confirm && !dry_run && args.long_amount > 0 {
         let allowance = crate::onchainos::check_allowance(
             cfg.rpc_url, long_token, &wallet, cfg.router,
         ).await.unwrap_or(0);
@@ -68,8 +134,8 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
         }
     }
 
-    // Approve short token if needed
-    if !dry_run && args.short_amount > 0 {
+    // Approve short token if needed (only when about to execute)
+    if confirm && !dry_run && args.short_amount > 0 {
         let allowance = crate::onchainos::check_allowance(
             cfg.rpc_url, short_token, &wallet, cfg.router,
         ).await.unwrap_or(0);
@@ -113,12 +179,35 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
     eprintln!("=== Deposit Liquidity Preview ===");
     eprintln!("Market: {}", market.name.as_deref().unwrap_or("?"));
     eprintln!("Market token: {}", market_token);
-    eprintln!("Long token amount: {}", args.long_amount);
-    eprintln!("Short token amount: {}", args.short_amount);
-    eprintln!("Min GM tokens to receive: {}", args.min_market_tokens);
-    eprintln!("Execution fee: {} wei", execution_fee);
+    eprintln!("Long token amount: {}", long_fmt);
+    eprintln!("Short token amount: {}", short_fmt);
+    eprintln!("Min GM tokens to receive: {}", min_gm_fmt);
+    if args.min_market_tokens == 0 {
+        eprintln!("⚠ min-market-tokens is 0 — no slippage protection on GM tokens received.");
+    }
+    eprintln!("Execution fee: {:.6} ETH", execution_fee_eth);
     eprintln!("⚠ GMX V2 keeper model: GM tokens minted 1-30s after tx lands.");
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "market": market.name,
+                "marketToken": market_token,
+                "longTokenAmount": long_fmt,
+                "shortTokenAmount": short_fmt,
+                "minGmTokens": min_gm_fmt,
+                "executionFee_eth": format!("{:.6}", execution_fee_eth),
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
 
     let result = crate::onchainos::wallet_contract_call_with_gas(
         cfg.chain_id,
@@ -142,10 +231,10 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: DepositLiquidi
             "txHash": tx_hash,
             "market": market.name,
             "marketToken": market_token,
-            "longTokenAmount": args.long_amount.to_string(),
-            "shortTokenAmount": args.short_amount.to_string(),
-            "minGmTokens": args.min_market_tokens.to_string(),
-            "executionFeeWei": execution_fee,
+            "longTokenAmount": long_fmt,
+            "shortTokenAmount": short_fmt,
+            "minGmTokens": min_gm_fmt,
+            "executionFee_eth": format!("{:.6}", execution_fee_eth),
             "note": "GM tokens will be minted within 1-30s after tx confirmation by keeper",
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?

--- a/skills/gmx-v2/src/commands/get_orders.rs
+++ b/skills/gmx-v2/src/commands/get_orders.rs
@@ -35,6 +35,7 @@ pub async fn run(chain: &str, args: GetOrdersArgs) -> anyhow::Result<()> {
     }
 
     let markets = crate::api::fetch_markets(cfg).await.unwrap_or_default();
+    let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
 
     // Build getAccountOrders(dataStore, account, start=0, end=20) calldata
     // Selector: 0x42a6f8d3
@@ -47,7 +48,7 @@ pub async fn run(chain: &str, args: GetOrdersArgs) -> anyhow::Result<()> {
 
     let raw = crate::rpc::eth_call(cfg.reader, &calldata, cfg.rpc_url).await?;
 
-    let orders = parse_orders(&raw, &markets);
+    let orders = parse_orders(&raw, &markets, &token_infos);
 
     println!(
         "{}",
@@ -62,7 +63,47 @@ pub async fn run(chain: &str, args: GetOrdersArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Value> {
+/// Parse orders from raw ABI bytes.
+///
+/// Order.Props ABI layout (from on-chain dump analysis):
+///
+/// Each element = (bytes32 key, Order.Props props) where Order.Props is dynamic.
+///
+/// Props head (18 words = 576 bytes):
+///   word  0: Addresses offset (= 576)
+///   word  1: orderType         (uint8)
+///   word  2: decreasePositionSwapType (uint8)
+///   word  3: sizeDeltaUsd      (uint256, ×10^30)
+///   word  4: initialCollateralDeltaAmount (uint256, token units)
+///   word  5: triggerPrice      (uint256, price × 10^(30-indexDecimals))
+///   word  6: acceptablePrice   (uint256, same format)
+///   word  7: executionFee      (uint256, wei)
+///   word  8: callbackGasLimit  (uint256)
+///   word  9: minOutputAmount   (uint256)
+///   word 10: validFromTime     (uint256, unix ts)
+///   word 11: isLong            (bool)
+///   word 12: shouldUnwrapNativeToken (bool)
+///   word 13: autoCancel        (bool)
+///   word 14: referralCode      (bytes32)
+///   word 15: (reserved)
+///   word 16: (reserved)
+///   word 17: dataList offset   (dynamic)
+///
+/// Addresses (at props_base + 576, 9 words):
+///   word  0: account
+///   word  1: receiver
+///   word  2: cancellationReceiver
+///   word  3: callbackContract
+///   word  4: uiFeeReceiver
+///   word  5: market
+///   word  6: initialCollateralToken
+///   word  7: swapPath offset (relative to Addresses start)
+///   word  8: swapPath length (= 0 for most orders)
+fn parse_orders(
+    raw: &str,
+    markets: &[crate::api::Market],
+    token_infos: &[crate::api::TokenInfo],
+) -> Vec<serde_json::Value> {
     let data = raw.trim_start_matches("0x");
     if data.len() < 128 {
         return vec![];
@@ -81,7 +122,6 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
     }
 
     // Order is dynamic (Addresses has swapPath[]), so each element has an offset pointer.
-    // ABI offset for element i is stored at data_start + i*64 and is RELATIVE to data_start.
     let data_start = array_offset + 64; // right after length word, in hex chars
     let mut results = Vec::new();
 
@@ -92,7 +132,6 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
         }
         let elem_offset_hex = &data[ptr_start..ptr_start + 64];
         let elem_offset_bytes = usize::from_str_radix(elem_offset_hex, 16).unwrap_or(0);
-        // elem_base: offset is relative to the start of the pointer block (data_start)
         let elem_base = data_start + elem_offset_bytes * 2;
 
         if data.len() < elem_base + 4 * 64 {
@@ -100,64 +139,115 @@ fn parse_orders(raw: &str, markets: &[crate::api::Market]) -> Vec<serde_json::Va
             continue;
         }
 
-        // Each element is encoded as a tuple: (bytes32 key, Order.Props props)
-        // OR just Order.Props depending on GMX version; empirically we see bytes32 at word 0.
-        // word 0 (elem_base): bytes32 order key
-        // word 1 (elem_base+64): offset to Order.Props struct (relative to elem_base)
+        // word 0: bytes32 order key
         let key_hex = &data[elem_base..elem_base + 64];
         let order_key = format!("0x{}", key_hex);
 
-        // Order.Props offset relative to elem_base
+        // word 1: offset to Order.Props (relative to elem_base)
         let props_rel_hex = &data[elem_base + 64..elem_base + 128];
         let props_rel = usize::from_str_radix(props_rel_hex, 16).unwrap_or(0) * 2;
         let props_base = elem_base + props_rel;
 
-        // Order.Props encoding (dynamic struct):
-        // word 0: offset to Addresses encoding (relative to props_base)
-        // words 1-14: Numbers fields inline (orderType at word 10 after accounting for structure)
-        //
-        // Empirically, Numbers.orderType is at props_base + 10*64 for our GMX V2 version.
-        // Addresses struct (at tail): account(0), receiver(1), cancellationReceiver(2),
-        //   callbackContract(3), uiFeeReceiver(4), market(5), initialCollateralToken(6),
-        //   swapPath offset(7), swapPath length(8+)
-        let (market_addr, order_type_val) = if data.len() >= props_base + 20 * 64 {
-            // Get addresses offset within props
-            let addr_off_hex = &data[props_base..props_base + 64];
-            let addr_off = usize::from_str_radix(addr_off_hex, 16).unwrap_or(0) * 2;
-            let addr_base = props_base + addr_off;
-            // market is at offset 5 within Addresses
-            let market = extract_address(data, addr_base + 5 * 64);
-            // orderType is Numbers.orderType, which is at props_base + 1*64 (first Numbers field)
-            let order_type_raw = if data.len() >= props_base + 2 * 64 {
-                let ot_hex = &data[props_base + 64..props_base + 128];
-                u8::try_from(usize::from_str_radix(ot_hex, 16).unwrap_or(0)).unwrap_or(0)
-            } else { 0 };
-            (market, order_type_raw)
-        } else {
-            ("0x0".to_string(), 0u8)
-        };
+        if data.len() < props_base + 18 * 64 {
+            results.push(json!({ "index": i, "orderKey": order_key }));
+            continue;
+        }
 
-        let market_name = markets
-            .iter()
-            .find(|m| {
-                m.market_token
-                    .as_deref()
-                    .map(|t| t.to_lowercase() == market_addr.to_lowercase())
-                    .unwrap_or(false)
-            })
+        // Props word 0: Addresses offset (relative to props_base, in bytes)
+        let addr_off_hex = &data[props_base..props_base + 64];
+        let addr_off = usize::from_str_radix(addr_off_hex, 16).unwrap_or(0) * 2;
+        let addr_base = props_base + addr_off;
+
+        // Props word 1: orderType
+        let order_type_val = extract_u8(data, props_base + 64);
+
+        // Props word 3: sizeDeltaUsd (×10^30)
+        let size_delta_raw = extract_u128(data, props_base + 3 * 64);
+        let size_usd = size_delta_raw as f64 / 1e30;
+
+        // Props word 4: initialCollateralDeltaAmount
+        let collateral_delta_raw = extract_u128(data, props_base + 4 * 64);
+
+        // Props word 5: triggerPrice (price × 10^(30 - indexDecimals))
+        let trigger_price_raw = extract_u128(data, props_base + 5 * 64);
+
+        // Props word 6: acceptablePrice
+        let acceptable_price_raw = extract_u128(data, props_base + 6 * 64);
+
+        // Props word 11: isLong (bool)
+        let is_long = extract_u128(data, props_base + 11 * 64) != 0;
+
+        // Addresses word 5: market
+        let market_addr = extract_address(data, addr_base + 5 * 64);
+
+        // Addresses word 6: initialCollateralToken
+        let collateral_token = extract_address(data, addr_base + 6 * 64);
+
+        // Market metadata
+        let market_info = markets.iter().find(|m| {
+            m.market_token
+                .as_deref()
+                .map(|t| t.to_lowercase() == market_addr.to_lowercase())
+                .unwrap_or(false)
+        });
+        let market_name = market_info
             .and_then(|m| m.name.clone())
             .unwrap_or_else(|| market_addr.clone());
+
+        // Index token decimals for price display
+        let index_decimals = market_info
+            .and_then(|m| m.index_token.as_deref())
+            .and_then(|addr| {
+                token_infos.iter()
+                    .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(addr.to_lowercase()))
+                    .and_then(|t| t.decimals)
+            })
+            .unwrap_or(18u8);
+
+        // Collateral token decimals
+        let collateral_decimals = token_infos.iter()
+            .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(collateral_token.to_lowercase()))
+            .and_then(|t| t.decimals)
+            .unwrap_or(6u8);
+
+        let trigger_price_usd = crate::api::raw_price_to_usd(trigger_price_raw, index_decimals);
+        let acceptable_price_usd = crate::api::raw_price_to_usd(acceptable_price_raw, index_decimals);
+        let collateral_delta_fmt = crate::api::format_token_amount(collateral_delta_raw, collateral_decimals);
 
         results.push(json!({
             "index": i,
             "orderKey": order_key,
             "market": market_addr,
             "marketName": market_name,
+            "collateralToken": collateral_token,
             "orderType": order_type_name(order_type_val),
+            "direction": if is_long { "LONG" } else { "SHORT" },
+            "sizeUsd": format!("{:.4}", size_usd),
+            "collateralDelta": collateral_delta_fmt,
+            "triggerPrice_usd": format!("{:.4}", trigger_price_usd),
+            "acceptablePrice_usd": format!("{:.4}", acceptable_price_usd),
         }));
     }
 
     results
+}
+
+fn extract_u8(data: &str, hex_offset: usize) -> u8 {
+    if data.len() < hex_offset + 64 {
+        return 0;
+    }
+    let slot = &data[hex_offset..hex_offset + 64];
+    usize::from_str_radix(slot, 16).unwrap_or(0) as u8
+}
+
+fn extract_u128(data: &str, hex_offset: usize) -> u128 {
+    if data.len() < hex_offset + 64 {
+        return 0;
+    }
+    // u128 can only hold 32 hex chars; take the lower 32 chars to avoid overflow
+    let slot = &data[hex_offset..hex_offset + 64];
+    let lower = &slot[32..]; // last 16 bytes = 32 hex chars
+    u128::from_str_radix(lower, 16).unwrap_or(0)
 }
 
 fn extract_address(data: &str, byte_offset: usize) -> String {
@@ -169,4 +259,36 @@ fn extract_address(data: &str, byte_offset: usize) -> String {
         return "0x0".to_string();
     }
     format!("0x{}", &slot[slot.len() - 40..])
+}
+
+/// Extract just the order keys (bytes32) from raw ABI-encoded getAccountOrders response.
+/// Used by place-order to diff pre/post order sets and find the newly created key.
+pub fn extract_order_keys(raw: &str) -> Vec<String> {
+    let data = raw.trim_start_matches("0x");
+    if data.len() < 128 {
+        return vec![];
+    }
+    let array_offset = usize::from_str_radix(&data[0..64], 16).unwrap_or(0) * 2;
+    if data.len() < array_offset + 64 {
+        return vec![];
+    }
+    let array_len = usize::from_str_radix(&data[array_offset..array_offset + 64], 16).unwrap_or(0);
+    if array_len == 0 {
+        return vec![];
+    }
+    let data_start = array_offset + 64;
+    let mut keys = Vec::new();
+    for i in 0..array_len.min(20) {
+        let ptr_start = data_start + i * 64;
+        if data.len() < ptr_start + 64 {
+            break;
+        }
+        let elem_offset_bytes = usize::from_str_radix(&data[ptr_start..ptr_start + 64], 16).unwrap_or(0);
+        let elem_base = data_start + elem_offset_bytes * 2;
+        if data.len() < elem_base + 64 {
+            continue;
+        }
+        keys.push(format!("0x{}", &data[elem_base..elem_base + 64]));
+    }
+    keys
 }

--- a/skills/gmx-v2/src/commands/list_markets.rs
+++ b/skills/gmx-v2/src/commands/list_markets.rs
@@ -51,6 +51,13 @@ pub async fn run(chain: &str, args: ListMarketsArgs) -> anyhow::Result<()> {
                 .parse::<u128>()
                 .unwrap_or(0);
 
+            // GMX stats API returns rates as (annual_rate_decimal × FLOAT_PRECISION)
+            // where FLOAT_PRECISION = 10^30. So: annual_pct = raw / 10^30 * 100 = raw / 10^28
+            let to_annual = |raw: Option<&str>| -> String {
+                raw.and_then(|s| s.parse::<f64>().ok())
+                    .map(|r| format!("{:.4}%", r / 1e28))
+                    .unwrap_or_else(|| "0.0000%".to_string())
+            };
             json!({
                 "name": m.name,
                 "marketToken": m.market_token,
@@ -61,10 +68,10 @@ pub async fn run(chain: &str, args: ListMarketsArgs) -> anyhow::Result<()> {
                 "availableLiquidityShort_usd": format!("{:.2}", liq_short as f64 / 1e30),
                 "openInterestLong_usd": format!("{:.2}", oi_long as f64 / 1e30),
                 "openInterestShort_usd": format!("{:.2}", oi_short as f64 / 1e30),
-                "fundingRateLong": m.funding_rate_long,
-                "fundingRateShort": m.funding_rate_short,
-                "borrowingRateLong": m.borrowing_rate_long,
-                "borrowingRateShort": m.borrowing_rate_short,
+                "fundingRateLong_annual": to_annual(m.funding_rate_long.as_deref()),
+                "fundingRateShort_annual": to_annual(m.funding_rate_short.as_deref()),
+                "borrowingRateLong_annual": to_annual(m.borrowing_rate_long.as_deref()),
+                "borrowingRateShort_annual": to_annual(m.borrowing_rate_short.as_deref()),
             })
         })
         .collect();

--- a/skills/gmx-v2/src/commands/open_position.rs
+++ b/skills/gmx-v2/src/commands/open_position.rs
@@ -3,7 +3,6 @@ use serde_json::json;
 
 /// Convert a USD float to GMX 30-decimal u128 without floating-point precision loss.
 fn parse_usd_to_u128(val: f64) -> u128 {
-    // Split into integer and fractional parts to avoid (val * 1e30) overflow/imprecision
     let integer_part = val.floor() as u128;
     let frac_part = val - val.floor();
     let precision: u128 = 1_000_000_000_000_000_000_000_000_000_000; // 10^30
@@ -68,13 +67,17 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     let min_price_raw: u128 = price_tick.min_price.as_deref().unwrap_or("0").parse().unwrap_or(0);
     let max_price_raw: u128 = price_tick.max_price.as_deref().unwrap_or("0").parse().unwrap_or(0);
-    // GMX prices are stored as price_usd * 10^(30 - token_decimals).
-    // For display, fetch token decimals to convert properly. Default to 18.
+
     let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
     let index_decimals = token_infos.iter()
         .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(index_token.to_lowercase()))
         .and_then(|t| t.decimals)
         .unwrap_or(18u8);
+    let collateral_decimals = token_infos.iter()
+        .find(|t| t.address.as_deref().map(|a| a.to_lowercase()) == Some(args.collateral_token.to_lowercase()))
+        .and_then(|t| t.decimals)
+        .unwrap_or(6u8);
+
     let min_price_usd = crate::api::raw_price_to_usd(min_price_raw, index_decimals);
     let max_price_usd = crate::api::raw_price_to_usd(max_price_raw, index_decimals);
     let mid_price_usd = (min_price_usd + max_price_usd) / 2.0;
@@ -99,46 +102,9 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     // Compute acceptable price with slippage
     let base_price = if args.long { min_price_raw } else { max_price_raw };
-    // Increase acceptable price (opposite of close):
-    //   LONG open:  ceiling = min_price * (1+slip) → keeper check: execution <= acceptable → pass false
-    //   SHORT open: floor   = max_price * (1-slip) → keeper check: execution >= acceptable → pass true
-    // Both cases = !args.long
     let acceptable_price = crate::abi::compute_acceptable_price(base_price, !args.long, args.slippage_bps);
 
     let execution_fee = cfg.execution_fee_wei;
-
-    // Check ERC-20 allowance and approve if needed.
-    // Guard with `confirm` so approve and the main TX are always in sync:
-    // without --confirm neither fires; with --confirm both fire.
-    if !dry_run {
-        let allowance = crate::onchainos::check_allowance(
-            cfg.rpc_url,
-            &args.collateral_token,
-            &wallet,
-            cfg.router,
-        ).await.unwrap_or(0);
-
-        if allowance < args.collateral_amount {
-            if !confirm {
-                eprintln!("NOTE: Allowance insufficient ({} < {}). Re-run with --confirm to approve and open position.",
-                    allowance, args.collateral_amount);
-            } else {
-                eprintln!("Approving {} collateral token to router {}...", args.collateral_amount, cfg.router);
-                let approve_result = crate::onchainos::erc20_approve(
-                    cfg.chain_id,
-                    &args.collateral_token,
-                    cfg.router,
-                    args.collateral_amount,
-                    Some(&wallet),
-                    false,
-                    true,
-                ).await?;
-                let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
-                eprintln!("Approval tx: {}", approve_hash);
-                crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
-            }
-        }
-    }
 
     // Build multicall: [sendWnt, sendTokens, createOrder]
     let send_wnt = crate::abi::encode_send_wnt(cfg.order_vault, execution_fee);
@@ -164,12 +130,6 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
 
     let multicall_hex = crate::abi::encode_multicall(&[send_wnt, send_tokens, create_order]);
     let calldata = format!("0x{}", multicall_hex);
-
-    let leverage = if mid_price_usd > 0.0 {
-        args.size_usd / (args.collateral_amount as f64 / 1e6)
-    } else {
-        0.0
-    };
 
     // Pre-flight check 1 — ERC-20 token balance
     let token_balance = crate::rpc::check_erc20_balance(
@@ -238,18 +198,71 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
         return Ok(());
     }
 
-    // Preview
+    let acceptable_price_usd = crate::api::raw_price_to_usd(acceptable_price, index_decimals);
+    let execution_fee_eth = execution_fee as f64 / 1e18;
+    let collateral_fmt = crate::api::format_token_amount(args.collateral_amount, collateral_decimals);
+    let leverage = if mid_price_usd > 0.0 && args.collateral_amount > 0 {
+        args.size_usd / (args.collateral_amount as f64 / 10f64.powi(collateral_decimals as i32))
+    } else {
+        0.0
+    };
+
     eprintln!("=== Open Position Preview ===");
     eprintln!("Market: {}", market.name.as_deref().unwrap_or("?"));
     eprintln!("Direction: {}", if args.long { "LONG" } else { "SHORT" });
     eprintln!("Size: ${:.2} USD", args.size_usd);
-    eprintln!("Collateral: {} units (${:.4} USD)", args.collateral_amount, collateral_usd_30 as f64 / 1e30);
+    eprintln!("Collateral: {} (${:.4} USD)", collateral_fmt, collateral_usd_30 as f64 / 1e30);
     eprintln!("Current price: ${:.4}", mid_price_usd);
-    eprintln!("Acceptable price: {}", acceptable_price);
-    eprintln!("Execution fee: {} wei", execution_fee);
+    eprintln!("Acceptable price: ${:.4}", acceptable_price_usd);
+    eprintln!("Execution fee: {:.6} ETH", execution_fee_eth);
     eprintln!("Estimated leverage: {:.1}x", leverage);
     eprintln!("⚠ GMX V2 uses a keeper model — position opens 1-30s after tx lands.");
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    // G5: preview-only path — never call onchainos without --confirm
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "market": market.name,
+                "marketToken": market_token,
+                "direction": if args.long { "long" } else { "short" },
+                "sizeDeltaUsd": args.size_usd,
+                "collateralAmount": collateral_fmt,
+                "entryPrice_approx_usd": format!("{:.4}", mid_price_usd),
+                "acceptablePrice_usd": format!("{:.4}", acceptable_price_usd),
+                "executionFee_eth": format!("{:.6}", execution_fee_eth),
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
+
+    // G7: allowance check only runs when about to execute (after all pre-flight passed)
+    if confirm && !dry_run {
+        let allowance = crate::onchainos::check_allowance(
+            cfg.rpc_url, &args.collateral_token, &wallet, cfg.router,
+        ).await.unwrap_or(0);
+        if allowance < args.collateral_amount {
+            eprintln!("Approving collateral token to router...");
+            let approve_result = crate::onchainos::erc20_approve(
+                cfg.chain_id,
+                &args.collateral_token,
+                cfg.router,
+                args.collateral_amount,
+                Some(&wallet),
+                false,
+                true,
+            ).await?;
+            let approve_hash = crate::onchainos::extract_tx_hash(&approve_result);
+            eprintln!("Approval tx: {}", approve_hash);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
+        }
+    }
 
     let result = crate::onchainos::wallet_contract_call(
         cfg.chain_id,
@@ -274,10 +287,10 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: OpenPositionAr
             "marketToken": market_token,
             "direction": if args.long { "long" } else { "short" },
             "sizeDeltaUsd": args.size_usd,
-            "collateralAmount": args.collateral_amount.to_string(),
+            "collateralAmount": collateral_fmt,
             "entryPrice_approx_usd": format!("{:.4}", mid_price_usd),
-            "acceptablePrice": acceptable_price.to_string(),
-            "executionFeeWei": execution_fee,
+            "acceptablePrice_usd": format!("{:.4}", acceptable_price_usd),
+            "executionFee_eth": format!("{:.6}", execution_fee_eth),
             "note": "GMX V2 keeper model: position will open within 1-30s after tx confirmation",
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?

--- a/skills/gmx-v2/src/commands/place_order.rs
+++ b/skills/gmx-v2/src/commands/place_order.rs
@@ -86,9 +86,6 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
     let order_type_u8 = args.order_type.to_u8();
 
     // Look up index token decimals so we can convert USD → raw GMX price format.
-    // GMX price format: price_usd × 10^(30 - token_decimals)
-    //   BTC (8 dec)  → × 10^22
-    //   ETH (18 dec) → × 10^12
     let markets = crate::api::fetch_markets(cfg).await?;
     let token_infos = crate::api::fetch_tokens(cfg).await.unwrap_or_default();
     let market_info = markets.iter().find(|m| {
@@ -115,7 +112,7 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
     let trigger_price = usd_to_raw(args.trigger_price_usd);
     let acceptable_price = usd_to_raw(args.acceptable_price_usd);
 
-    // size_delta_usd is in GMX's 10^30 USD precision (not token-decimal-adjusted)
+    // size_delta_usd is in GMX's 10^30 USD precision
     let size_delta_usd = {
         let int_part = args.size_usd.floor() as u128;
         let frac_part = args.size_usd - args.size_usd.floor();
@@ -167,6 +164,42 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
     let multicall_hex = crate::abi::encode_multicall(&inner_calls);
     let calldata = format!("0x{}", multicall_hex);
 
+    // Pre-flight: ETH balance for execution fee + gas
+    let eth_balance = crate::rpc::get_eth_balance(&wallet, cfg.rpc_url).await;
+    let gas_margin: u128 = 200_000_000_000_000; // 0.0002 ETH
+    let eth_required = execution_fee.saturating_add(gas_margin);
+    if eth_balance < eth_required {
+        println!("{}", serde_json::to_string_pretty(&json!({
+            "ok": false,
+            "error": "INSUFFICIENT_ETH_FOR_EXECUTION",
+            "reason": "Wallet does not have enough ETH to cover execution fee + gas.",
+            "eth_balance": format!("{:.8}", eth_balance as f64 / 1e18),
+            "execution_fee_eth": format!("{:.8}", execution_fee as f64 / 1e18),
+            "gas_buffer_eth": format!("{:.8}", gas_margin as f64 / 1e18),
+            "eth_required": format!("{:.8}", eth_required as f64 / 1e18),
+            "suggestion": format!("Top up wallet {} with at least {:.6} ETH.", wallet, (eth_required.saturating_sub(eth_balance)) as f64 / 1e18)
+        }))?);
+        return Ok(());
+    }
+
+    // Pre-flight: for increase orders, check collateral token balance
+    if matches!(order_type_u8, 3 | 8) && args.collateral_amount > 0 {
+        let bal = crate::rpc::check_erc20_balance(cfg.rpc_url, &args.collateral_token, &wallet).await.unwrap_or(u128::MAX);
+        if bal < args.collateral_amount {
+            println!("{}", serde_json::to_string_pretty(&json!({
+                "ok": false,
+                "error": "INSUFFICIENT_COLLATERAL_BALANCE",
+                "reason": "Wallet collateral token balance is less than the required collateral amount.",
+                "collateral_token": args.collateral_token,
+                "wallet_balance": bal.to_string(),
+                "required_amount": args.collateral_amount.to_string(),
+                "suggestion": format!("Reduce --collateral-amount to at most {} or top up the collateral token.", bal)
+            }))?);
+            return Ok(());
+        }
+    }
+
+    let execution_fee_eth = execution_fee as f64 / 1e18;
     eprintln!("=== Place Order Preview ===");
     eprintln!("Order type: {}", args.order_type.name());
     eprintln!("Market token: {}", args.market_token);
@@ -176,11 +209,45 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
     eprintln!("Acceptable price: ${:.4} (raw: {})", args.acceptable_price_usd, acceptable_price);
     eprintln!("Index token decimals: {}", index_decimals);
     eprintln!("Current price: ${:.4}", current_price_usd);
-    eprintln!("Execution fee: {} wei", execution_fee);
-    eprintln!("Ask user to confirm before proceeding.");
+    eprintln!("Execution fee: {:.6} ETH", execution_fee_eth);
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "orderType": args.order_type.name(),
+                "marketToken": args.market_token,
+                "direction": if args.long { "long" } else { "short" },
+                "sizeUsd": args.size_usd,
+                "triggerPrice_usd": args.trigger_price_usd,
+                "acceptablePrice_usd": args.acceptable_price_usd,
+                "executionFee_eth": format!("{:.6}", execution_fee_eth),
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
+
+    // G19: snapshot existing order keys so we can diff after tx to find the new orderKey
+    let orders_calldata = {
+        let ds = cfg.datastore.trim_start_matches("0x");
+        let wlt = wallet.trim_start_matches("0x");
+        format!("0x42a6f8d3{:0>64}{:0>64}{:064x}{:064x}", ds, wlt, 0u128, 20u128)
+    };
+    let pre_keys: std::collections::HashSet<String> = if confirm && !dry_run {
+        let raw = crate::rpc::eth_call(cfg.reader, &orders_calldata, cfg.rpc_url).await.unwrap_or_default();
+        crate::commands::get_orders::extract_order_keys(&raw).into_iter().collect()
+    } else {
+        Default::default()
+    };
 
     // For increase orders, check/approve collateral first
-    if !dry_run && matches!(order_type_u8, 3 | 8) {
+    if confirm && !dry_run && matches!(order_type_u8, 3 | 8) {
         let allowance = crate::onchainos::check_allowance(
             cfg.rpc_url,
             &args.collateral_token,
@@ -217,6 +284,16 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
 
     let tx_hash = crate::onchainos::extract_tx_hash(&result);
 
+    // G19: after tx confirms, query orders and find the newly created orderKey
+    let new_order_key: Option<String> = if confirm && !dry_run {
+        crate::onchainos::wait_for_tx(cfg.chain_id, &tx_hash, &wallet, 60)?;
+        let raw_after = crate::rpc::eth_call(cfg.reader, &orders_calldata, cfg.rpc_url).await.unwrap_or_default();
+        let post_keys: std::collections::HashSet<String> = crate::commands::get_orders::extract_order_keys(&raw_after).into_iter().collect();
+        post_keys.difference(&pre_keys).next().cloned()
+    } else {
+        None
+    };
+
     println!(
         "{}",
         serde_json::to_string_pretty(&json!({
@@ -224,13 +301,14 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: PlaceOrderArgs
             "dry_run": dry_run,
             "chain": chain,
             "txHash": tx_hash,
+            "orderKey": new_order_key,
             "orderType": args.order_type.name(),
             "marketToken": args.market_token,
             "direction": if args.long { "long" } else { "short" },
             "sizeUsd": args.size_usd,
             "triggerPrice_usd": args.trigger_price_usd,
             "acceptablePrice_usd": args.acceptable_price_usd,
-            "executionFeeWei": execution_fee,
+            "executionFee_eth": format!("{:.6}", execution_fee_eth),
             "note": "Order will be executed by keeper when trigger price is reached",
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?

--- a/skills/gmx-v2/src/commands/withdraw_liquidity.rs
+++ b/skills/gmx-v2/src/commands/withdraw_liquidity.rs
@@ -35,22 +35,8 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: WithdrawLiquid
     }
 
     let execution_fee = cfg.execution_fee_wei;
-
-    // Approve GM token to Router if needed
-    if !dry_run {
-        let allowance = crate::onchainos::check_allowance(
-            cfg.rpc_url, &args.market_token, &wallet, cfg.router,
-        ).await.unwrap_or(0);
-        if allowance < args.gm_amount {
-            eprintln!("WARNING: Approving {} GM token to {} -- approving exact amount only. Use --dry-run to preview.", args.gm_amount, cfg.router);
-            let r = crate::onchainos::erc20_approve(
-                cfg.chain_id, &args.market_token, cfg.router, args.gm_amount, Some(&wallet), false, confirm,
-            ).await?;
-            let approve_hash = crate::onchainos::extract_tx_hash(&r);
-            eprintln!("Approval tx: {}", approve_hash);
-            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
-        }
-    }
+    let execution_fee_eth = execution_fee as f64 / 1e18;
+    let gm_fmt = crate::api::format_token_amount(args.gm_amount, 18);
 
     // Build multicall: [sendWnt, sendTokens(gmToken), createWithdrawal]
     let send_wnt = crate::abi::encode_send_wnt(cfg.withdrawal_vault, execution_fee);
@@ -70,14 +56,87 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: WithdrawLiquid
     let multicall_hex = crate::abi::encode_multicall(&[send_wnt, send_gm, create_withdrawal]);
     let calldata = format!("0x{}", multicall_hex);
 
+    // Pre-flight: ETH balance for execution fee + gas
+    let eth_balance = crate::rpc::get_eth_balance(&wallet, cfg.rpc_url).await;
+    let gas_margin: u128 = 200_000_000_000_000; // 0.0002 ETH
+    let eth_required = execution_fee.saturating_add(gas_margin);
+    if eth_balance < eth_required {
+        println!("{}", serde_json::to_string_pretty(&json!({
+            "ok": false,
+            "error": "INSUFFICIENT_ETH_FOR_EXECUTION",
+            "reason": "Wallet does not have enough ETH to cover execution fee + gas.",
+            "eth_balance": format!("{:.8}", eth_balance as f64 / 1e18),
+            "execution_fee_eth": format!("{:.8}", execution_fee as f64 / 1e18),
+            "gas_buffer_eth": format!("{:.8}", gas_margin as f64 / 1e18),
+            "eth_required": format!("{:.8}", eth_required as f64 / 1e18),
+            "suggestion": format!("Top up wallet {} with at least {:.6} ETH.", wallet, (eth_required.saturating_sub(eth_balance)) as f64 / 1e18)
+        }))?);
+        return Ok(());
+    }
+
+    // Pre-flight: GM token balance
+    let gm_bal = crate::rpc::check_erc20_balance(cfg.rpc_url, &args.market_token, &wallet).await.unwrap_or(u128::MAX);
+    if gm_bal < args.gm_amount {
+        println!("{}", serde_json::to_string_pretty(&json!({
+            "ok": false,
+            "error": "INSUFFICIENT_GM_TOKEN_BALANCE",
+            "reason": "Wallet GM token balance is less than --gm-amount.",
+            "token": args.market_token,
+            "wallet_balance": gm_bal.to_string(),
+            "wallet_balance_formatted": crate::api::format_token_amount(gm_bal, 18),
+            "required_amount": args.gm_amount.to_string(),
+            "required_formatted": gm_fmt.clone(),
+            "suggestion": format!("Reduce --gm-amount to at most {} ({} GM tokens).", gm_bal, crate::api::format_token_amount(gm_bal, 18))
+        }))?);
+        return Ok(());
+    }
+
     eprintln!("=== Withdraw Liquidity Preview ===");
     eprintln!("Market token (GM): {}", args.market_token);
-    eprintln!("GM amount to burn: {}", args.gm_amount);
+    eprintln!("GM amount to burn: {}", gm_fmt);
     eprintln!("Min long token: {}", args.min_long_amount);
     eprintln!("Min short token: {}", args.min_short_amount);
-    eprintln!("Execution fee: {} wei", execution_fee);
+    if args.min_long_amount == 0 && args.min_short_amount == 0 {
+        eprintln!("⚠ Both min amounts are 0 — no slippage protection on tokens received.");
+    }
+    eprintln!("Execution fee: {:.6} ETH", execution_fee_eth);
     eprintln!("⚠ GMX V2 keeper model: tokens returned 1-30s after tx lands.");
-    eprintln!("Ask user to confirm before proceeding.");
+    if !confirm { eprintln!("Add --confirm to broadcast."); }
+
+    if !confirm && !dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "ok": true,
+                "status": "preview",
+                "message": "Add --confirm to broadcast this transaction",
+                "chain": chain,
+                "marketToken": args.market_token,
+                "gmAmountBurned": gm_fmt,
+                "minLongAmount": args.min_long_amount.to_string(),
+                "minShortAmount": args.min_short_amount.to_string(),
+                "executionFee_eth": format!("{:.6}", execution_fee_eth),
+                "calldata": calldata
+            }))?
+        );
+        return Ok(());
+    }
+
+    // Approve GM token to Router only when about to execute
+    if confirm && !dry_run {
+        let allowance = crate::onchainos::check_allowance(
+            cfg.rpc_url, &args.market_token, &wallet, cfg.router,
+        ).await.unwrap_or(0);
+        if allowance < args.gm_amount {
+            eprintln!("Approving GM token to router...");
+            let r = crate::onchainos::erc20_approve(
+                cfg.chain_id, &args.market_token, cfg.router, args.gm_amount, Some(&wallet), false, confirm,
+            ).await?;
+            let approve_hash = crate::onchainos::extract_tx_hash(&r);
+            eprintln!("Approval tx: {}", approve_hash);
+            crate::onchainos::wait_for_tx(cfg.chain_id, approve_hash, &wallet, 60)?;
+        }
+    }
 
     let result = crate::onchainos::wallet_contract_call_with_gas(
         cfg.chain_id,
@@ -100,10 +159,10 @@ pub async fn run(chain: &str, dry_run: bool, confirm: bool, args: WithdrawLiquid
             "chain": chain,
             "txHash": tx_hash,
             "marketToken": args.market_token,
-            "gmAmountBurned": args.gm_amount.to_string(),
+            "gmAmountBurned": gm_fmt,
             "minLongAmount": args.min_long_amount.to_string(),
             "minShortAmount": args.min_short_amount.to_string(),
-            "executionFeeWei": execution_fee,
+            "executionFee_eth": format!("{:.6}", execution_fee_eth),
             "note": "Underlying tokens returned within 1-30s after keeper executes",
             "calldata": if dry_run { Some(calldata.as_str()) } else { None }
         }))?


### PR DESCRIPTION
## Summary

- **G2** — all 7 write commands now require `--confirm` to broadcast; without `--confirm` (or `--dry-run`) they return a `"status":"preview"` JSON and never submit
- **G14** — source code URL corrected to `okx/plugin-store`
- **G17** — `cancel-order` waits for on-chain confirmation before reporting `ok:true`; returns `TX_NOT_SUBMITTED` error if no hash received
- **G18** — `get-orders` full ABI rewrite: decodes `direction`, `sizeUsd`, `collateralDelta`, `triggerPrice_usd`, `acceptablePrice_usd`, `collateralToken` from on-chain `Order.Props` struct
- **G19** — `place-order` snapshots pre/post account orders and returns the new `orderKey` (bytes32) in output
- **G20** — `claim-funding-fees` measures pre/post ERC-20 balance delta and returns `claimed` array with token + raw amount per token
- **G21** — preview gate added to all 7 write commands
- **Pre-flight checks** — all write ops check wallet ETH balance before submitting; `open-position` and `place-order` (increase orders) also check collateral token balance; `deposit-liquidity` checks long/short token balances; `withdraw-liquidity` checks GM token balance — all return structured `ok:false` JSON with `suggestion` field
- **list-markets** — funding and borrowing rates shown as annualised % (GMX bigint ÷ 10²⁸)
- **Output improvements** — `executionFee_eth` (human-readable), `acceptablePrice_usd`, collateral amounts via `format_token_amount`

## Test plan

- [x] `cargo build` passes (warnings only)
- [x] `list-markets` — rates show reasonable values (ETH borrow 3.91%, funding ±14%)
- [x] `get-prices --symbol ETH` — correct USD prices
- [x] `get-positions` / `get-orders` — full fields decoded correctly
- [x] All write commands — ETH pre-flight error fires correctly (`INSUFFICIENT_ETH_FOR_EXECUTION`)
- [x] `open-position` — token balance check fires (`INSUFFICIENT_TOKEN_BALANCE`)
- [x] `cancel-order --dry-run` — preview JSON, no broadcast
- [x] `cancel-order` (no `--confirm`) — preview gate returns `"status":"preview"`
- [x] `claim-funding-fees --dry-run` — correct calldata, `claimed:[]`
- [x] All 15 modified files only; `registry.json` and other skills untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)