### PR TITLE
feat(polymarket): v0.2.7 — series trading for 5-minute Up/Down markets

### DIFF
--- a/skills/polymarket/CHANGELOG.md
+++ b/skills/polymarket/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Polymarket Plugin Changelog
 
+### v0.2.7 (2026-04-12)
+
+- **feat**: Series trading support for Polymarket's recurring 5-minute "Up or Down" crypto markets. Series markets run on BTC, ETH, SOL, and XRP during NYSE trading hours (9:30 AM–4:00 PM ET, Mon–Fri). Use `buy --market-id btc-5m` (or `eth`, `sol`, `xrp`) instead of a full slug — the plugin auto-resolves to the current accepting slot at trade time.
+- **feat**: `get-series [btc-5m|eth-5m|sol-5m|xrp-5m]` command — shows the current and next slot with prices, token IDs, seconds remaining, liquidity, and a ready-to-run buy hint. `--list` enumerates all supported series.
+- **feat**: DST-aware NYSE trading hours check. Outside trading hours, `buy`/`sell`/`get-series` report the exact series name and the time until the next session opens instead of a cryptic lookup failure.
+- **feat**: Slot transition gap handling — when the current slot closes and the next has not yet opened, the plugin tries the next slot automatically (± one interval) before failing, avoiding spurious "no market found" errors at the 5-minute boundary.
+
 ### v0.2.6 (2026-04-12)
 
 - **fix (critical) [C1]**: `buy` on `neg_risk: true` markets no longer approves the wrong contract. Root cause: `get_gamma_market_by_slug` omits `negRisk` for many markets, causing the field to default to `false` and `approve_usdc` to target `CTF_EXCHANGE` instead of `NEG_RISK_CTF_EXCHANGE`. Fix: `resolve_market_token` now fetches the CLOB market by `condition_id` after the Gamma lookup to get the authoritative `neg_risk`. Falls back to the Gamma value if the CLOB is unreachable. Same fix applied in `redeem`.

--- a/skills/polymarket/CHANGELOG.md
+++ b/skills/polymarket/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Polymarket Plugin Changelog
 
+### v0.2.8 (2026-04-13)
+
+- **perf**: Deduplicated CLOB market fee call — `resolve_market_token` now extracts `maker_base_fee` from the `ClobMarket` it already fetches for `neg_risk` resolution, eliminating a second `GET /markets/{condition_id}` round trip. Saves ~150ms unconditionally.
+- **perf**: Eliminated separate `get_tick_size` call — the order book response (`GET /book?token_id=X`) already contains the `tick_size` field. The plugin now reads it from there, removing one CLOB round trip. Saves ~100ms unconditionally.
+- **perf**: Eliminated double Gamma API fetch for series markets — previously `resolve_to_slug` fetched the `GammaMarket` then `resolve_market_token` fetched the same slug again. The series path now calls `resolve_to_market` (returns the already-fetched `GammaMarket`) and passes it directly to `resolve_from_gamma`. Saves ~200ms on all series trades.
+- **perf**: Parallelized order book fetch + wallet address subprocess — for live (non-dry-run) orders, `get_orderbook` and `get_wallet_address` now run concurrently via `tokio::join!`. Saves ~100-200ms on the live hot path. Dry-run behavior is unchanged (wallet is never called during dry-run).
+- **feat**: `buy --token-id <id>` and `sell --token-id <id>` fast path — when the outcome token ID is known (from prior `get-series` or `get-market` output), all Gamma and CLOB market resolution is skipped. A single `GET /book?token_id=X` provides `condition_id`, `neg_risk`, and `tick_size`; only `get_market_fee` is additionally called. Combined with `--price`, this is the fastest possible trade path: ~0.5s binary execution vs ~1.5s baseline. Intended use: run `get-series btc-5m` once per slot to cache token IDs, then use `--token-id` for all buys within that slot.
+
 ### v0.2.7 (2026-04-12)
 
 - **feat**: Series trading support for Polymarket's recurring 5-minute "Up or Down" crypto markets. Series markets run on BTC, ETH, SOL, and XRP during NYSE trading hours (9:30 AM–4:00 PM ET, Mon–Fri). Use `buy --market-id btc-5m` (or `eth`, `sol`, `xrp`) instead of a full slug — the plugin auto-resolves to the current accepting slot at trade time.

--- a/skills/polymarket/CHANGELOG.md
+++ b/skills/polymarket/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Polymarket Plugin Changelog
 
-### v0.2.7 (2026-04-13)
+### v0.2.7 (2026-04-13) — patch fixes
+
+- **fix [N1]**: `get-series` on 4h series no longer reports wrong `session` and `trading_hours`. Root cause: `session` was computed using the NYSE hours check regardless of series type, and `trading_hours` was hardcoded to `"9:30 AM – 4:00 PM ET, Monday–Friday"` for all series. Fix: for `nyse_hours_only: false` series, `session` is always `"24/7 — market open"` and `trading_hours` is `"24/7"`. Also fixes the `interval` field for 4h series (now shows `"4 hours"` instead of `"240 minutes"`).
+- **fix [N2]**: `--token-id` no longer requires `--market-id`. `--market-id` is now optional in `buy` and `sell`; it is required only when `--token-id` is not provided. When `--token-id` is given, the binary skips all market lookup and `--market-id` is unused. Attempting to call `buy`/`sell` without either flag returns a clear error.
+- **fix [N3]**: `get-series` slot output now includes `end_unix` (Unix timestamp integer) alongside the existing `end` (ISO-8601 string). SKILL.md agent caching protocol references `current_slot.end_unix` for slot-validity checks — the field now exists.
+- **fix [N4]**: `buy --market-id btc-5m` (and 15m variants) no longer blocks trading outside NYSE hours. The NYSE hours gate in `get_current_slot` has been removed; the binary now always attempts to find the current accepting slot and lets the CLOB be the source of truth. If no slot is accepting orders, a clear `"No open market found"` error is returned. Live verification confirms 5m/15m slots accept orders 24/7 on the CLOB despite the NYSE hours label.
+
+### v0.2.7 (2026-04-13) — original release
 
 - **feat**: Series trading for recurring "Up or Down" crypto markets. Supports 5-minute (NYSE hours), 15-minute (NYSE hours), and 4-hour (24/7) slots for BTC, ETH, SOL, and XRP. Use `buy --market-id btc-5m`, `btc-15m`, or `btc-4h` — the plugin auto-resolves to the current accepting slot at trade time.
 - **feat**: `get-series` command — shows the current and next slot with prices, token IDs, seconds remaining, liquidity, and a ready-to-run buy hint. `--list` enumerates all 12 supported series (4 assets × 3 intervals).

--- a/skills/polymarket/CHANGELOG.md
+++ b/skills/polymarket/CHANGELOG.md
@@ -1,19 +1,14 @@
 # Polymarket Plugin Changelog
 
-### v0.2.8 (2026-04-13)
+### v0.2.7 (2026-04-13)
 
-- **perf**: Deduplicated CLOB market fee call — `resolve_market_token` now extracts `maker_base_fee` from the `ClobMarket` it already fetches for `neg_risk` resolution, eliminating a second `GET /markets/{condition_id}` round trip. Saves ~150ms unconditionally.
-- **perf**: Eliminated separate `get_tick_size` call — the order book response (`GET /book?token_id=X`) already contains the `tick_size` field. The plugin now reads it from there, removing one CLOB round trip. Saves ~100ms unconditionally.
-- **perf**: Eliminated double Gamma API fetch for series markets — previously `resolve_to_slug` fetched the `GammaMarket` then `resolve_market_token` fetched the same slug again. The series path now calls `resolve_to_market` (returns the already-fetched `GammaMarket`) and passes it directly to `resolve_from_gamma`. Saves ~200ms on all series trades.
-- **perf**: Parallelized order book fetch + wallet address subprocess — for live (non-dry-run) orders, `get_orderbook` and `get_wallet_address` now run concurrently via `tokio::join!`. Saves ~100-200ms on the live hot path. Dry-run behavior is unchanged (wallet is never called during dry-run).
-- **feat**: `buy --token-id <id>` and `sell --token-id <id>` fast path — when the outcome token ID is known (from prior `get-series` or `get-market` output), all Gamma and CLOB market resolution is skipped. A single `GET /book?token_id=X` provides `condition_id`, `neg_risk`, and `tick_size`; only `get_market_fee` is additionally called. Combined with `--price`, this is the fastest possible trade path: ~0.5s binary execution vs ~1.5s baseline. Intended use: run `get-series btc-5m` once per slot to cache token IDs, then use `--token-id` for all buys within that slot.
-
-### v0.2.7 (2026-04-12)
-
-- **feat**: Series trading support for Polymarket's recurring 5-minute "Up or Down" crypto markets. Series markets run on BTC, ETH, SOL, and XRP during NYSE trading hours (9:30 AM–4:00 PM ET, Mon–Fri). Use `buy --market-id btc-5m` (or `eth`, `sol`, `xrp`) instead of a full slug — the plugin auto-resolves to the current accepting slot at trade time.
-- **feat**: `get-series [btc-5m|eth-5m|sol-5m|xrp-5m]` command — shows the current and next slot with prices, token IDs, seconds remaining, liquidity, and a ready-to-run buy hint. `--list` enumerates all supported series.
-- **feat**: DST-aware NYSE trading hours check. Outside trading hours, `buy`/`sell`/`get-series` report the exact series name and the time until the next session opens instead of a cryptic lookup failure.
-- **feat**: Slot transition gap handling — when the current slot closes and the next has not yet opened, the plugin tries the next slot automatically (± one interval) before failing, avoiding spurious "no market found" errors at the 5-minute boundary.
+- **feat**: Series trading for recurring "Up or Down" crypto markets. Supports 5-minute (NYSE hours), 15-minute (NYSE hours), and 4-hour (24/7) slots for BTC, ETH, SOL, and XRP. Use `buy --market-id btc-5m`, `btc-15m`, or `btc-4h` — the plugin auto-resolves to the current accepting slot at trade time.
+- **feat**: `get-series` command — shows the current and next slot with prices, token IDs, seconds remaining, liquidity, and a ready-to-run buy hint. `--list` enumerates all 12 supported series (4 assets × 3 intervals).
+- **feat**: DST-aware NYSE trading hours check. For 5m and 15m series, reports time until next session when called outside hours. 4h series runs 24/7 and bypasses the hours check.
+- **feat**: Slot transition gap handling — at the 5/15-minute boundary, tries the next slot automatically before failing.
+- **perf**: Eliminated 3 redundant HTTP calls on the buy/sell hot path: deduplicated CLOB fee fetch (~150ms), eliminated separate tick-size call by reading it from the order book response (~100ms), and avoided double Gamma fetch on series markets (~200ms).
+- **perf**: Parallelized order book fetch + wallet address subprocess via `tokio::join!` for live orders (~100-200ms saved). Dry-run still works without a configured wallet.
+- **feat**: `buy --token-id <id>` / `sell --token-id <id>` fast path — skips all market resolution when the token ID is known from a prior `get-series` call. Only 2 HTTP calls (book + fee) vs 5-6 normally. Target: ~0.5s binary execution. Token IDs change each slot so re-run `get-series` at each new slot.
 
 ### v0.2.6 (2026-04-12)
 

--- a/skills/polymarket/Cargo.lock
+++ b/skills/polymarket/Cargo.lock
@@ -1000,7 +1000,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket/Cargo.lock
+++ b/skills/polymarket/Cargo.lock
@@ -1000,7 +1000,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket/Cargo.lock
+++ b/skills/polymarket/Cargo.lock
@@ -1000,7 +1000,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.2.8"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket/Cargo.toml
+++ b/skills/polymarket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket/Cargo.toml
+++ b/skills/polymarket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket"
-version = "0.2.8"
+version = "0.2.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket/Cargo.toml
+++ b/skills/polymarket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on."
-version: "0.2.6"
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down."
+version: "0.2.7"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -48,7 +48,7 @@ if ! command -v polymarket >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.6/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.7/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
   chmod +x ~/.local/bin/polymarket${EXT}
 fi
 ```
@@ -67,7 +67,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket","version":"0.2.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket","version":"0.2.7"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"polymarket","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -230,7 +230,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket --version
 ```
 
-Expected: `polymarket 0.2.6`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.2.7`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -570,6 +570,52 @@ polymarket redeem --market-id <condition_id_or_slug> --dry-run
 
 **Output fields on success:** `condition_id`, `question`, `tx_hash`, `note`
 
+---
+
+### `get-series` — Series Markets (Recurring Short-Duration)
+
+Polymarket runs recurring **Up or Down** markets on crypto assets during NYSE trading hours
+(9:30 AM – 4:00 PM ET, Monday–Friday). Each market covers a 5-minute window and resolves
+based on whether the asset price moved up or down during that window.
+
+Supported series: `btc-5m`, `eth-5m`, `sol-5m`, `xrp-5m`
+
+**Slug pattern:** `{asset}-updown-5m-{unix_start_timestamp_utc}`
+
+```
+polymarket get-series --series btc-5m      # Current + next BTC 5-min slot
+polymarket get-series --series eth-5m      # Ethereum 5-min
+polymarket get-series --list               # Show all supported series
+```
+
+**Output fields:** `series`, `asset`, `session` (in/out of trading hours), `current_slot` (slug, condition_id, outcomes with token_ids/prices, seconds_remaining, liquidity), `next_slot`, `tip` (ready-to-use buy command)
+
+**Trading on a series (two ways):**
+
+*Option A — use the series ID directly (recommended):*
+```
+polymarket buy --market-id btc-5m --outcome up --amount 50
+polymarket buy --market-id btc-5m --outcome down --amount 50
+```
+The binary auto-resolves `btc-5m` to the current accepting slot at execution time.
+If the market is closed or outside trading hours, the command fails with a clear message.
+
+*Option B — resolve first, then trade:*
+```
+polymarket get-series --series btc-5m      # note the slug in current_slot.tip
+polymarket buy --market-id btc-updown-5m-<ts> --outcome up --amount 50
+```
+
+**When to use which:**
+- Option A is faster for single trades — one command, auto-resolves the slot
+- Option B is better when you want to inspect price/liquidity before committing
+- For repeated trades on consecutive slots, use Option A each time — it always resolves the current open slot
+
+**Outcomes:** `up` (price went higher) and `down` (price went lower) in the 5-minute window.
+Both are valid `--outcome` values for `buy` and `sell`.
+
+**Outside trading hours:** `buy --market-id btc-5m` fails with a message showing when the next session opens. Check with `get-series --series btc-5m` to see session status before placing orders.
+
 **Agent flow:**
 1. Resolve `--market-id` to a condition_id and check `neg_risk` (auto from market lookup)
 2. Offer `--dry-run` first to show the user what will happen
@@ -721,6 +767,10 @@ User wants to trade:
 | Cancel all orders for market | `polymarket cancel --market <condition_id>` |
 | Cancel all open orders | `polymarket cancel --all` |
 | Redeem winning tokens after market resolves | `polymarket redeem --market-id <slug_or_condition_id>` |
+| View current BTC/ETH/SOL/XRP 5-min slot | `polymarket get-series --series btc-5m` |
+| List all supported series | `polymarket get-series --list` |
+| Trade current BTC 5-min slot (up) | `polymarket buy --market-id btc-5m --outcome up --amount <usdc>` |
+| Trade current ETH 5-min slot (down) | `polymarket buy --market-id eth-5m --outcome down --amount <usdc>` |
 
 ---
 
@@ -751,4 +801,4 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.6** (2026-04-12).
+See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.7** (2026-04-12).

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down, quick btc trade, quick bitcoin bet, quick eth trade, quick ethereum bet, quick sol trade, quick xrp bet, bitcoin going up, btc going down, is bitcoin going up or down, will btc go up, will eth go up or down, will sol go up, trade btc direction, trade eth direction, trade crypto direction, short term bitcoin trade, short term eth trade, intraday bitcoin bet, 5 minute bitcoin market, 5 minute crypto market, 5 minute eth market, 5 minute sol market, 5 minute xrp market, next 5 minutes bitcoin, next 5 minutes ethereum, bet on bitcoin in next few minutes, trade bitcoin price direction, updown market, up down market, crypto price direction bet, bet on price movement."
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down, quick btc trade, quick bitcoin bet, quick eth trade, quick ethereum bet, quick sol trade, quick xrp bet, bitcoin going up, btc going down, is bitcoin going up or down, will btc go up, will eth go up or down, will sol go up, trade btc direction, trade eth direction, trade crypto direction, short term bitcoin trade, short term eth trade, intraday bitcoin bet, 5 minute bitcoin market, 5 minute crypto market, 5 minute eth market, 5 minute sol market, 5 minute xrp market, next 5 minutes bitcoin, next 5 minutes ethereum, bet on bitcoin in next few minutes, trade bitcoin price direction, updown market, up down market, crypto price direction bet, bet on price movement, 5m eth, 5m btc, 5m sol, 5m xrp, eth 5m, btc 5m, sol 5m, xrp 5m, 5m market, 5m trade, 5m bet, 5m candle, 5 minute candle, trade the 5m, play the 5m, 5m ethereum, 5m bitcoin, 5m solana, ethereum 5m, bitcoin 5m, solana 5m, eth 5 minute, btc 5 minute, 5m eth market, 5m btc market, eth 5 min market, btc 5 min market, give me the 5m, eth updown, btc updown, sol updown, xrp updown, short eth, long eth, short btc, long btc, eth short term, btc short term, crypto 5m, 5min eth, 5min btc, 5min sol, 5min xrp."
 version: "0.2.8"
 author: "skylavis-sky"
 tags:
@@ -677,30 +677,40 @@ User wants to trade a series (BTC/ETH/SOL/XRP up/down):
 
 Route to series trading when the user's message combines a **supported crypto asset** with a **short time horizon or directional framing**:
 
-| Signal type | Keywords |
-|-------------|----------|
+| Signal type | Keywords / patterns |
+|-------------|---------------------|
 | Asset | bitcoin, btc, ethereum, eth, solana, sol, xrp, ripple |
-| Time / direction | 5 minutes, 5 min, 5m, next few minutes, quick trade, short term, intraday, up or down, price direction, higher or lower, going up, going down, next candle |
+| Abbreviated time | 5m, 5min, 5-min, 5 min, 5 minute(s) |
+| Trader shorthand | `5m ETH`, `ETH 5m`, `5m BTC`, `BTC 5m`, `5m SOL`, `SOL 5m`, `5m XRP`, `XRP 5m` |
+| Direction framing | up or down, updown, up/down, price direction, higher or lower, going up, going down |
+| Speed signals | quick trade, quick bet, short term, intraday, next few minutes, next candle, trade the 5m, play the 5m |
 
 **Phrases that map to series trading:**
+- "5m ETH market" / "ETH 5m" / "5m BTC"
+- "trade the 5m on ETH"
+- "give me the BTC 5m"
+- "5min SOL market"
 - "bet on bitcoin going up in the next 5 minutes"
 - "quick BTC trade" / "quick ETH bet"
 - "will ETH go up or down right now?"
 - "short term SOL trade"
-- "trade XRP direction"
-- "5-minute bitcoin market"
+- "ETH updown" / "BTC updown"
 - "is BTC going up or down?"
-- "I want to bet on the price of BTC in the next few minutes"
+- "play the 5-minute candle on ETH"
 
 **Disambiguation from regular markets:**
 
 | User phrase | Route |
 |-------------|-------|
-| "Will BTC hit 100k?" | Regular market — `list-markets --keyword bitcoin` |
+| "5m ETH" / "ETH 5m" / "5m BTC" / "BTC 5m" | Series — `buy --market-id eth-5m` (or btc-5m) |
+| "5min SOL market" / "trade the 5m on XRP" | Series — route to matching series |
 | "Bet on ETH price direction right now" | Series — `buy --market-id eth-5m` |
-| "BTC prediction market" (no time frame) | Regular market — `list-markets` first |
+| "Will BTC hit 100k?" | Regular market — `list-markets --keyword bitcoin` |
+| "BTC prediction market" (no time frame, no direction) | Regular market — `list-markets` first |
 | Any named event (election, sports, etc.) | Regular market |
 | "quick crypto bet" (no specific asset) | Ask which asset: BTC, ETH, SOL, or XRP |
+
+**Key rule**: `<asset> + 5m` or `5m + <asset>` in any order always means series. The "5m" (or "5 min", "5-min", "5 minute") pattern is unambiguous — Polymarket has no other 5-minute markets.
 
 **When in doubt:** call `get-series --series btc-5m` (or the relevant asset). The output clearly shows whether trading is currently possible (in/out of hours, seconds remaining, current prices), which is low-cost and resolves ambiguity before committing funds.
 

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down."
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down, quick btc trade, quick bitcoin bet, quick eth trade, quick ethereum bet, quick sol trade, quick xrp bet, bitcoin going up, btc going down, is bitcoin going up or down, will btc go up, will eth go up or down, will sol go up, trade btc direction, trade eth direction, trade crypto direction, short term bitcoin trade, short term eth trade, intraday bitcoin bet, 5 minute bitcoin market, 5 minute crypto market, 5 minute eth market, 5 minute sol market, 5 minute xrp market, next 5 minutes bitcoin, next 5 minutes ethereum, bet on bitcoin in next few minutes, trade bitcoin price direction, updown market, up down market, crypto price direction bet, bet on price movement."
 version: "0.2.7"
 author: "skylavis-sky"
 tags:
@@ -617,19 +617,53 @@ Both are valid `--outcome` values for `buy` and `sell`.
 **Outside trading hours:** `buy --market-id btc-5m` fails with a message showing when the next session opens. Check with `get-series --series btc-5m` to see session status before placing orders.
 
 **Agent flow:**
-1. Resolve `--market-id` to a condition_id and check `neg_risk` (auto from market lookup)
-2. Offer `--dry-run` first to show the user what will happen
-3. After user confirms, run without `--dry-run` to submit the tx
-4. Return the `tx_hash` — redemption settles once the tx confirms on Polygon (~seconds)
+1. Run `get-series --series <id>` to show the user the current slot (price, liquidity, seconds remaining) and confirm they want to trade it.
+2. Once confirmed, run `buy --market-id <series-id> --outcome <up|down> --amount <usdc> --dry-run` to preview the order.
+3. After user confirms the dry-run output, run without `--dry-run` to submit.
+4. Return the `order_id` and `status` from the response.
 
 **Example:**
 ```bash
-# Preview first
-polymarket redeem --market-id will-trump-win-2024 --dry-run
+# Show current slot
+polymarket get-series --series btc-5m
+
+# Preview the order
+polymarket buy --market-id btc-5m --outcome up --amount 50 --dry-run
 
 # After user confirms:
-polymarket redeem --market-id will-trump-win-2024
+polymarket buy --market-id btc-5m --outcome up --amount 50
 ```
+
+### Series intent detection
+
+Route to series trading when the user's message combines a **supported crypto asset** with a **short time horizon or directional framing**:
+
+| Signal type | Keywords |
+|-------------|----------|
+| Asset | bitcoin, btc, ethereum, eth, solana, sol, xrp, ripple |
+| Time / direction | 5 minutes, 5 min, 5m, next few minutes, quick trade, short term, intraday, up or down, price direction, higher or lower, going up, going down, next candle |
+
+**Phrases that map to series trading:**
+- "bet on bitcoin going up in the next 5 minutes"
+- "quick BTC trade" / "quick ETH bet"
+- "will ETH go up or down right now?"
+- "short term SOL trade"
+- "trade XRP direction"
+- "5-minute bitcoin market"
+- "is BTC going up or down?"
+- "I want to bet on the price of BTC in the next few minutes"
+
+**Disambiguation from regular markets:**
+
+| User phrase | Route |
+|-------------|-------|
+| "Will BTC hit 100k?" | Regular market — `list-markets --keyword bitcoin` |
+| "Bet on ETH price direction right now" | Series — `buy --market-id eth-5m` |
+| "BTC prediction market" (no time frame) | Regular market — `list-markets` first |
+| Any named event (election, sports, etc.) | Regular market |
+| "quick crypto bet" (no specific asset) | Ask which asset: BTC, ETH, SOL, or XRP |
+
+**When in doubt:** call `get-series --series btc-5m` (or the relevant asset). The output clearly shows whether trading is currently possible (in/out of hours, seconds remaining, current prices), which is low-cost and resolves ambiguity before committing funds.
 
 ---
 

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down, quick btc trade, quick bitcoin bet, quick eth trade, quick ethereum bet, quick sol trade, quick xrp bet, bitcoin going up, btc going down, is bitcoin going up or down, will btc go up, will eth go up or down, will sol go up, trade btc direction, trade eth direction, trade crypto direction, short term bitcoin trade, short term eth trade, intraday bitcoin bet, 5 minute bitcoin market, 5 minute crypto market, 5 minute eth market, 5 minute sol market, 5 minute xrp market, next 5 minutes bitcoin, next 5 minutes ethereum, bet on bitcoin in next few minutes, trade bitcoin price direction, updown market, up down market, crypto price direction bet, bet on price movement."
-version: "0.2.7"
+version: "0.2.8"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -48,7 +48,7 @@ if ! command -v polymarket >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.7/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.8/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
   chmod +x ~/.local/bin/polymarket${EXT}
 fi
 ```
@@ -67,7 +67,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket","version":"0.2.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket","version":"0.2.8"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"polymarket","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -230,7 +230,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket --version
 ```
 
-Expected: `polymarket 0.2.7`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.2.8`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -394,6 +394,7 @@ polymarket buy --market-id <id> --outcome <outcome> --amount <usdc> [--price <0-
 | `--post-only` | Maker-only: reject if the order would immediately cross the spread (become a taker). Requires `--order-type GTC`. Qualifies for Polymarket maker rebates (up to 50% of fees returned daily). Incompatible with `--order-type FOK`. | false |
 | `--expires` | Unix timestamp (seconds, UTC) at which the order auto-cancels. Minimum 90 seconds in the future (CLOB enforces a "now + 1 min 30 s" security threshold). Automatically sets `order_type` to `GTD` (Good Till Date) — do not also pass `--order-type GTC`. Example: `--expires $(date -d '+1 hour' +%s)` | — |
 | `--confirm` | Confirm a previously gated action (reserved for future use) | false |
+| `--token-id` | Skip market lookup — provide the outcome token ID directly (from `get-series` or `get-market` output). Saves 3-4 HTTP round trips. Use after `get-series` to cache the token ID for repeated trades on the same slot. | — |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
@@ -451,6 +452,7 @@ polymarket sell --market-id <id> --outcome <outcome> --shares <amount> [--price 
 | `--expires` | Unix timestamp (seconds, UTC) at which the order auto-cancels. Minimum 90 seconds in the future. Auto-sets `order_type` to `GTD`. | — |
 | `--dry-run` | Simulate without submitting the order or triggering any on-chain approval. Prints a confirmation JSON and exits. Use to verify parameters before a real sell. | false |
 | `--confirm` | Confirm a low-price market sell that was previously gated | false |
+| `--token-id` | Skip market lookup — provide the outcome token ID directly. Same fast path as `buy --token-id`. | — |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
@@ -610,6 +612,16 @@ polymarket buy --market-id btc-updown-5m-<ts> --outcome up --amount 50
 - Option A is faster for single trades — one command, auto-resolves the slot
 - Option B is better when you want to inspect price/liquidity before committing
 - For repeated trades on consecutive slots, use Option A each time — it always resolves the current open slot
+
+*Option C — fastest path (power users):*
+```
+# 1. Get token IDs once (note the token_id for "Up" from the output)
+polymarket get-series --series btc-5m
+
+# 2. Use --token-id to skip all market resolution on subsequent trades
+polymarket buy --token-id <up_token_id_from_above> --outcome up --amount 50 --price 0.52
+```
+`--token-id` skips the Gamma and CLOB market lookup entirely — only the order book and fee are fetched. Note: token IDs change each slot (every 5 min), so re-run `get-series` at each new slot.
 
 **Outcomes:** `up` (price went higher) and `down` (price went lower) in the 5-minute window.
 Both are valid `--outcome` values for `buy` and `sell`.
@@ -805,6 +817,7 @@ User wants to trade:
 | List all supported series | `polymarket get-series --list` |
 | Trade current BTC 5-min slot (up) | `polymarket buy --market-id btc-5m --outcome up --amount <usdc>` |
 | Trade current ETH 5-min slot (down) | `polymarket buy --market-id eth-5m --outcome down --amount <usdc>` |
+| Fast repeat trade (known token ID) | `polymarket buy --token-id <id> --outcome up --amount <usdc> --price <x>` |
 
 ---
 
@@ -835,4 +848,4 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.7** (2026-04-12).
+See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.8** (2026-04-12).

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, bitcoin up or down, btc 5 min, crypto series market, bet on btc price, eth up down, quick btc trade, quick bitcoin bet, quick eth trade, quick ethereum bet, quick sol trade, quick xrp bet, bitcoin going up, btc going down, is bitcoin going up or down, will btc go up, will eth go up or down, will sol go up, trade btc direction, trade eth direction, trade crypto direction, short term bitcoin trade, short term eth trade, intraday bitcoin bet, 5 minute bitcoin market, 5 minute crypto market, 5 minute eth market, 5 minute sol market, 5 minute xrp market, next 5 minutes bitcoin, next 5 minutes ethereum, bet on bitcoin in next few minutes, trade bitcoin price direction, updown market, up down market, crypto price direction bet, bet on price movement, 5m eth, 5m btc, 5m sol, 5m xrp, eth 5m, btc 5m, sol 5m, xrp 5m, 5m market, 5m trade, 5m bet, 5m candle, 5 minute candle, trade the 5m, play the 5m, 5m ethereum, 5m bitcoin, 5m solana, ethereum 5m, bitcoin 5m, solana 5m, eth 5 minute, btc 5 minute, 5m eth market, 5m btc market, eth 5 min market, btc 5 min market, give me the 5m, eth updown, btc updown, sol updown, xrp updown, short eth, long eth, short btc, long btc, eth short term, btc short term, crypto 5m, 5min eth, 5min btc, 5min sol, 5min xrp."
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, <token> up or down, <token> 5m, 5m <token>, <token> 5 min, 5 minute <token> market, <token> 5 minute market, 5m <token> market, <token> 5-minute, 5min <token>, <token> 5min, trade the 5m <token>, play the 5m on <token>, give me the 5m <token>, <token> updown, quick <token> trade, quick <token> bet, <token> going up, <token> going down, is <token> going up or down, will <token> go up, will <token> go up or down, trade <token> direction, short term <token> trade, intraday <token> bet, next 5 minutes <token>, bet on <token> in next few minutes, short <token>, long <token>, <token> short term, crypto series market, 5m market, 5m trade, 5m bet, 5m candle, 5 minute candle, trade the 5m, play the 5m, updown market, up down market, crypto price direction bet, bet on price movement, crypto 5m."
 version: "0.2.8"
 author: "skylavis-sky"
 tags:
@@ -677,33 +677,32 @@ User wants to trade a series (BTC/ETH/SOL/XRP up/down):
 
 Route to series trading when the user's message combines a **supported crypto asset** with a **short time horizon or directional framing**:
 
-| Signal type | Keywords / patterns |
-|-------------|---------------------|
-| Asset | bitcoin, btc, ethereum, eth, solana, sol, xrp, ripple |
+| Signal type | Pattern |
+|-------------|---------|
+| Asset (`<token>`) | bitcoin, btc, ethereum, eth, solana, sol, xrp, ripple — any of these fills `<token>` |
 | Abbreviated time | 5m, 5min, 5-min, 5 min, 5 minute(s) |
-| Trader shorthand | `5m ETH`, `ETH 5m`, `5m BTC`, `BTC 5m`, `5m SOL`, `SOL 5m`, `5m XRP`, `XRP 5m` |
+| Trader shorthand | `5m <token>`, `<token> 5m`, `<token> 5min`, `5min <token>` |
 | Direction framing | up or down, updown, up/down, price direction, higher or lower, going up, going down |
 | Speed signals | quick trade, quick bet, short term, intraday, next few minutes, next candle, trade the 5m, play the 5m |
 
-**Phrases that map to series trading:**
-- "5m ETH market" / "ETH 5m" / "5m BTC"
-- "trade the 5m on ETH"
-- "give me the BTC 5m"
-- "5min SOL market"
-- "bet on bitcoin going up in the next 5 minutes"
-- "quick BTC trade" / "quick ETH bet"
-- "will ETH go up or down right now?"
-- "short term SOL trade"
-- "ETH updown" / "BTC updown"
-- "is BTC going up or down?"
-- "play the 5-minute candle on ETH"
+**Phrases that map to series trading** (`<token>` = btc / eth / sol / xrp or full names):
+- "5m `<token>` market" / "`<token>` 5m" / "5m `<token>`"
+- "trade the 5m on `<token>`" / "play the 5m `<token>`"
+- "give me the `<token>` 5m"
+- "5min `<token>` market"
+- "bet on `<token>` going up in the next 5 minutes"
+- "quick `<token>` trade" / "quick `<token>` bet"
+- "will `<token>` go up or down right now?"
+- "`<token>` updown" / "`<token>` up or down"
+- "is `<token>` going up or down?"
+- "play the 5-minute candle on `<token>`"
 
 **Disambiguation from regular markets:**
 
 | User phrase | Route |
 |-------------|-------|
-| "5m ETH" / "ETH 5m" / "5m BTC" / "BTC 5m" | Series — `buy --market-id eth-5m` (or btc-5m) |
-| "5min SOL market" / "trade the 5m on XRP" | Series — route to matching series |
+| "`<token>` 5m" / "5m `<token>`" / "`<token>` 5min" / "5min `<token>`" | Series — `buy --market-id <token>-5m` |
+| "trade the 5m on `<token>`" / "`<token>` updown" | Series — route to matching series |
 | "Bet on ETH price direction right now" | Series — `buy --market-id eth-5m` |
 | "Will BTC hit 100k?" | Regular market — `list-markets --keyword bitcoin` |
 | "BTC prediction market" (no time frame, no direction) | Regular market — `list-markets` first |

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, <token> up or down, <token> 5m, 5m <token>, <token> 5 min, 5 minute <token> market, <token> 5 minute market, 5m <token> market, <token> 5-minute, 5min <token>, <token> 5min, trade the 5m <token>, play the 5m on <token>, give me the 5m <token>, <token> updown, quick <token> trade, quick <token> bet, <token> going up, <token> going down, is <token> going up or down, will <token> go up, will <token> go up or down, trade <token> direction, short term <token> trade, intraday <token> bet, next 5 minutes <token>, bet on <token> in next few minutes, short <token>, long <token>, <token> short term, crypto series market, 5m market, 5m trade, 5m bet, 5m candle, 5 minute candle, trade the 5m, play the 5m, updown market, up down market, crypto price direction bet, bet on price movement, crypto 5m."
-version: "0.2.8"
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, <token> up or down, <token> 5m, 5m <token>, <token> 5 min, 5 minute <token> market, <token> 5 minute market, 5m <token> market, <token> 5-minute, 5min <token>, <token> 5min, trade the 5m <token>, play the 5m on <token>, give me the 5m <token>, <token> updown, quick <token> trade, quick <token> bet, <token> going up, <token> going down, is <token> going up or down, will <token> go up, will <token> go up or down, trade <token> direction, short term <token> trade, intraday <token> bet, next 5 minutes <token>, bet on <token> in next few minutes, short <token>, long <token>, <token> short term, crypto series market, 5m market, 5m trade, 5m bet, 5m candle, 5 minute candle, trade the 5m, play the 5m, updown market, up down market, crypto price direction bet, bet on price movement, crypto 5m, <token> 15m, 15m <token>, <token> 15 min, 15 minute <token> market, <token> 15 minute market, 15m <token> market, <token> 15-minute, 15min <token>, <token> 15min, trade the 15m <token>, play the 15m on <token>, give me the 15m <token>, 15m market, 15m trade, 15m bet, 15m candle, 15 minute candle, trade the 15m, play the 15m, crypto 15m, <token> 4h, 4h <token>, <token> 4 hour, 4 hour <token> market, <token> 4-hour, 4h <token> market, trade the 4h <token>, play the 4h on <token>, <token> hourly, hourly <token> trade, hourly <token> bet, 4h market, 4h trade, 4h candle, 4 hour candle, trade the 4h, crypto 4h, overnight <token> trade, 24/7 <token> bet."
+version: "0.2.7"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -48,7 +48,7 @@ if ! command -v polymarket >/dev/null 2>&1; then
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.8/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.2.7/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
   chmod +x ~/.local/bin/polymarket${EXT}
 fi
 ```
@@ -67,7 +67,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   unset _K
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket","version":"0.2.8"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket","version":"0.2.7"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
     -d '{"pluginName":"polymarket","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
@@ -230,7 +230,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket --version
 ```
 
-Expected: `polymarket 0.2.8`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.2.7`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -576,18 +576,21 @@ polymarket redeem --market-id <condition_id_or_slug> --dry-run
 
 ### `get-series` — Series Markets (Recurring Short-Duration)
 
-Polymarket runs recurring **Up or Down** markets on crypto assets during NYSE trading hours
-(9:30 AM – 4:00 PM ET, Monday–Friday). Each market covers a 5-minute window and resolves
-based on whether the asset price moved up or down during that window.
+Polymarket runs recurring **Up or Down** markets on BTC, ETH, SOL, and XRP at three intervals:
 
-Supported series: `btc-5m`, `eth-5m`, `sol-5m`, `xrp-5m`
+| Series ID | Interval | Schedule | Slug pattern |
+|-----------|----------|----------|--------------|
+| `btc-5m`, `eth-5m`, `sol-5m`, `xrp-5m` | 5 minutes | NYSE hours (9:30 AM–4:00 PM ET, Mon–Fri) | `{asset}-updown-5m-{unix_ts}` |
+| `btc-15m`, `eth-15m`, `sol-15m`, `xrp-15m` | 15 minutes | NYSE hours | `{asset}-updown-15m-{unix_ts}` |
+| `btc-4h`, `eth-4h`, `sol-4h`, `xrp-4h` | 4 hours | 24/7 | `{asset}-updown-4h-{unix_ts}` |
 
-**Slug pattern:** `{asset}-updown-5m-{unix_start_timestamp_utc}`
+Bare asset aliases (`btc`, `bitcoin`, `eth`, `ethereum`, `sol`, `solana`, `xrp`) resolve to the 5-minute series.
 
 ```
 polymarket get-series --series btc-5m      # Current + next BTC 5-min slot
-polymarket get-series --series eth-5m      # Ethereum 5-min
-polymarket get-series --list               # Show all supported series
+polymarket get-series --series eth-15m     # Ethereum 15-min
+polymarket get-series --series btc-4h      # BTC 4-hour (available 24/7)
+polymarket get-series --list               # Show all 12 supported series
 ```
 
 **Output fields:** `series`, `asset`, `session` (in/out of trading hours), `current_slot` (slug, condition_id, outcomes with token_ids/prices, seconds_remaining, liquidity), `next_slot`, `tip` (ready-to-use buy command)
@@ -675,43 +678,74 @@ User wants to trade a series (BTC/ETH/SOL/XRP up/down):
 
 ### Series intent detection
 
-Route to series trading when the user's message combines a **supported crypto asset** with a **short time horizon or directional framing**:
+Route to series trading when the user's message combines a **supported crypto asset** with a **short time horizon or directional framing**. Detect the interval first, then the asset.
 
-| Signal type | Pattern |
-|-------------|---------|
-| Asset (`<token>`) | bitcoin, btc, ethereum, eth, solana, sol, xrp, ripple — any of these fills `<token>` |
-| Abbreviated time | 5m, 5min, 5-min, 5 min, 5 minute(s) |
-| Trader shorthand | `5m <token>`, `<token> 5m`, `<token> 5min`, `5min <token>` |
-| Direction framing | up or down, updown, up/down, price direction, higher or lower, going up, going down |
-| Speed signals | quick trade, quick bet, short term, intraday, next few minutes, next candle, trade the 5m, play the 5m |
+#### Step 1 — Detect interval
 
-**Phrases that map to series trading** (`<token>` = btc / eth / sol / xrp or full names):
-- "5m `<token>` market" / "`<token>` 5m" / "5m `<token>`"
+| Interval | Trigger patterns |
+|----------|-----------------|
+| **5m** | `5m`, `5min`, `5-min`, `5 min`, `5 minute(s)`, `next 5 minutes`, `next few minutes`, `quick`, `intraday`, `short term`, `right now` (implied immediate) |
+| **15m** | `15m`, `15min`, `15-min`, `15 min`, `15 minute(s)`, `quarter hour` |
+| **4h** | `4h`, `4hr`, `4 hour`, `4-hour`, `hourly` (when no 1h is mentioned), `overnight`, `evening trade` |
+| **Ambiguous** | No time qualifier → ask user: *"Which interval — 5m, 15m, or 4h?"* then route accordingly |
+
+#### Step 2 — Detect asset
+
+`<token>` fills with: `bitcoin`/`btc`, `ethereum`/`eth`, `solana`/`sol`, `xrp`/`ripple`
+
+#### Step 3 — Route
+
+```
+asset detected + interval detected → get-series --series <token>-<interval>
+asset detected + no interval → ask interval, default offer: 5m
+no asset + interval → ask which asset (BTC, ETH, SOL, XRP)
+neither → Regular market (list-markets or get-market)
+```
+
+**Phrases that map to each series** (`<token>` = btc / eth / sol / xrp or full names):
+
+*5m series:*
+- "`<token>` 5m" / "5m `<token>`" / "`<token>` 5min"
 - "trade the 5m on `<token>`" / "play the 5m `<token>`"
-- "give me the `<token>` 5m"
-- "5min `<token>` market"
 - "bet on `<token>` going up in the next 5 minutes"
 - "quick `<token>` trade" / "quick `<token>` bet"
 - "will `<token>` go up or down right now?"
 - "`<token>` updown" / "`<token>` up or down"
-- "is `<token>` going up or down?"
 - "play the 5-minute candle on `<token>`"
+
+*15m series:*
+- "`<token>` 15m" / "15m `<token>`" / "`<token>` 15min"
+- "trade the 15m on `<token>`" / "play the 15m `<token>`"
+- "15 minute `<token>` market" / "bet on `<token>` in the next 15 minutes"
+- "give me the `<token>` 15m"
+
+*4h series (24/7):*
+- "`<token>` 4h" / "4h `<token>`" / "`<token>` 4 hour"
+- "trade the 4h on `<token>`" / "play the 4h `<token>`"
+- "hourly `<token>` trade" / "overnight `<token>` bet"
+- "4h candle on `<token>`"
 
 **Disambiguation from regular markets:**
 
 | User phrase | Route |
 |-------------|-------|
-| "`<token>` 5m" / "5m `<token>`" / "`<token>` 5min" / "5min `<token>`" | Series — `buy --market-id <token>-5m` |
-| "trade the 5m on `<token>`" / "`<token>` updown" | Series — route to matching series |
-| "Bet on ETH price direction right now" | Series — `buy --market-id eth-5m` |
+| "`<token>` 5m" / "5m `<token>`" / "`<token>` 5min" | Series — `buy --market-id <token>-5m` |
+| "`<token>` 15m" / "15m `<token>`" / "`<token>` 15min" | Series — `buy --market-id <token>-15m` |
+| "`<token>` 4h" / "4h `<token>`" / "`<token>` hourly" | Series — `buy --market-id <token>-4h` |
+| "trade the 5m/15m/4h on `<token>`" / "`<token>` updown" | Series — route to matching series |
+| "Bet on ETH price direction right now" | Series — default 5m → `buy --market-id eth-5m` |
 | "Will BTC hit 100k?" | Regular market — `list-markets --keyword bitcoin` |
 | "BTC prediction market" (no time frame, no direction) | Regular market — `list-markets` first |
-| Any named event (election, sports, etc.) | Regular market |
+| "TSLA up or down today?" / "Will NVDA go up?" | Daily stock market (not series) — `list-markets --keyword tsla` |
+| Any named event (election, sports, earnings) | Regular market |
 | "quick crypto bet" (no specific asset) | Ask which asset: BTC, ETH, SOL, or XRP |
 
-**Key rule**: `<asset> + 5m` or `5m + <asset>` in any order always means series. The "5m" (or "5 min", "5-min", "5 minute") pattern is unambiguous — Polymarket has no other 5-minute markets.
+**Key rules:**
+- `<asset> + <Nm>` or `<Nm> + <asset>` in any order always means series when N is 5, 15, or 4h
+- Stocks/equities (TSLA, NVDA, SPX, gold, oil) use date-based daily markets, **not** series — route via `list-markets`
+- 4h series runs **24/7** — no NYSE hours check needed; safe to route at any time of day
 
-**When in doubt:** call `get-series --series btc-5m` (or the relevant asset). The output clearly shows whether trading is currently possible (in/out of hours, seconds remaining, current prices), which is low-cost and resolves ambiguity before committing funds.
+**When in doubt:** call `get-series --series <token>-5m` (or the relevant interval). The output clearly shows whether trading is currently possible (in/out of hours, seconds remaining, current prices), which is low-cost and resolves ambiguity before committing funds.
 
 ---
 
@@ -826,6 +860,53 @@ User wants to trade:
 
 ---
 
+## Market Taxonomy
+
+Polymarket offers three broad categories of markets. Route user requests differently depending on which category applies:
+
+### Category 1 — Auto-resolvable series (use `get-series` / `--market-id <series-id>`)
+
+These are recurring short-duration **Up or Down** markets on BTC, ETH, SOL, and XRP. The slug contains a Unix timestamp that changes each slot — the plugin resolves the current slot automatically from the series ID.
+
+| Interval | Assets | Schedule | Auto-resolve ID |
+|----------|--------|----------|----------------|
+| 5 minutes | BTC, ETH, SOL, XRP | NYSE hours (9:30 AM–4:00 PM ET, Mon–Fri) | `btc-5m`, `eth-5m`, `sol-5m`, `xrp-5m` |
+| 15 minutes | BTC, ETH, SOL, XRP | NYSE hours | `btc-15m`, `eth-15m`, `sol-15m`, `xrp-15m` |
+| 4 hours | BTC, ETH, SOL, XRP | 24/7 | `btc-4h`, `eth-4h`, `sol-4h`, `xrp-4h` |
+
+**Use:** `polymarket buy --market-id btc-5m --outcome up --amount 50`  
+**Do not:** manually construct slug timestamps — the binary handles this.
+
+### Category 2 — Daily price direction markets (use `list-markets --keyword`)
+
+These are daily "Up or Down" markets on stocks, indices, and commodities. The slug includes the specific date (e.g. `tsla-up-or-down-on-april-13-2026`), so they cannot be auto-resolved. A new market is created each trading day.
+
+**Equities (daily, NYSE hours):** TSLA, NVDA, AAPL, COIN, PLTR, META, MSFT, AMZN, GOOGL, NFLX, HOOD, RKLB  
+**Indices (daily):** SPX, SPY, QQQ  
+**Commodities (daily):** WTI (crude oil), XAUUSD (gold), XAGUSD (silver), NG (natural gas)
+
+**Use:** `polymarket list-markets --keyword tsla` → find today's slug → `polymarket buy --market-id tsla-up-or-down-on-<date> ...`  
+**Agent flow:** Run `list-markets --keyword <ticker>` first; let the user pick the market from results; then trade by slug.
+
+### Category 3 — Event / news markets (use `list-markets --keyword` or direct slug)
+
+Binary (YES/NO) or categorical (multi-outcome) markets on elections, sports, tech, macro events, etc. Slugs are static (e.g. `will-trump-win-2024`, `nba-championship-2025`).
+
+**Use:** `polymarket list-markets --keyword <topic>` or `polymarket get-market --market-id <slug>`
+
+### Quick routing reference
+
+| User says | Category | How to route |
+|-----------|----------|-------------|
+| "BTC 5m" / "ETH 15m" / "SOL 4h" | Series (Cat 1) | `buy --market-id <token>-<interval>` |
+| "TSLA up or down today" / "Will NVDA go up?" | Daily stock (Cat 2) | `list-markets --keyword tsla` |
+| "Gold up or down today" / "Oil direction" | Daily commodity (Cat 2) | `list-markets --keyword gold` / `--keyword wti` |
+| "SPX direction today" / "QQQ trade" | Daily index (Cat 2) | `list-markets --keyword spx` |
+| "Will Trump win?" / "NBA finals winner" | Event (Cat 3) | `list-markets --keyword trump` / `--keyword nba` |
+| "TSLA 5m" (stock + short interval) | No such market — clarify | Stocks only have daily markets on Polymarket, not 5m/15m. Ask if they mean the daily TSLA market or a BTC/ETH/SOL/XRP series. |
+
+---
+
 ## Command Routing Table
 
 > **Extracting market ID from a URL**: Polymarket URLs look like `polymarket.com/event/<slug>` or `polymarket.com/event/<slug>/<condition_id>`. Use the slug (the human-readable string, e.g. `will-trump-win-2024`) directly as `--market-id`. If the URL contains a `0x`-prefixed condition_id, use that instead.
@@ -850,9 +931,15 @@ User wants to trade:
 | Cancel all open orders | `polymarket cancel --all` |
 | Redeem winning tokens after market resolves | `polymarket redeem --market-id <slug_or_condition_id>` |
 | View current BTC/ETH/SOL/XRP 5-min slot | `polymarket get-series --series btc-5m` |
+| View current BTC/ETH/SOL/XRP 15-min slot | `polymarket get-series --series btc-15m` |
+| View current BTC/ETH/SOL/XRP 4-hour slot (24/7) | `polymarket get-series --series btc-4h` |
 | List all supported series | `polymarket get-series --list` |
 | Trade current BTC 5-min slot (up) | `polymarket buy --market-id btc-5m --outcome up --amount <usdc>` |
 | Trade current ETH 5-min slot (down) | `polymarket buy --market-id eth-5m --outcome down --amount <usdc>` |
+| Trade current BTC 15-min slot | `polymarket buy --market-id btc-15m --outcome up --amount <usdc>` |
+| Trade current ETH 4-hour slot (24/7) | `polymarket buy --market-id eth-4h --outcome up --amount <usdc>` |
+| Find today's TSLA / stock daily market | `polymarket list-markets --keyword tsla` |
+| Find today's gold / commodity market | `polymarket list-markets --keyword gold` |
 | Fast repeat trade (known token ID) | `polymarket buy --token-id <id> --outcome up --amount <usdc> --price <x>` |
 
 ---
@@ -884,4 +971,4 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.8** (2026-04-12).
+See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.7** (2026-04-12).

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -630,20 +630,47 @@ Both are valid `--outcome` values for `buy` and `sell`.
 
 **Agent flow:**
 1. Run `get-series --series <id>` to show the user the current slot (price, liquidity, seconds remaining) and confirm they want to trade it.
-2. Once confirmed, run `buy --market-id <series-id> --outcome <up|down> --amount <usdc> --dry-run` to preview the order.
+2. Once confirmed, run `buy --token-id <token_id_from_step_1> --outcome <up|down> --amount <usdc> --price <price_from_step_1> --dry-run` to preview the order. Use the token ID from `current_slot.outcomes.Up.token_id` (or `Down`). This is faster than using `--market-id` because the market lookup is already done.
 3. After user confirms the dry-run output, run without `--dry-run` to submit.
 4. Return the `order_id` and `status` from the response.
 
 **Example:**
 ```bash
-# Show current slot
+# Step 1: Show current slot — note token_id and price in the output
 polymarket get-series --series btc-5m
+# Output includes: current_slot.outcomes.Up.token_id = "0xabc...", price = 0.52
 
-# Preview the order
-polymarket buy --market-id btc-5m --outcome up --amount 50 --dry-run
+# Step 2: Preview using cached token ID (faster — skips market lookup)
+polymarket buy --token-id 0xabc... --outcome up --amount 50 --price 0.52 --dry-run
 
-# After user confirms:
-polymarket buy --market-id btc-5m --outcome up --amount 50
+# Step 3: After user confirms:
+polymarket buy --token-id 0xabc... --outcome up --amount 50 --price 0.52
+```
+
+### Token ID caching for fast execution
+
+**Automatically activate `--token-id`** whenever a `get-series` call has already been made in the current conversation:
+
+1. After any `get-series` call, record from the output:
+   - `current_slot.outcomes.Up.token_id` and `current_slot.outcomes.Down.token_id`
+   - `current_slot.end_unix` (the Unix timestamp when this slot expires)
+
+2. Before using cached token IDs, verify the slot is still live:
+   - If current time < `end_unix - 30` seconds → slot is valid, use `--token-id`
+   - If current time ≥ `end_unix - 30` seconds → slot is expiring; re-run `get-series` to refresh
+
+3. When the slot is valid, always prefer `--token-id` over `--market-id btc-5m` — it saves 3-4 HTTP round trips from the binary (~500ms).
+
+4. Always pass `--price` when using `--token-id`. The price from `get-series` output is the current market price — use it or ask the user for their target price. Without `--price`, the binary must still fetch the order book for worst-case pricing (the main savings come when `--price` is also provided).
+
+**Decision rule:**
+
+```
+User wants to trade a series (BTC/ETH/SOL/XRP up/down):
+├── get-series output available in this conversation AND slot still live (end_unix > now + 30s)?
+│   └── YES → use: buy --token-id <cached_id> --outcome <up|down> --amount <x> --price <cached_price>
+└── NO (no prior get-series, or slot expired)
+    └── Run get-series first → then use --token-id from fresh output
 ```
 
 ### Series intent detection

--- a/skills/polymarket/plugin.yaml
+++ b/skills/polymarket/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket
-version: "0.2.7"
+version: "0.2.8"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket/plugin.yaml
+++ b/skills/polymarket/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket
-version: "0.2.6"
+version: "0.2.7"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket/plugin.yaml
+++ b/skills/polymarket/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket
-version: "0.2.8"
+version: "0.2.7"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket/src/commands/buy.rs
+++ b/skills/polymarket/src/commands/buy.rs
@@ -8,6 +8,7 @@ use crate::api::{
 };
 use crate::auth::ensure_credentials;
 use crate::onchainos::{approve_usdc, get_wallet_address};
+use crate::series;
 use crate::signing::{sign_order_via_onchainos, OrderParams};
 
 /// Run the buy command.
@@ -53,6 +54,15 @@ pub async fn run(
     let client = Client::new();
 
     // ── Public API phase (no auth, runs for dry-run too) ─────────────────────
+
+    // Resolve series ID to current slot slug if needed (e.g. "btc-5m" → "btc-updown-5m-{ts}")
+    let resolved_market_id;
+    let market_id = if series::is_series_id(market_id) {
+        resolved_market_id = series::resolve_to_slug(&client, market_id).await?;
+        &resolved_market_id as &str
+    } else {
+        market_id
+    };
 
     // Resolve market (no auth required — public API)
     let (condition_id, token_id, neg_risk) =

--- a/skills/polymarket/src/commands/buy.rs
+++ b/skills/polymarket/src/commands/buy.rs
@@ -13,7 +13,7 @@ use crate::signing::{sign_order_via_onchainos, OrderParams};
 
 /// Run the buy command.
 pub async fn run(
-    market_id: &str,
+    market_id: Option<&str>,
     outcome: &str,
     amount: &str,
     price: Option<f64>,
@@ -89,39 +89,46 @@ pub async fn run(
             };
 
             (condition_id, token_id, neg_risk, fee_r, book, wallet_opt)
-        } else if series::is_series_id(market_id) {
-            // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
-            let gamma = series::resolve_to_market(&client, market_id).await?;
-            let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
-
-            // Parallelize book fetch + wallet (wallet only if not dry-run)
-            let (book, wallet_opt) = if dry_run {
-                (get_orderbook(&client, &tid).await?, None)
-            } else {
-                let (b, w) = tokio::join!(
-                    get_orderbook(&client, &tid),
-                    get_wallet_address()
-                );
-                (b?, Some(w?))
-            };
-
-            (cid, tid, nr, fee, book, wallet_opt)
         } else {
-            // ── Standard path: slug or condition_id ────────────────────────────
-            let (cid, tid, nr, fee) = resolve_market_token(&client, market_id, outcome).await?;
+            // ── market_id required for non-fast-path ──────────────────────────
+            let mid = market_id.ok_or_else(|| anyhow::anyhow!(
+                "--market-id is required when --token-id is not provided"
+            ))?;
 
-            // Parallelize book fetch + wallet (wallet only if not dry-run)
-            let (book, wallet_opt) = if dry_run {
-                (get_orderbook(&client, &tid).await?, None)
+            if series::is_series_id(mid) {
+                // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
+                let gamma = series::resolve_to_market(&client, mid).await?;
+                let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
+
+                // Parallelize book fetch + wallet (wallet only if not dry-run)
+                let (book, wallet_opt) = if dry_run {
+                    (get_orderbook(&client, &tid).await?, None)
+                } else {
+                    let (b, w) = tokio::join!(
+                        get_orderbook(&client, &tid),
+                        get_wallet_address()
+                    );
+                    (b?, Some(w?))
+                };
+
+                (cid, tid, nr, fee, book, wallet_opt)
             } else {
-                let (b, w) = tokio::join!(
-                    get_orderbook(&client, &tid),
-                    get_wallet_address()
-                );
-                (b?, Some(w?))
-            };
+                // ── Standard path: slug or condition_id ────────────────────────
+                let (cid, tid, nr, fee) = resolve_market_token(&client, mid, outcome).await?;
 
-            (cid, tid, nr, fee, book, wallet_opt)
+                // Parallelize book fetch + wallet (wallet only if not dry-run)
+                let (book, wallet_opt) = if dry_run {
+                    (get_orderbook(&client, &tid).await?, None)
+                } else {
+                    let (b, w) = tokio::join!(
+                        get_orderbook(&client, &tid),
+                        get_wallet_address()
+                    );
+                    (b?, Some(w?))
+                };
+
+                (cid, tid, nr, fee, book, wallet_opt)
+            }
         };
 
     // Extract tick_size from the order book (avoids a separate get_tick_size call).

--- a/skills/polymarket/src/commands/buy.rs
+++ b/skills/polymarket/src/commands/buy.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 
 use crate::api::{
     compute_buy_worst_price, get_balance_allowance, get_clob_market, get_market_fee, get_orderbook,
-    get_tick_size, post_order, round_price,
+    post_order, round_price,
     OrderBody, OrderRequest,
 };
 use crate::auth::ensure_credentials;
@@ -23,6 +23,7 @@ pub async fn run(
     round_up: bool,
     post_only: bool,
     expires: Option<u64>,
+    token_id_fast: Option<&str>,
 ) -> Result<()> {
     // Parse USDC amount early so we can enforce the minimum order size
     // check even on dry-run (the agent needs to know before placing).
@@ -55,25 +56,79 @@ pub async fn run(
 
     // ── Public API phase (no auth, runs for dry-run too) ─────────────────────
 
-    // Resolve series ID to current slot slug if needed (e.g. "btc-5m" → "btc-updown-5m-{ts}")
-    let resolved_market_id;
-    let market_id = if series::is_series_id(market_id) {
-        resolved_market_id = series::resolve_to_slug(&client, market_id).await?;
-        &resolved_market_id as &str
-    } else {
-        market_id
-    };
+    // Resolve market identifiers and fetch order book.
+    // Four paths:
+    //   1. --token-id fast path: skip all market resolution, get condition_id from book
+    //   2. Series path: resolve series → GammaMarket once (avoid double Gamma fetch)
+    //   3. Slug/condition_id path: standard resolve_market_token
 
-    // Resolve market (no auth required — public API)
-    let (condition_id, token_id, neg_risk) =
-        resolve_market_token(&client, market_id, outcome).await?;
+    let (condition_id, token_id, neg_risk, fee_rate_bps, book, signer_addr_opt) =
+        if let Some(tid) = token_id_fast {
+            // ── Fast path: token_id provided directly ──────────────────────────
+            // Fetch the book (has condition_id, neg_risk, tick_size) and, in parallel
+            // with the fee call, fetch the wallet address (non-dry-run only).
+            let book = get_orderbook(&client, tid).await?;
+            let condition_id = book.market.clone()
+                .ok_or_else(|| anyhow::anyhow!(
+                    "Order book did not return a condition_id for token {}. \
+                     Try using --market-id instead.", tid
+                ))?;
+            let neg_risk = book.neg_risk;
+            let token_id = tid.to_string();
 
-    // Fetch the order book.
-    let book = get_orderbook(&client, &token_id).await?;
+            // Parallelize fee fetch + wallet (wallet only if not dry-run)
+            let (fee_r, wallet_opt) = if dry_run {
+                let fee = get_market_fee(&client, &condition_id).await.unwrap_or(0);
+                (fee, None)
+            } else {
+                let (fee_res, wallet_res) = tokio::join!(
+                    get_market_fee(&client, &condition_id),
+                    get_wallet_address()
+                );
+                (fee_res.unwrap_or(0), Some(wallet_res?))
+            };
 
-    // Get tick size and market fee rate.
-    let tick_size = get_tick_size(&client, &token_id).await?;
-    let fee_rate_bps = get_market_fee(&client, &condition_id).await.unwrap_or(0);
+            (condition_id, token_id, neg_risk, fee_r, book, wallet_opt)
+        } else if series::is_series_id(market_id) {
+            // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
+            let gamma = series::resolve_to_market(&client, market_id).await?;
+            let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
+
+            // Parallelize book fetch + wallet (wallet only if not dry-run)
+            let (book, wallet_opt) = if dry_run {
+                (get_orderbook(&client, &tid).await?, None)
+            } else {
+                let (b, w) = tokio::join!(
+                    get_orderbook(&client, &tid),
+                    get_wallet_address()
+                );
+                (b?, Some(w?))
+            };
+
+            (cid, tid, nr, fee, book, wallet_opt)
+        } else {
+            // ── Standard path: slug or condition_id ────────────────────────────
+            let (cid, tid, nr, fee) = resolve_market_token(&client, market_id, outcome).await?;
+
+            // Parallelize book fetch + wallet (wallet only if not dry-run)
+            let (book, wallet_opt) = if dry_run {
+                (get_orderbook(&client, &tid).await?, None)
+            } else {
+                let (b, w) = tokio::join!(
+                    get_orderbook(&client, &tid),
+                    get_wallet_address()
+                );
+                (b?, Some(w?))
+            };
+
+            (cid, tid, nr, fee, book, wallet_opt)
+        };
+
+    // Extract tick_size from the order book (avoids a separate get_tick_size call).
+    let tick_size = book.tick_size.as_deref()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|&t| t > 0.0)
+        .unwrap_or(0.01);
 
     // Determine price (limit or market).
     let limit_price = if let Some(p) = price {
@@ -209,8 +264,8 @@ pub async fn run(
 
     // ── Auth phase ────────────────────────────────────────────────────────────
 
-    // onchainos wallet is the signer.
-    let signer_addr = get_wallet_address().await?;
+    // Wallet address was already fetched in parallel with the book (non-dry-run path).
+    let signer_addr = signer_addr_opt.expect("signer_addr must be set in non-dry-run path");
     let creds = ensure_credentials(&client, &signer_addr).await?;
     let maker_addr = signer_addr.clone();
 
@@ -340,17 +395,16 @@ pub async fn run(
     Ok(())
 }
 
-/// Resolve (condition_id, token_id, neg_risk) from a market_id and outcome string.
+/// Resolve (condition_id, token_id, neg_risk, fee_rate_bps) from a market_id and outcome string.
 /// Supports any outcome label (e.g. "yes", "no", "trump", "republican", "option-a").
 /// Bails early if the market is not accepting orders (closed, resolved, or paused).
 ///
-/// neg_risk is always sourced from the CLOB API (authoritative) because the Gamma API
-/// omits the negRisk field for many markets, causing incorrect contract approval targets.
+/// neg_risk and fee_rate_bps are always sourced from the CLOB API (authoritative).
 pub async fn resolve_market_token(
     client: &Client,
     market_id: &str,
     outcome: &str,
-) -> Result<(String, String, bool)> {
+) -> Result<(String, String, bool, u64)> {
     let outcome_lower = outcome.to_lowercase();
     if market_id.starts_with("0x") || market_id.starts_with("0X") {
         let market = get_clob_market(client, market_id).await?;
@@ -369,7 +423,8 @@ pub async fn resolve_market_token(
                 let available: Vec<&str> = market.tokens.iter().map(|t| t.outcome.as_str()).collect();
                 anyhow::anyhow!("Outcome '{}' not found. Available outcomes: {:?}", outcome, available)
             })?;
-        Ok((market.condition_id.clone(), token.token_id.clone(), market.neg_risk))
+        let fee_rate_bps = market.maker_base_fee.unwrap_or(0);
+        Ok((market.condition_id.clone(), token.token_id.clone(), market.neg_risk, fee_rate_bps))
     } else {
         let gamma = crate::api::get_gamma_market_by_slug(client, market_id).await?;
         if !gamma.accepting_orders {
@@ -396,16 +451,43 @@ pub async fn resolve_market_token(
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("No token_id for outcome index {}", idx))?;
 
-        // Get authoritative neg_risk from CLOB — Gamma API omits negRisk for many markets,
+        // Get authoritative neg_risk and fee from CLOB — Gamma API omits negRisk for many markets,
         // which causes the wrong exchange to be approved (CTF_EXCHANGE instead of
         // NEG_RISK_CTF_EXCHANGE), wasting gas and failing the order.
-        let neg_risk = match get_clob_market(client, &condition_id).await {
-            Ok(clob) => clob.neg_risk,
-            Err(_) => gamma.neg_risk, // fall back to gamma value if CLOB unavailable
+        let (neg_risk, fee_rate_bps) = match get_clob_market(client, &condition_id).await {
+            Ok(clob) => (clob.neg_risk, clob.maker_base_fee.unwrap_or(0)),
+            Err(_) => (gamma.neg_risk, 0), // fall back to gamma value if CLOB unavailable
         };
 
-        Ok((condition_id, token_id, neg_risk))
+        Ok((condition_id, token_id, neg_risk, fee_rate_bps))
     }
+}
+
+/// Resolve (condition_id, token_id, neg_risk, fee_rate_bps) from a pre-fetched GammaMarket.
+/// Used in the series path to avoid fetching the same Gamma market twice.
+pub async fn resolve_from_gamma(
+    client: &Client,
+    gamma: crate::api::GammaMarket,
+    outcome: &str,
+) -> Result<(String, String, bool, u64)> {
+    if !gamma.accepting_orders {
+        bail!("Series market is not currently accepting orders. It may be outside trading hours or in a transition window.");
+    }
+    let outcome_lower = outcome.to_lowercase();
+    let condition_id = gamma.condition_id.clone()
+        .ok_or_else(|| anyhow::anyhow!("No condition_id in Gamma market response"))?;
+    let token_ids = gamma.token_ids();
+    let outcomes = gamma.outcome_list();
+    let idx = outcomes.iter().position(|o| o.to_lowercase() == outcome_lower)
+        .ok_or_else(|| anyhow::anyhow!("Outcome '{}' not found. Available outcomes: {:?}", outcome, outcomes))?;
+    let token_id = token_ids.get(idx).cloned()
+        .ok_or_else(|| anyhow::anyhow!("No token_id for outcome index {}", idx))?;
+    // Get authoritative neg_risk + fee from CLOB
+    let (neg_risk, fee_rate_bps) = match get_clob_market(client, &condition_id).await {
+        Ok(clob) => (clob.neg_risk, clob.maker_base_fee.unwrap_or(0)),
+        Err(_) => (gamma.neg_risk, 0),
+    };
+    Ok((condition_id, token_id, neg_risk, fee_rate_bps))
 }
 
 /// Generate a random salt within JavaScript's safe integer range (< 2^53).

--- a/skills/polymarket/src/commands/get_series.rs
+++ b/skills/polymarket/src/commands/get_series.rs
@@ -8,10 +8,16 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
     // --list: print all supported series and exit
     if list || series_id.is_none() {
         let supported: Vec<serde_json::Value> = SERIES.iter().map(|s| {
+            let interval_human = if s.interval_secs >= 3600 {
+                format!("{} hours", s.interval_secs / 3600)
+            } else {
+                format!("{} minutes", s.interval_secs / 60)
+            };
             serde_json::json!({
                 "id": s.id,
                 "asset": s.display,
-                "interval": format!("{} minutes", s.interval_secs / 60),
+                "interval": interval_human,
+                "trading_hours": if s.nyse_hours_only { "NYSE hours (9:30 AM – 4:00 PM ET, Mon–Fri)" } else { "24/7" },
                 "slug_pattern": format!("{}-updown-{}-{{unix_start_utc}}", s.asset, s.interval_label),
                 "usage": format!("polymarket buy --market-id {} --outcome up --amount 50", s.id),
             })
@@ -20,7 +26,7 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&serde_json::json!({
             "ok": true,
             "data": {
-                "trading_hours": "9:30 AM – 4:00 PM ET, Monday–Friday (NYSE hours)",
+                "note": "5m and 15m series: NYSE hours only. 4h series: 24/7.",
                 "supported_series": supported,
             }
         }))?);

--- a/skills/polymarket/src/commands/get_series.rs
+++ b/skills/polymarket/src/commands/get_series.rs
@@ -47,8 +47,7 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
         .unwrap_or_default()
         .as_secs();
 
-    let in_trading_hours = series::is_in_trading_hours(now);
-    let (_, current, next) = series::get_series_info(&client, spec).await?;
+    let (in_hours, current, next) = series::get_series_info(&client, spec).await?;
 
     // Format a slot for JSON output
     let format_slot = |slot: &series::SlotSummary, label: &str| -> serde_json::Value {
@@ -80,6 +79,7 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
                 "question": sanitize_opt_owned(&m.question),
                 "start": start_iso,
                 "end": end_iso,
+                "end_unix": slot.end_unix,
                 "seconds_remaining": secs_remaining,
                 "accepting_orders": m.accepting_orders,
                 "outcomes": outcome_map,
@@ -95,6 +95,7 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
                 "slug": slot.slug,
                 "start": start_iso,
                 "end": end_iso,
+                "end_unix": slot.end_unix,
                 "seconds_remaining": secs_remaining,
                 "accepting_orders": false,
                 "note": "market not yet created or not found",
@@ -122,14 +123,28 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
         spec.id
     ));
 
-    let session_note = if in_trading_hours {
+    let (session_note, trading_hours_str, interval_str) = if !spec.nyse_hours_only {
+        (
+            "24/7 — market open".to_string(),
+            "24/7",
+            format!("{} hours", spec.interval_secs / 3600),
+        )
+    } else if in_hours {
         let secs = seconds_remaining_in_session(now);
-        format!("in trading hours — {}m {}s remaining in session", secs / 60, secs % 60)
+        (
+            format!("in trading hours — {}m {}s remaining in session", secs / 60, secs % 60),
+            "9:30 AM – 4:00 PM ET, Monday–Friday",
+            format!("{} minutes", spec.interval_secs / 60),
+        )
     } else {
         let secs = seconds_until_trading_opens(now);
         let h = secs / 3600;
         let m = (secs % 3600) / 60;
-        format!("outside trading hours — next session opens in ~{}h {}m", h, m)
+        (
+            format!("outside trading hours — next session opens in ~{}h {}m", h, m),
+            "9:30 AM – 4:00 PM ET, Monday–Friday",
+            format!("{} minutes", spec.interval_secs / 60),
+        )
     };
 
     println!("{}", serde_json::to_string_pretty(&serde_json::json!({
@@ -137,8 +152,8 @@ pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
         "data": {
             "series": spec.id,
             "asset": spec.display,
-            "interval": format!("{} minutes", spec.interval_secs / 60),
-            "trading_hours": "9:30 AM – 4:00 PM ET, Monday–Friday",
+            "interval": interval_str,
+            "trading_hours": trading_hours_str,
             "session": session_note,
             "current_slot": current_json,
             "next_slot": next_json,

--- a/skills/polymarket/src/commands/get_series.rs
+++ b/skills/polymarket/src/commands/get_series.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use reqwest::Client;
+
+use crate::sanitize::sanitize_opt_owned;
+use crate::series::{self, seconds_remaining_in_session, seconds_until_trading_opens, SERIES};
+
+pub async fn run(series_id: Option<&str>, list: bool) -> Result<()> {
+    // --list: print all supported series and exit
+    if list || series_id.is_none() {
+        let supported: Vec<serde_json::Value> = SERIES.iter().map(|s| {
+            serde_json::json!({
+                "id": s.id,
+                "asset": s.display,
+                "interval": format!("{} minutes", s.interval_secs / 60),
+                "slug_pattern": format!("{}-updown-{}-{{unix_start_utc}}", s.asset, s.interval_label),
+                "usage": format!("polymarket buy --market-id {} --outcome up --amount 50", s.id),
+            })
+        }).collect();
+
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "data": {
+                "trading_hours": "9:30 AM – 4:00 PM ET, Monday–Friday (NYSE hours)",
+                "supported_series": supported,
+            }
+        }))?);
+        return Ok(());
+    }
+
+    let id = series_id.unwrap();
+    let spec = series::parse_series(id)
+        .ok_or_else(|| anyhow::anyhow!(
+            "Unknown series '{}'. Run `polymarket get-series --list` to see supported series.",
+            id
+        ))?;
+
+    let client = Client::new();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let in_trading_hours = series::is_in_trading_hours(now);
+    let (_, current, next) = series::get_series_info(&client, spec).await?;
+
+    // Format a slot for JSON output
+    let format_slot = |slot: &series::SlotSummary, label: &str| -> serde_json::Value {
+        let start_iso = chrono::DateTime::from_timestamp(slot.start_unix as i64, 0)
+            .map(|d| d.to_rfc3339())
+            .unwrap_or_default();
+        let end_iso = chrono::DateTime::from_timestamp(slot.end_unix as i64, 0)
+            .map(|d| d.to_rfc3339())
+            .unwrap_or_default();
+        let secs_remaining = slot.end_unix.saturating_sub(now);
+
+        if let Some(m) = &slot.market {
+            let token_ids = m.token_ids();
+            let prices = m.prices();
+            let outcomes = m.outcome_list();
+
+            // Build outcome map: outcome_name -> {token_id, price}
+            let outcome_map: serde_json::Value = outcomes.iter().enumerate().map(|(i, name)| {
+                (name.clone(), serde_json::json!({
+                    "token_id": token_ids.get(i).cloned().unwrap_or_default(),
+                    "price": prices.get(i).and_then(|p| p.parse::<f64>().ok()),
+                }))
+            }).collect::<serde_json::Map<String, serde_json::Value>>().into();
+
+            serde_json::json!({
+                "slot": label,
+                "slug": sanitize_opt_owned(&m.slug),
+                "condition_id": m.condition_id,
+                "question": sanitize_opt_owned(&m.question),
+                "start": start_iso,
+                "end": end_iso,
+                "seconds_remaining": secs_remaining,
+                "accepting_orders": m.accepting_orders,
+                "outcomes": outcome_map,
+                "liquidity": m.liquidity,
+                "volume_24hr": m.volume24hr,
+                "best_bid": m.best_bid,
+                "best_ask": m.best_ask,
+                "last_trade_price": m.last_trade_price,
+            })
+        } else {
+            serde_json::json!({
+                "slot": label,
+                "slug": slot.slug,
+                "start": start_iso,
+                "end": end_iso,
+                "seconds_remaining": secs_remaining,
+                "accepting_orders": false,
+                "note": "market not yet created or not found",
+            })
+        }
+    };
+
+    let current_json = format_slot(&current, "current");
+    let next_json = format_slot(&next, "next");
+
+    // Build buy hint using the accepting slot
+    let accepting_slug = if current.market.as_ref().map_or(false, |m| m.accepting_orders) {
+        current.market.as_ref().and_then(|m| m.slug.as_deref().map(String::from))
+    } else {
+        next.market.as_ref().and_then(|m| m.slug.as_deref().map(String::from))
+    };
+
+    let buy_hint = accepting_slug.map(|slug| {
+        format!(
+            "polymarket buy --market-id {} --outcome up --amount <USDC>",
+            slug
+        )
+    }).unwrap_or_else(|| format!(
+        "polymarket buy --market-id {} --outcome up --amount <USDC>",
+        spec.id
+    ));
+
+    let session_note = if in_trading_hours {
+        let secs = seconds_remaining_in_session(now);
+        format!("in trading hours — {}m {}s remaining in session", secs / 60, secs % 60)
+    } else {
+        let secs = seconds_until_trading_opens(now);
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        format!("outside trading hours — next session opens in ~{}h {}m", h, m)
+    };
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "data": {
+            "series": spec.id,
+            "asset": spec.display,
+            "interval": format!("{} minutes", spec.interval_secs / 60),
+            "trading_hours": "9:30 AM – 4:00 PM ET, Monday–Friday",
+            "session": session_note,
+            "current_slot": current_json,
+            "next_slot": next_json,
+            "tip": buy_hint,
+        }
+    }))?);
+
+    Ok(())
+}

--- a/skills/polymarket/src/commands/mod.rs
+++ b/skills/polymarket/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod cancel;
 pub mod check_access;
 pub mod get_market;
 pub mod get_positions;
+pub mod get_series;
 pub mod list_markets;
 pub mod redeem;
 pub mod sell;

--- a/skills/polymarket/src/commands/sell.rs
+++ b/skills/polymarket/src/commands/sell.rs
@@ -8,6 +8,7 @@ use crate::api::{
 };
 use crate::auth::ensure_credentials;
 use crate::onchainos::{approve_ctf, get_wallet_address, is_ctf_approved_for_all};
+use crate::series;
 use crate::signing::{sign_order_via_onchainos, OrderParams};
 
 use super::buy::resolve_market_token;
@@ -57,6 +58,15 @@ pub async fn run(
     let client = Client::new();
 
     // ── Public API phase (no auth, runs for dry-run too) ─────────────────────
+
+    // Resolve series ID to current slot slug if needed (e.g. "btc-5m" → "btc-updown-5m-{ts}")
+    let resolved_market_id;
+    let market_id = if series::is_series_id(market_id) {
+        resolved_market_id = series::resolve_to_slug(&client, market_id).await?;
+        &resolved_market_id as &str
+    } else {
+        market_id
+    };
 
     let (condition_id, token_id, neg_risk) = resolve_market_token(&client, market_id, outcome).await?;
 

--- a/skills/polymarket/src/commands/sell.rs
+++ b/skills/polymarket/src/commands/sell.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use reqwest::Client;
 
 use crate::api::{
-    compute_sell_worst_price, get_balance_allowance, get_market_fee, get_orderbook, get_tick_size,
+    compute_sell_worst_price, get_balance_allowance, get_market_fee, get_orderbook,
     post_order, round_price, to_token_units, OrderBody,
     OrderRequest,
 };
@@ -11,7 +11,7 @@ use crate::onchainos::{approve_ctf, get_wallet_address, is_ctf_approved_for_all}
 use crate::series;
 use crate::signing::{sign_order_via_onchainos, OrderParams};
 
-use super::buy::resolve_market_token;
+use super::buy::{resolve_from_gamma, resolve_market_token};
 
 /// Run the sell command.
 ///
@@ -29,6 +29,7 @@ pub async fn run(
     dry_run: bool,
     post_only: bool,
     expires: Option<u64>,
+    token_id_fast: Option<&str>,
 ) -> Result<()> {
     // Parse shares and validate order flags up front (before any network calls).
     let share_amount: f64 = shares.parse().context("invalid shares amount")?;
@@ -59,19 +60,71 @@ pub async fn run(
 
     // ── Public API phase (no auth, runs for dry-run too) ─────────────────────
 
-    // Resolve series ID to current slot slug if needed (e.g. "btc-5m" → "btc-updown-5m-{ts}")
-    let resolved_market_id;
-    let market_id = if series::is_series_id(market_id) {
-        resolved_market_id = series::resolve_to_slug(&client, market_id).await?;
-        &resolved_market_id as &str
-    } else {
-        market_id
-    };
+    // Resolve market identifiers and fetch order book (always needed for tick_size).
+    let (condition_id, token_id, neg_risk, fee_rate_bps, book, signer_addr_opt) =
+        if let Some(tid) = token_id_fast {
+            // ── Fast path: token_id provided directly ──────────────────────────
+            let book = get_orderbook(&client, tid).await?;
+            let condition_id = book.market.clone()
+                .ok_or_else(|| anyhow::anyhow!(
+                    "Order book did not return a condition_id for token {}. \
+                     Try using --market-id instead.", tid
+                ))?;
+            let neg_risk = book.neg_risk;
+            let token_id = tid.to_string();
 
-    let (condition_id, token_id, neg_risk) = resolve_market_token(&client, market_id, outcome).await?;
+            let (fee_r, wallet_opt) = if dry_run {
+                let fee = get_market_fee(&client, &condition_id).await.unwrap_or(0);
+                (fee, None)
+            } else {
+                let (fee_res, wallet_res) = tokio::join!(
+                    get_market_fee(&client, &condition_id),
+                    get_wallet_address()
+                );
+                (fee_res.unwrap_or(0), Some(wallet_res?))
+            };
 
-    let tick_size = get_tick_size(&client, &token_id).await?;
-    let fee_rate_bps = get_market_fee(&client, &condition_id).await.unwrap_or(0);
+            (condition_id, token_id, neg_risk, fee_r, book, wallet_opt)
+        } else if series::is_series_id(market_id) {
+            // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
+            let gamma = series::resolve_to_market(&client, market_id).await?;
+            let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
+
+            // Always fetch the book (needed for tick_size and price computation).
+            let (book, wallet_opt) = if dry_run {
+                (get_orderbook(&client, &tid).await?, None)
+            } else {
+                let (b, w) = tokio::join!(
+                    get_orderbook(&client, &tid),
+                    get_wallet_address()
+                );
+                (b?, Some(w?))
+            };
+
+            (cid, tid, nr, fee, book, wallet_opt)
+        } else {
+            // ── Standard path: slug or condition_id ────────────────────────────
+            let (cid, tid, nr, fee) = resolve_market_token(&client, market_id, outcome).await?;
+
+            // Always fetch the book (needed for tick_size and price computation).
+            let (book, wallet_opt) = if dry_run {
+                (get_orderbook(&client, &tid).await?, None)
+            } else {
+                let (b, w) = tokio::join!(
+                    get_orderbook(&client, &tid),
+                    get_wallet_address()
+                );
+                (b?, Some(w?))
+            };
+
+            (cid, tid, nr, fee, book, wallet_opt)
+        };
+
+    // Extract tick_size from the order book (avoids a separate get_tick_size call).
+    let tick_size = book.tick_size.as_deref()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|&t| t > 0.0)
+        .unwrap_or(0.01);
 
     // Determine price.
     let requested_price = price; // keep for adjustment warning
@@ -92,7 +145,7 @@ pub async fn run(
         }
         rp
     } else {
-        let book = get_orderbook(&client, &token_id).await?;
+        // No explicit price — use the book (already fetched) to compute worst price.
         if let Some(p) = compute_sell_worst_price(&book.bids, share_amount) {
             p
         } else {
@@ -179,7 +232,8 @@ pub async fn run(
 
     // ── Auth phase ────────────────────────────────────────────────────────────
 
-    let signer_addr = get_wallet_address().await?;
+    // Wallet address was already fetched in parallel with the book (non-dry-run path).
+    let signer_addr = signer_addr_opt.expect("signer_addr must be set in non-dry-run path");
     let creds = ensure_credentials(&client, &signer_addr).await?;
     let maker_addr = signer_addr.clone();
 

--- a/skills/polymarket/src/commands/sell.rs
+++ b/skills/polymarket/src/commands/sell.rs
@@ -15,12 +15,12 @@ use super::buy::{resolve_from_gamma, resolve_market_token};
 
 /// Run the sell command.
 ///
-/// market_id: condition_id (0x-prefixed) or slug
+/// market_id: condition_id (0x-prefixed) or slug; optional when --token-id is provided
 /// outcome: outcome label, case-insensitive (e.g. "yes", "no", "trump")
 /// shares: number of token shares to sell (human-readable)
 /// price: limit price in [0, 1], or None for market order (FOK)
 pub async fn run(
-    market_id: &str,
+    market_id: Option<&str>,
     outcome: &str,
     shares: &str,
     price: Option<f64>,
@@ -85,39 +85,46 @@ pub async fn run(
             };
 
             (condition_id, token_id, neg_risk, fee_r, book, wallet_opt)
-        } else if series::is_series_id(market_id) {
-            // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
-            let gamma = series::resolve_to_market(&client, market_id).await?;
-            let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
-
-            // Always fetch the book (needed for tick_size and price computation).
-            let (book, wallet_opt) = if dry_run {
-                (get_orderbook(&client, &tid).await?, None)
-            } else {
-                let (b, w) = tokio::join!(
-                    get_orderbook(&client, &tid),
-                    get_wallet_address()
-                );
-                (b?, Some(w?))
-            };
-
-            (cid, tid, nr, fee, book, wallet_opt)
         } else {
-            // ── Standard path: slug or condition_id ────────────────────────────
-            let (cid, tid, nr, fee) = resolve_market_token(&client, market_id, outcome).await?;
+            // ── market_id required for non-fast-path ──────────────────────────
+            let mid = market_id.ok_or_else(|| anyhow::anyhow!(
+                "--market-id is required when --token-id is not provided"
+            ))?;
 
-            // Always fetch the book (needed for tick_size and price computation).
-            let (book, wallet_opt) = if dry_run {
-                (get_orderbook(&client, &tid).await?, None)
+            if series::is_series_id(mid) {
+                // ── Series path: single Gamma fetch, then CLOB for neg_risk + fee ──
+                let gamma = series::resolve_to_market(&client, mid).await?;
+                let (cid, tid, nr, fee) = resolve_from_gamma(&client, gamma, outcome).await?;
+
+                // Always fetch the book (needed for tick_size and price computation).
+                let (book, wallet_opt) = if dry_run {
+                    (get_orderbook(&client, &tid).await?, None)
+                } else {
+                    let (b, w) = tokio::join!(
+                        get_orderbook(&client, &tid),
+                        get_wallet_address()
+                    );
+                    (b?, Some(w?))
+                };
+
+                (cid, tid, nr, fee, book, wallet_opt)
             } else {
-                let (b, w) = tokio::join!(
-                    get_orderbook(&client, &tid),
-                    get_wallet_address()
-                );
-                (b?, Some(w?))
-            };
+                // ── Standard path: slug or condition_id ────────────────────────
+                let (cid, tid, nr, fee) = resolve_market_token(&client, mid, outcome).await?;
 
-            (cid, tid, nr, fee, book, wallet_opt)
+                // Always fetch the book (needed for tick_size and price computation).
+                let (book, wallet_opt) = if dry_run {
+                    (get_orderbook(&client, &tid).await?, None)
+                } else {
+                    let (b, w) = tokio::join!(
+                        get_orderbook(&client, &tid),
+                        get_wallet_address()
+                    );
+                    (b?, Some(w?))
+                };
+
+                (cid, tid, nr, fee, book, wallet_opt)
+            }
         };
 
     // Extract tick_size from the order book (avoids a separate get_tick_size call).

--- a/skills/polymarket/src/main.rs
+++ b/skills/polymarket/src/main.rs
@@ -99,6 +99,11 @@ enum Commands {
         /// Confirm a previously gated action (reserved for future use)
         #[arg(long)]
         confirm: bool,
+
+        /// Skip market lookup — use a known token ID directly (from get-series or get-market output).
+        /// Faster for repeated trades: resolves condition_id and neg_risk from the order book.
+        #[arg(long)]
+        token_id: Option<String>,
     },
 
     /// Sell YES or NO shares in a market (signs via onchainos wallet)
@@ -144,6 +149,11 @@ enum Commands {
         /// Confirm a low-price market sell that was previously gated
         #[arg(long)]
         confirm: bool,
+
+        /// Skip market lookup — use a known token ID directly (from get-series or get-market output).
+        /// Faster for repeated trades: resolves condition_id and neg_risk from the order book.
+        #[arg(long)]
+        token_id: Option<String>,
     },
 
     /// Redeem winning outcome tokens after a market resolves (signs via onchainos wallet)
@@ -213,8 +223,9 @@ async fn main() {
             post_only,
             expires,
             confirm: _confirm,
+            token_id,
         } => {
-            commands::buy::run(&market_id, &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires).await
+            commands::buy::run(&market_id, &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, token_id.as_deref()).await
         }
         Commands::Sell {
             market_id,
@@ -227,8 +238,9 @@ async fn main() {
             post_only,
             expires,
             confirm: _confirm,
+            token_id,
         } => {
-            commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires).await
+            commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, token_id.as_deref()).await
         }
         Commands::GetSeries { series, list } => {
             commands::get_series::run(series.as_deref(), list).await

--- a/skills/polymarket/src/main.rs
+++ b/skills/polymarket/src/main.rs
@@ -4,6 +4,7 @@ mod commands;
 mod config;
 mod onchainos;
 mod sanitize;
+mod series;
 mod signing;
 
 use clap::{Parser, Subcommand};
@@ -156,6 +157,17 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Get current and next slot for a recurring series market (e.g. btc-5m, eth-5m)
+    GetSeries {
+        /// Series ID: btc-5m, eth-5m, sol-5m, xrp-5m (or just btc, eth, sol, xrp)
+        #[arg(long)]
+        series: Option<String>,
+
+        /// List all supported series and exit
+        #[arg(long)]
+        list: bool,
+    },
+
     /// Cancel a single open order by order ID (signs via onchainos wallet)
     Cancel {
         /// Order ID (0x-prefixed hash). Omit to cancel all orders.
@@ -217,6 +229,9 @@ async fn main() {
             confirm: _confirm,
         } => {
             commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires).await
+        }
+        Commands::GetSeries { series, list } => {
+            commands::get_series::run(series.as_deref(), list).await
         }
         Commands::Redeem { market_id, dry_run } => {
             commands::redeem::run(&market_id, dry_run).await

--- a/skills/polymarket/src/main.rs
+++ b/skills/polymarket/src/main.rs
@@ -52,9 +52,10 @@ enum Commands {
 
     /// Buy YES or NO shares in a market (signs via onchainos wallet)
     Buy {
-        /// Market identifier: condition_id (0x-prefixed hex) or slug
+        /// Market identifier: condition_id (0x-prefixed hex) or slug.
+        /// Optional when --token-id is provided (fast path skips market lookup).
         #[arg(long)]
-        market_id: String,
+        market_id: Option<String>,
 
         /// Outcome to buy: "yes" or "no"
         #[arg(long)]
@@ -108,9 +109,10 @@ enum Commands {
 
     /// Sell YES or NO shares in a market (signs via onchainos wallet)
     Sell {
-        /// Market identifier: condition_id (0x-prefixed hex) or slug
+        /// Market identifier: condition_id (0x-prefixed hex) or slug.
+        /// Optional when --token-id is provided (fast path skips market lookup).
         #[arg(long)]
-        market_id: String,
+        market_id: Option<String>,
 
         /// Outcome to sell: "yes" or "no"
         #[arg(long)]
@@ -225,7 +227,7 @@ async fn main() {
             confirm: _confirm,
             token_id,
         } => {
-            commands::buy::run(&market_id, &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, token_id.as_deref()).await
+            commands::buy::run(market_id.as_deref(), &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, token_id.as_deref()).await
         }
         Commands::Sell {
             market_id,
@@ -240,7 +242,7 @@ async fn main() {
             confirm: _confirm,
             token_id,
         } => {
-            commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, token_id.as_deref()).await
+            commands::sell::run(market_id.as_deref(), &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, token_id.as_deref()).await
         }
         Commands::GetSeries { series, list } => {
             commands::get_series::run(series.as_deref(), list).await

--- a/skills/polymarket/src/series.rs
+++ b/skills/polymarket/src/series.rs
@@ -227,6 +227,13 @@ pub async fn resolve_to_slug(client: &Client, series_id: &str) -> Result<String>
     market.slug.ok_or_else(|| anyhow::anyhow!("Series market has no slug"))
 }
 
+/// Resolve a series ID to the current accepting GammaMarket (avoids double Gamma fetch in buy/sell).
+pub async fn resolve_to_market(client: &Client, series_id: &str) -> Result<crate::api::GammaMarket> {
+    let spec = parse_series(series_id)
+        .ok_or_else(|| anyhow::anyhow!("Unknown series '{}'. Supported: btc-5m, eth-5m, sol-5m, xrp-5m", series_id))?;
+    get_current_slot(client, spec).await
+}
+
 // ─── get-series output helpers ────────────────────────────────────────────────
 
 pub struct SlotSummary {

--- a/skills/polymarket/src/series.rs
+++ b/skills/polymarket/src/series.rs
@@ -1,0 +1,273 @@
+/// Series market resolution for recurring short-duration markets.
+///
+/// Polymarket runs "Up or Down" series markets on crypto assets during NYSE trading
+/// hours (9:30 AM – 4:00 PM ET, Monday–Friday). Each slot is a 5-minute window.
+///
+/// Slug pattern: `{asset}-updown-5m-{unix_start_timestamp_utc}`
+/// Example: `btc-updown-5m-1776054300` → Bitcoin slot starting at Unix 1776054300
+///
+/// Supported series IDs: btc-5m, eth-5m, sol-5m, xrp-5m
+/// Aliases accepted: "btc", "bitcoin", "eth", "ethereum", "sol", "solana", "xrp"
+use anyhow::{bail, Result};
+use reqwest::Client;
+
+use crate::api::GammaMarket;
+
+// ─── Series registry ──────────────────────────────────────────────────────────
+
+pub struct SeriesSpec {
+    pub id: &'static str,       // canonical ID, e.g. "btc-5m"
+    pub asset: &'static str,    // slug prefix, e.g. "btc"
+    pub display: &'static str,  // human name, e.g. "Bitcoin"
+    pub interval_secs: u64,     // window length in seconds
+    pub interval_label: &'static str, // e.g. "5m"
+}
+
+pub const SERIES: &[SeriesSpec] = &[
+    SeriesSpec { id: "btc-5m", asset: "btc", display: "Bitcoin",  interval_secs: 300, interval_label: "5m" },
+    SeriesSpec { id: "eth-5m", asset: "eth", display: "Ethereum", interval_secs: 300, interval_label: "5m" },
+    SeriesSpec { id: "sol-5m", asset: "sol", display: "Solana",   interval_secs: 300, interval_label: "5m" },
+    SeriesSpec { id: "xrp-5m", asset: "xrp", display: "XRP",     interval_secs: 300, interval_label: "5m" },
+];
+
+/// Parse a series string into a SeriesSpec.
+/// Accepts: "btc-5m", "btc", "bitcoin", "BTC", "BTC-5M", etc.
+pub fn parse_series(s: &str) -> Option<&'static SeriesSpec> {
+    let lower = s.to_lowercase();
+    SERIES.iter().find(|spec| {
+        lower == spec.id
+            || lower == spec.asset
+            || lower == spec.display.to_lowercase()
+            || lower == format!("{}-updown-{}", spec.asset, spec.interval_label)
+    })
+}
+
+/// Returns true if the string looks like a series identifier.
+pub fn is_series_id(s: &str) -> bool {
+    parse_series(s).is_some()
+}
+
+// ─── NYSE trading hours ───────────────────────────────────────────────────────
+
+/// Return the ET (Eastern Time) UTC offset in seconds for a given Unix timestamp.
+/// Accounts for US DST: EDT (UTC-4) from 2nd Sunday of March to 1st Sunday of November,
+/// EST (UTC-5) otherwise.
+fn et_offset_secs(unix_ts: u64) -> i64 {
+    use chrono::{DateTime, Datelike, NaiveDate, Utc, Weekday};
+
+    let dt = DateTime::from_timestamp(unix_ts as i64, 0).unwrap_or_else(|| Utc::now());
+    let year = dt.year();
+
+    // 2nd Sunday of March → DST starts at 2 AM EST = 7 AM UTC
+    let dst_start_day = nth_weekday_of_month(year, 3, Weekday::Sun, 2);
+    let dst_start = NaiveDate::from_ymd_opt(year, 3, dst_start_day)
+        .and_then(|d| d.and_hms_opt(7, 0, 0))
+        .map(|dt| dt.and_utc())
+        .unwrap_or(dt);
+
+    // 1st Sunday of November → DST ends at 2 AM EDT = 6 AM UTC
+    let dst_end_day = nth_weekday_of_month(year, 11, Weekday::Sun, 1);
+    let dst_end = NaiveDate::from_ymd_opt(year, 11, dst_end_day)
+        .and_then(|d| d.and_hms_opt(6, 0, 0))
+        .map(|dt| dt.and_utc())
+        .unwrap_or(dt);
+
+    if dt >= dst_start && dt < dst_end {
+        -4 * 3600 // EDT
+    } else {
+        -5 * 3600 // EST
+    }
+}
+
+/// Find the nth occurrence of a weekday in a given year/month.
+fn nth_weekday_of_month(year: i32, month: u32, weekday: chrono::Weekday, n: u32) -> u32 {
+    use chrono::{Datelike, NaiveDate};
+    let mut count = 0u32;
+    for day in 1u32..=31 {
+        if let Some(d) = NaiveDate::from_ymd_opt(year, month, day) {
+            if d.weekday() == weekday {
+                count += 1;
+                if count == n {
+                    return day;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+    1 // fallback
+}
+
+/// Check whether a Unix timestamp falls within NYSE trading hours:
+/// 9:30 AM – 4:00 PM ET, Monday–Friday.
+pub fn is_in_trading_hours(unix_ts: u64) -> bool {
+    use chrono::{DateTime, Datelike, Timelike, Weekday};
+
+    // Shift timestamp to ET by adding the offset (negative), giving a "fake UTC"
+    // whose hour/minute/weekday fields read as ET local time.
+    let et_ts = unix_ts as i64 + et_offset_secs(unix_ts);
+    let dt = match DateTime::from_timestamp(et_ts, 0) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    // Weekend check
+    if matches!(dt.weekday(), Weekday::Sat | Weekday::Sun) {
+        return false;
+    }
+
+    // 9:30 AM (570 min) inclusive to 4:00 PM (960 min) exclusive
+    let mins = dt.hour() * 60 + dt.minute();
+    mins >= 570 && mins < 960
+}
+
+/// Compute how many seconds remain in the current trading session,
+/// or 0 if currently outside trading hours.
+pub fn seconds_remaining_in_session(unix_ts: u64) -> u64 {
+    if !is_in_trading_hours(unix_ts) {
+        return 0;
+    }
+    let et_ts = unix_ts as i64 + et_offset_secs(unix_ts);
+    let dt = match chrono::DateTime::from_timestamp(et_ts, 0) {
+        Some(d) => d,
+        None => return 0,
+    };
+    use chrono::Timelike;
+    let end_of_session_mins = 16 * 60u32; // 4:00 PM
+    let current_mins = dt.hour() * 60 + dt.minute();
+    let remaining_mins = end_of_session_mins.saturating_sub(current_mins);
+    (remaining_mins as u64) * 60 - dt.second() as u64
+}
+
+/// Compute seconds until the next NYSE trading session opens (0 if currently open).
+pub fn seconds_until_trading_opens(from_unix: u64) -> u64 {
+    if is_in_trading_hours(from_unix) {
+        return 0;
+    }
+    // Walk forward in 60-second steps; cap at 7 days
+    let mut t = from_unix;
+    for _ in 0..(7 * 24 * 60) {
+        t += 60;
+        if is_in_trading_hours(t) {
+            return t - from_unix;
+        }
+    }
+    0
+}
+
+// ─── Slot resolution ──────────────────────────────────────────────────────────
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Build the Gamma slug for a series slot.
+fn slot_slug(spec: &SeriesSpec, slot_start: u64) -> String {
+    format!("{}-updown-{}-{}", spec.asset, spec.interval_label, slot_start)
+}
+
+/// Round a Unix timestamp down to the nearest slot boundary.
+fn floor_to_slot(unix_ts: u64, interval_secs: u64) -> u64 {
+    (unix_ts / interval_secs) * interval_secs
+}
+
+/// Fetch the current accepting market for a series.
+///
+/// Tries the current slot and the next slot (handles the brief gap between
+/// when one slot closes and the next one opens). Returns the first one
+/// that is `accepting_orders: true`.
+pub async fn get_current_slot(client: &Client, spec: &SeriesSpec) -> Result<GammaMarket> {
+    let now = now_unix();
+
+    if !is_in_trading_hours(now) {
+        let secs = seconds_until_trading_opens(now);
+        let hours = secs / 3600;
+        let mins = (secs % 3600) / 60;
+        bail!(
+            "{} Up/Down 5-minute markets are only available during NYSE trading hours \
+             (9:30 AM – 4:00 PM ET, Monday–Friday). \
+             Next session opens in ~{}h {}m.",
+            spec.display,
+            hours,
+            mins
+        );
+    }
+
+    let current = floor_to_slot(now, spec.interval_secs);
+
+    // Try current slot, then next (slot may have just closed, next may be open)
+    for ts in [current, current + spec.interval_secs] {
+        let slug = slot_slug(spec, ts);
+        match crate::api::get_gamma_market_by_slug(client, &slug).await {
+            Ok(m) if m.accepting_orders => return Ok(m),
+            Ok(_) => {}  // market exists but not accepting orders
+            Err(_) => {} // not yet created
+        }
+    }
+
+    bail!(
+        "No open {} 5-minute market found for the current slot (around {}). \
+         The window may be transitioning — wait a few seconds and retry.",
+        spec.display,
+        chrono::DateTime::from_timestamp(current as i64, 0)
+            .map(|d| d.to_rfc3339())
+            .unwrap_or_else(|| current.to_string())
+    );
+}
+
+/// Resolve a series ID to the slug of the current accepting market slot.
+/// Used by buy/sell to transparently handle series identifiers as market_ids.
+pub async fn resolve_to_slug(client: &Client, series_id: &str) -> Result<String> {
+    let spec = parse_series(series_id)
+        .ok_or_else(|| anyhow::anyhow!("Unknown series '{}'. Supported: btc-5m, eth-5m, sol-5m, xrp-5m", series_id))?;
+    let market = get_current_slot(client, spec).await?;
+    market.slug.ok_or_else(|| anyhow::anyhow!("Series market has no slug"))
+}
+
+// ─── get-series output helpers ────────────────────────────────────────────────
+
+pub struct SlotSummary {
+    pub slug: String,
+    pub start_unix: u64,
+    pub end_unix: u64,
+    pub market: Option<GammaMarket>,
+}
+
+/// Fetch info for the current and next slot of a series.
+pub async fn get_series_info(
+    client: &Client,
+    spec: &SeriesSpec,
+) -> Result<(bool, SlotSummary, SlotSummary)> {
+    let now = now_unix();
+    let in_hours = is_in_trading_hours(now);
+
+    let current_start = floor_to_slot(now, spec.interval_secs);
+    let next_start = current_start + spec.interval_secs;
+
+    let current_slug = slot_slug(spec, current_start);
+    let next_slug = slot_slug(spec, next_start);
+
+    // Fetch both in parallel
+    let (current_market, next_market) = tokio::join!(
+        crate::api::get_gamma_market_by_slug(client, &current_slug),
+        crate::api::get_gamma_market_by_slug(client, &next_slug),
+    );
+
+    let current = SlotSummary {
+        slug: current_slug,
+        start_unix: current_start,
+        end_unix: current_start + spec.interval_secs,
+        market: current_market.ok(),
+    };
+    let next = SlotSummary {
+        slug: next_slug,
+        start_unix: next_start,
+        end_unix: next_start + spec.interval_secs,
+        market: next_market.ok(),
+    };
+
+    Ok((in_hours, current, next))
+}

--- a/skills/polymarket/src/series.rs
+++ b/skills/polymarket/src/series.rs
@@ -1,13 +1,21 @@
 /// Series market resolution for recurring short-duration markets.
 ///
-/// Polymarket runs "Up or Down" series markets on crypto assets during NYSE trading
-/// hours (9:30 AM – 4:00 PM ET, Monday–Friday). Each slot is a 5-minute window.
+/// Polymarket runs recurring "Up or Down" series markets on crypto assets:
 ///
-/// Slug pattern: `{asset}-updown-5m-{unix_start_timestamp_utc}`
-/// Example: `btc-updown-5m-1776054300` → Bitcoin slot starting at Unix 1776054300
+/// 5-minute slots  — NYSE trading hours only (9:30 AM – 4:00 PM ET, Mon–Fri)
+///   Slug: `{asset}-updown-5m-{unix_start_utc}`
+///   IDs:  btc-5m, eth-5m, sol-5m, xrp-5m
 ///
-/// Supported series IDs: btc-5m, eth-5m, sol-5m, xrp-5m
-/// Aliases accepted: "btc", "bitcoin", "eth", "ethereum", "sol", "solana", "xrp"
+/// 15-minute slots — NYSE trading hours only
+///   Slug: `{asset}-updown-15m-{unix_start_utc}`
+///   IDs:  btc-15m, eth-15m, sol-15m, xrp-15m
+///
+/// 4-hour slots    — runs 24/7 (6 slots per day, every 4 hours)
+///   Slug: `{asset}-updown-4h-{unix_start_utc}`
+///   IDs:  btc-4h, eth-4h, sol-4h, xrp-4h
+///
+/// Aliases accepted: "btc"/"bitcoin", "eth"/"ethereum", "sol"/"solana", "xrp"
+/// plus interval suffixes: "btc-5m", "btc-15m", "btc-4h", etc.
 use anyhow::{bail, Result};
 use reqwest::Client;
 
@@ -16,29 +24,43 @@ use crate::api::GammaMarket;
 // ─── Series registry ──────────────────────────────────────────────────────────
 
 pub struct SeriesSpec {
-    pub id: &'static str,       // canonical ID, e.g. "btc-5m"
-    pub asset: &'static str,    // slug prefix, e.g. "btc"
-    pub display: &'static str,  // human name, e.g. "Bitcoin"
-    pub interval_secs: u64,     // window length in seconds
-    pub interval_label: &'static str, // e.g. "5m"
+    pub id: &'static str,              // canonical ID, e.g. "btc-5m"
+    pub asset: &'static str,           // slug prefix, e.g. "btc"
+    pub display: &'static str,         // human name, e.g. "Bitcoin"
+    pub interval_secs: u64,            // window length in seconds
+    pub interval_label: &'static str,  // e.g. "5m", "15m", "4h"
+    pub nyse_hours_only: bool,         // if true, only active during NYSE trading hours
 }
 
 pub const SERIES: &[SeriesSpec] = &[
-    SeriesSpec { id: "btc-5m", asset: "btc", display: "Bitcoin",  interval_secs: 300, interval_label: "5m" },
-    SeriesSpec { id: "eth-5m", asset: "eth", display: "Ethereum", interval_secs: 300, interval_label: "5m" },
-    SeriesSpec { id: "sol-5m", asset: "sol", display: "Solana",   interval_secs: 300, interval_label: "5m" },
-    SeriesSpec { id: "xrp-5m", asset: "xrp", display: "XRP",     interval_secs: 300, interval_label: "5m" },
+    // 5-minute slots (NYSE hours)
+    SeriesSpec { id: "btc-5m",  asset: "btc", display: "Bitcoin",  interval_secs: 300,   interval_label: "5m",  nyse_hours_only: true  },
+    SeriesSpec { id: "eth-5m",  asset: "eth", display: "Ethereum", interval_secs: 300,   interval_label: "5m",  nyse_hours_only: true  },
+    SeriesSpec { id: "sol-5m",  asset: "sol", display: "Solana",   interval_secs: 300,   interval_label: "5m",  nyse_hours_only: true  },
+    SeriesSpec { id: "xrp-5m",  asset: "xrp", display: "XRP",     interval_secs: 300,   interval_label: "5m",  nyse_hours_only: true  },
+    // 15-minute slots (NYSE hours)
+    SeriesSpec { id: "btc-15m", asset: "btc", display: "Bitcoin",  interval_secs: 900,   interval_label: "15m", nyse_hours_only: true  },
+    SeriesSpec { id: "eth-15m", asset: "eth", display: "Ethereum", interval_secs: 900,   interval_label: "15m", nyse_hours_only: true  },
+    SeriesSpec { id: "sol-15m", asset: "sol", display: "Solana",   interval_secs: 900,   interval_label: "15m", nyse_hours_only: true  },
+    SeriesSpec { id: "xrp-15m", asset: "xrp", display: "XRP",     interval_secs: 900,   interval_label: "15m", nyse_hours_only: true  },
+    // 4-hour slots (24/7 — no NYSE hours restriction)
+    SeriesSpec { id: "btc-4h",  asset: "btc", display: "Bitcoin",  interval_secs: 14400, interval_label: "4h",  nyse_hours_only: false },
+    SeriesSpec { id: "eth-4h",  asset: "eth", display: "Ethereum", interval_secs: 14400, interval_label: "4h",  nyse_hours_only: false },
+    SeriesSpec { id: "sol-4h",  asset: "sol", display: "Solana",   interval_secs: 14400, interval_label: "4h",  nyse_hours_only: false },
+    SeriesSpec { id: "xrp-4h",  asset: "xrp", display: "XRP",     interval_secs: 14400, interval_label: "4h",  nyse_hours_only: false },
 ];
 
 /// Parse a series string into a SeriesSpec.
-/// Accepts: "btc-5m", "btc", "bitcoin", "BTC", "BTC-5M", etc.
+/// Accepts full IDs ("btc-5m", "eth-15m", "btc-4h"), bare asset names ("btc",
+/// "bitcoin"), and asset+interval combos ("btc-updown-5m", "eth-updown-15m").
+/// Bare asset names ("btc", "bitcoin") resolve to the 5-minute series.
 pub fn parse_series(s: &str) -> Option<&'static SeriesSpec> {
     let lower = s.to_lowercase();
     SERIES.iter().find(|spec| {
         lower == spec.id
-            || lower == spec.asset
-            || lower == spec.display.to_lowercase()
             || lower == format!("{}-updown-{}", spec.asset, spec.interval_label)
+            // bare asset name → default to 5m
+            || (spec.interval_label == "5m" && (lower == spec.asset || lower == spec.display.to_lowercase()))
     })
 }
 
@@ -179,18 +201,22 @@ fn floor_to_slot(unix_ts: u64, interval_secs: u64) -> u64 {
 /// Tries the current slot and the next slot (handles the brief gap between
 /// when one slot closes and the next one opens). Returns the first one
 /// that is `accepting_orders: true`.
+///
+/// For NYSE-hours-only series (5m, 15m), fails clearly outside trading hours.
+/// For 24/7 series (4h), always attempts the lookup.
 pub async fn get_current_slot(client: &Client, spec: &SeriesSpec) -> Result<GammaMarket> {
     let now = now_unix();
 
-    if !is_in_trading_hours(now) {
+    if spec.nyse_hours_only && !is_in_trading_hours(now) {
         let secs = seconds_until_trading_opens(now);
         let hours = secs / 3600;
         let mins = (secs % 3600) / 60;
         bail!(
-            "{} Up/Down 5-minute markets are only available during NYSE trading hours \
+            "{} Up/Down {}-minute markets are only available during NYSE trading hours \
              (9:30 AM – 4:00 PM ET, Monday–Friday). \
              Next session opens in ~{}h {}m.",
             spec.display,
+            spec.interval_secs / 60,
             hours,
             mins
         );
@@ -209,9 +235,10 @@ pub async fn get_current_slot(client: &Client, spec: &SeriesSpec) -> Result<Gamm
     }
 
     bail!(
-        "No open {} 5-minute market found for the current slot (around {}). \
+        "No open {} {} market found for the current slot (around {}). \
          The window may be transitioning — wait a few seconds and retry.",
         spec.display,
+        spec.id,
         chrono::DateTime::from_timestamp(current as i64, 0)
             .map(|d| d.to_rfc3339())
             .unwrap_or_else(|| current.to_string())
@@ -222,7 +249,7 @@ pub async fn get_current_slot(client: &Client, spec: &SeriesSpec) -> Result<Gamm
 /// Used by buy/sell to transparently handle series identifiers as market_ids.
 pub async fn resolve_to_slug(client: &Client, series_id: &str) -> Result<String> {
     let spec = parse_series(series_id)
-        .ok_or_else(|| anyhow::anyhow!("Unknown series '{}'. Supported: btc-5m, eth-5m, sol-5m, xrp-5m", series_id))?;
+        .ok_or_else(|| anyhow::anyhow!("Unknown series '{}'. Supported: btc-5m/15m/4h, eth-5m/15m/4h, sol-5m/15m/4h, xrp-5m/15m/4h", series_id))?;
     let market = get_current_slot(client, spec).await?;
     market.slug.ok_or_else(|| anyhow::anyhow!("Series market has no slug"))
 }
@@ -249,7 +276,9 @@ pub async fn get_series_info(
     spec: &SeriesSpec,
 ) -> Result<(bool, SlotSummary, SlotSummary)> {
     let now = now_unix();
-    let in_hours = is_in_trading_hours(now);
+    // For NYSE-restricted series, report whether we're in trading hours.
+    // For 24/7 series (4h), always treat as "in hours".
+    let in_hours = !spec.nyse_hours_only || is_in_trading_hours(now);
 
     let current_start = floor_to_slot(now, spec.interval_secs);
     let next_start = current_start + spec.interval_secs;

--- a/skills/polymarket/src/series.rs
+++ b/skills/polymarket/src/series.rs
@@ -207,21 +207,6 @@ fn floor_to_slot(unix_ts: u64, interval_secs: u64) -> u64 {
 pub async fn get_current_slot(client: &Client, spec: &SeriesSpec) -> Result<GammaMarket> {
     let now = now_unix();
 
-    if spec.nyse_hours_only && !is_in_trading_hours(now) {
-        let secs = seconds_until_trading_opens(now);
-        let hours = secs / 3600;
-        let mins = (secs % 3600) / 60;
-        bail!(
-            "{} Up/Down {}-minute markets are only available during NYSE trading hours \
-             (9:30 AM – 4:00 PM ET, Monday–Friday). \
-             Next session opens in ~{}h {}m.",
-            spec.display,
-            spec.interval_secs / 60,
-            hours,
-            mins
-        );
-    }
-
     let current = floor_to_slot(now, spec.interval_secs);
 
     // Try current slot, then next (slot may have just closed, next may be open)


### PR DESCRIPTION
## Summary

- **New `get-series` command** — shows the current and next 5-minute slot for BTC/ETH/SOL/XRP with prices, token IDs, seconds remaining, liquidity, and a ready-to-run buy hint. `--list` enumerates all supported series.
- **Transparent series resolution in `buy`/`sell`** — pass `--market-id btc-5m` (or `eth-5m`, `sol-5m`, `xrp-5m`) and the plugin auto-resolves to the current accepting slot at trade time. No manual slug lookup required.
- **DST-aware NYSE trading hours check** — series markets only run 9:30 AM–4:00 PM ET Mon–Fri. Outside hours, the plugin reports the exact time until the next session opens.
- **Slot transition gap handling** — when the current slot closes and the next hasn't opened yet, the plugin tries the next slot automatically before failing.

## New files

- `src/series.rs` — series registry, DST-aware ET offset, NYSE hours check, slot resolution logic
- `src/commands/get_series.rs` — `get-series` command implementation

## Modified files

- `src/commands/buy.rs` / `sell.rs` — series ID detection + auto-resolution before market lookup
- `src/commands/mod.rs` / `src/main.rs` — `GetSeries` subcommand wired up
- `Cargo.toml` / `plugin.yaml` — version bumped to `0.2.7`
- `SKILL.md` — `get-series` command docs, series buy/sell routing, trigger phrases
- `CHANGELOG.md` — v0.2.7 entry

## Test plan

- [ ] `polymarket get-series --list` returns all 4 series (btc-5m, eth-5m, sol-5m, xrp-5m)
- [ ] `polymarket get-series btc-5m` during trading hours: shows current/next slot data and accepting status
- [ ] `polymarket get-series btc` (alias) resolves correctly
- [ ] `polymarket buy --market-id btc-5m ...` during trading hours resolves to current slot slug and proceeds to order placement
- [ ] `polymarket buy --market-id eth ...` (no suffix) resolves correctly via alias
- [ ] Outside NYSE hours: `get-series btc-5m` and `buy --market-id btc-5m` both report time until next session
- [ ] At slot boundary (~5min mark): slot transition gap handling routes to next slot if current is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)