### PR TITLE
feat(polymarket): add POLY_PROXY mode, balance/setup-proxy/deposit/withdraw/switch-mode (v0.3.0)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket",
   "description": "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/CHANGELOG.md
+++ b/skills/polymarket-plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Polymarket Plugin Changelog
 
+### v0.3.0 (2026-04-13)
+
+- **feat**: POLY_PROXY trading mode. New `setup-proxy` command deploys a Polymarket proxy wallet (one-time POL gas); subsequent `buy`/`sell` orders are relayer-paid (no POL per trade). `setup-proxy` runs 6 on-chain approvals (USDC.e + CTF for all 3 exchanges) idempotently at setup time — no per-trade approve calls.
+- **feat**: `balance` command shows POL and USDC.e for EOA and proxy wallet (if initialized).
+- **feat**: `deposit` transfers USDC.e from EOA → proxy wallet; `withdraw` transfers back (proxy → EOA).
+- **feat**: `switch-mode --mode eoa|proxy` changes the persistent default trading mode.
+- **feat**: `buy --mode eoa|proxy` and `sell --mode eoa|proxy` override mode for a single order without changing the stored default.
+- **feat**: `get-positions` now auto-queries the proxy wallet in POLY_PROXY mode; displays `pol_balance` and `usdc_e_balance` in EOA mode. Filters out zero-value resolved losing positions (Data API cache persists these after on-chain redeem).
+- **feat**: `positions` alias for `get-positions`.
+- **fix**: `sell` in POLY_PROXY mode no longer fails with "insufficient token balance" — CLOB API `/balance-allowance` returns 0 for proxy wallets regardless of actual balance; pre-flight check now skipped for proxy mode.
+- **fix**: Mode-mismatch error messages: `buy` in EOA mode with no USDC.e hints `polymarket deposit` (proxy mode) or top-up; `sell` in EOA mode with no tokens hints `polymarket switch-mode --mode proxy`.
+- **fix**: RPC updated from `polygon-rpc.com` → `polygon.drpc.org` for improved reliability.
+
 ### v0.2.6 (2026-04-12)
 
 - **fix (critical) [C1]**: `buy` on `neg_risk: true` markets no longer approves the wrong contract. Root cause: `get_gamma_market_by_slug` omits `negRisk` for many markets, causing the field to default to `false` and `approve_usdc` to target `CTF_EXCHANGE` instead of `NEG_RISK_CTF_EXCHANGE`. Fix: `resolve_market_token` now fetches the CLOB market by `condition_id` after the Gamma lookup to get the authoritative `neg_risk`. Falls back to the Gamma value if the CLOB is unreachable. Same fix applied in `redeem`.

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1000,7 +1000,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "polymarket-plugin"
-version = "0.2.6"
+name = "polymarket"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]
-name = "polymarket-plugin"
+name = "polymarket"
 path = "src/main.rs"
 
 [dependencies]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, and redeem winning tokens on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on."
-version: "0.2.6"
+version: "0.3.0"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -11,7 +11,6 @@ tags:
   - defi
   - clob
 ---
-
 
 ## Pre-flight Dependencies (auto-injected by Plugin Store CI)
 
@@ -30,21 +29,11 @@ npx skills add okx/onchainos-skills --yes --global
 npx skills add okx/plugin-store --skill plugin-store --yes --global
 ```
 
-### Install polymarket-plugin binary + update wrapper (auto-injected)
+### Install polymarket binary (auto-injected)
 
 ```bash
-# Install update checker (shared by all plugins, only once)
-CHECKER="$HOME/.plugin-store/update-checker.py"
-if [ ! -f "$CHECKER" ]; then
-  mkdir -p "$HOME/.plugin-store"
-  curl -fsSL "https://raw.githubusercontent.com/okx/plugin-store/main/scripts/update-checker.py" -o "$CHECKER" 2>/dev/null || true
-fi
-
-# Clean up old installation (direct binary without wrapper)
-rm -f "$HOME/.local/bin/polymarket-plugin" "$HOME/.local/bin/.polymarket-plugin-core" 2>/dev/null
-
-# Download binary to hidden name (.polymarket-plugin-core)
-OS=$(uname -s | tr A-Z a-z)
+if ! command -v polymarket >/dev/null 2>&1; then
+  OS=$(uname -s | tr A-Z a-z)
   ARCH=$(uname -m)
   EXT=""
   case "${OS}_${ARCH}" in
@@ -59,56 +48,34 @@ OS=$(uname -s | tr A-Z a-z)
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.2.6/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
-  chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
-
-# Generate wrapper script (version check + exec core binary)
-cat > ~/.local/bin/polymarket-plugin << 'WRAPPER_EOF'
-#!/bin/sh
-PLUGIN_NAME="polymarket-plugin"
-PLUGIN_VERSION="0.2.6"
-CHECKER="$HOME/.plugin-store/update-checker.py"
-CORE="$(dirname "$0")/.polymarket-plugin-core"
-if [ -f "$CHECKER" ]; then
-  if command -v python3 >/dev/null 2>&1; then
-    python3 "$CHECKER" "$PLUGIN_NAME" "$PLUGIN_VERSION"
-  elif command -v python >/dev/null 2>&1; then
-    python "$CHECKER" "$PLUGIN_NAME" "$PLUGIN_VERSION"
-  fi
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket@0.3.0/polymarket-${TARGET}${EXT}" -o ~/.local/bin/polymarket${EXT}
+  chmod +x ~/.local/bin/polymarket${EXT}
 fi
-exec "$CORE" "$@"
-WRAPPER_EOF
-chmod +x ~/.local/bin/polymarket-plugin
 ```
 
 ### Report install (auto-injected, runs once)
 
 ```bash
-REPORT_FLAG="$HOME/.plugin-store/reported/polymarket-plugin"
+REPORT_FLAG="$HOME/.plugin-store/reported/polymarket"
 if [ ! -f "$REPORT_FLAG" ]; then
   mkdir -p "$HOME/.plugin-store/reported"
-  # Device fingerprint → SHA256 → 32-char device ID
   DEV_RAW="$(hostname):$(uname -s):$(uname -m):$HOME"
   DEV_ID=$(echo -n "$DEV_RAW" | shasum -a 256 | head -c 32)
-  # HMAC signature (obfuscated key, same as CLI binary)
   _K=$(echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | base64 -d 2>/dev/null || echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | openssl base64 -d)
   HMAC_SIG=$(echo -n "${_K}${DEV_ID}" | shasum -a 256 | head -c 8)
   DIV_ID="${DEV_ID}${HMAC_SIG}"
   unset _K
-  # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.2.6"}' >/dev/null 2>&1 || true
-  # Report to OKX API (with HMAC-signed device token)
+    -d '{"name":"polymarket","version":"0.3.0"}' >/dev/null 2>&1 || true
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
-    -d '{"pluginName":"polymarket-plugin","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
+    -d '{"pluginName":"polymarket","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
   touch "$REPORT_FLAG"
 fi
 ```
 
 ---
-
 
 ## Pre-flight Dependencies
 
@@ -140,9 +107,12 @@ When a user signals they are **new or just installed** this plugin — e.g. "I j
 
 1. **Check wallet** — run `onchainos wallet addresses --chain 137`. If no address, direct them to connect via `onchainos wallet login`. Also verify `onchainos wallet sign-message --help` works — if missing, run `onchainos upgrade` and re-verify. Do not proceed to trading or suggest workarounds (MetaMask, private key export, manual curl signing) until sign-message is confirmed working.
 2. **Check access** — run `polymarket check-access`. If `accessible: false`, stop and show the warning. Do not proceed to funding.
-3. **Check balance** — run `onchainos wallet balance --chain 137`. Show USDC.e balance. If insufficient, explain bridging options (OKX Web3 bridge or CEX withdrawal to Polygon).
-4. **Find a market** — run `polymarket list-markets` and offer to help them find something interesting. Ask what topics they care about.
-5. **Place a trade** — once they pick a market, guide them through `buy` or `sell` with explicit confirmation of market, outcome, and amount before executing.
+3. **Choose trading mode** — explain the two modes and ask which they prefer:
+   - **EOA mode** (default): trade directly from the onchainos wallet; each buy requires a USDC.e `approve` tx (POL gas, typically < $0.01)
+   - **POLY_PROXY mode** (recommended): deploy a proxy wallet once via `polymarket setup-proxy` (one-time ~$0.01 POL), then trade without any gas. USDC.e must be deposited into the proxy via `polymarket deposit`.
+4. **Check balance** — run `polymarket balance`. Shows POL and USDC.e for both EOA and proxy wallet (if set up). If insufficient, explain bridging options (OKX Web3 bridge or CEX withdrawal to Polygon). Verify the `usdc_e_contract` field matches `0x2791...a84174` before bridging.
+5. **Find a market** — run `polymarket list-markets` and offer to help them find something interesting. Ask what topics they care about.
+6. **Place a trade** — once they pick a market, guide them through `buy` or `sell` with explicit confirmation of market, outcome, and amount before executing.
 
 Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
 
@@ -172,9 +142,11 @@ Polymarket is a prediction market platform on Polygon where users trade outcome 
 
 **Architecture:**
 - Read-only commands (`list-markets`, `get-market`, `get-positions`) — direct REST API calls; no wallet required
-- Write commands (`buy`, `sell`, `cancel`) — EOA mode (signature_type=0): maker = signer = onchainos wallet; EIP-712 signing via `onchainos sign-message --type eip712`; no proxy wallet or polymarket.com onboarding required
-- On-chain approvals — submitted via `onchainos wallet contract-call --chain 137 --force`
-- **Approval model**: `buy` uses exact-amount USDC.e approval (`approve(exchange, order_amount)`) — only the precise order amount is approved, never an unlimited allowance. `sell` uses `setApprovalForAll(exchange, true)` for CTF outcome tokens — blanket ERC-1155 approval (per-token amounts are not supported by the ERC-1155 standard; this is the same model used by Polymarket's web interface).
+- Write commands (`buy`, `sell`, `cancel`) support two trading modes:
+  - **EOA mode** (default, signature_type=0): maker = onchainos wallet; each buy requires a USDC.e `approve` tx costing POL gas
+  - **POLY_PROXY mode** (signature_type=1): maker = proxy wallet deployed via `setup-proxy`; Polymarket's relayer pays gas; no POL needed per trade
+- On-chain ops submitted via `onchainos wallet contract-call --chain 137 --force`
+- **Approval model (EOA)**: `buy` uses exact-amount USDC.e `approve(exchange, amount)`. `sell` uses `setApprovalForAll(exchange, true)` for CTF tokens (blanket ERC-1155 approval; same as Polymarket's web interface). No on-chain approvals needed in POLY_PROXY mode.
 
 **How it works:**
 1. On first trading command, API credentials are auto-derived from the onchainos wallet via Polymarket's CLOB API and cached at `~/.config/polymarket/creds.json`
@@ -219,33 +191,54 @@ polymarket check-access
 - `accessible: true` — you're good to proceed
 - `accessible: false` — your IP is restricted; **do not top up USDC.e** until you have reviewed Polymarket's Terms of Use
 
-### Step 3 — Top up USDC.e on Polygon
+### Step 3 — Choose a trading mode
 
-Polymarket uses **USDC.e** (bridged USDC) on Polygon as collateral. Check your balance:
+There are two modes. Pick one before topping up:
 
+| | **EOA mode** (default) | **POLY_PROXY mode** (recommended) |
+|--|--|--|
+| Maker | onchainos wallet | proxy contract wallet |
+| POL for gas | Required per `buy`/`sell` approve tx | Not needed — relayer pays |
+| Setup | None | One-time `setup-proxy` (costs ~$0.01 POL) |
+| USDC.e lives in | EOA wallet | Proxy wallet (top up via `deposit`) |
+
+**EOA mode** — works out of the box, but every buy needs a USDC.e `approve` on-chain (POL gas).
+
+**POLY_PROXY mode** — one-time setup, then trade without spending POL:
 ```bash
-onchainos wallet balance --chain 137
+polymarket setup-proxy   # deploy proxy wallet (one-time ~$0.01 gas)
+polymarket deposit --amount 50   # fund it with USDC.e
 ```
 
-Look for `USDC.e` (contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`). If your balance is zero or insufficient:
+### Step 4 — Top up USDC.e on Polygon
+
+Check your current balances:
+
+```bash
+polymarket balance
+```
+
+This shows POL and USDC.e for both your EOA wallet and proxy wallet (if set up). The `usdc_e_contract` field shows the truncated contract address — verify it matches `0x2791...a84174` before bridging.
+
+If balance is zero or insufficient:
 
 - **From another chain**: bridge USDC to Polygon via the OKX Web3 bridge or Polygon Bridge
-- **From a CEX**: withdraw USDC to your Polygon address via the Polygon network
-- **Minimum suggested**: $5–$10 to cover a small test trade plus gas (Polygon gas is cheap, typically < $0.01 per tx)
+- **From a CEX**: withdraw USDC to your Polygon address (EOA) via the Polygon network, then run `polymarket deposit` to move it to the proxy wallet if using POLY_PROXY mode
+- **Minimum suggested**: $5–$10 for a small test trade. EOA mode also needs a small amount of POL for gas (typically < $0.01 per approve tx)
 
-> **There is no "Polymarket deposit"**: Polymarket does not have a deposit step. USDC.e lives in your onchainos wallet on Polygon and is spent directly when you buy shares — no transfer to a Polymarket account is required or possible.
+> **There is no "Polymarket deposit"**: Polymarket does not have a deposit step. USDC.e lives in your wallet on Polygon and is spent directly when you buy shares.
 
-### Step 4 — Find a market and place a trade
+### Step 5 — Find a market and place a trade
 
 ```bash
 # Browse active markets
 polymarket list-markets --keyword "trump"
 
 # Get details on a specific market
-polymarket get-market --market-id will-trump-win-2024
+polymarket get-market --market-id <slug>
 
 # Buy $5 of YES shares at market price
-polymarket buy --market-id will-trump-win-2024 --outcome yes --amount 5
+polymarket buy --market-id <slug> --outcome yes --amount 5
 
 # Check your open positions
 polymarket get-positions
@@ -263,7 +256,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket --version
 ```
 
-Expected: `polymarket 0.2.6`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket 0.3.0`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -308,6 +301,23 @@ Confirm the wallet holds sufficient USDC.e (contract `0x2791Bca1f2de4661ED88A30C
 ---
 
 ## Commands
+
+| Command | Auth | Description |
+|---------|------|-------------|
+| `check-access` | No | Verify region is not restricted |
+| `list-markets` | No | Browse active prediction markets |
+| `get-market` | No | Get market details and order book |
+| `get-positions` | No | View open positions |
+| `balance` | No | Show POL and USDC.e balances (EOA + proxy wallet) |
+| `buy` | Yes | Buy YES/NO outcome shares |
+| `sell` | Yes | Sell outcome shares |
+| `cancel` | Yes | Cancel an open order |
+| `redeem` | Yes | Redeem winning tokens after market resolves |
+| `setup-proxy` | Yes | Deploy proxy wallet for gasless trading (one-time) |
+| `deposit` | Yes | Transfer USDC.e from EOA to proxy wallet |
+| `switch-mode` | Yes | Switch default trading mode (eoa / proxy) |
+
+---
 
 ### `check-access` — Verify Region is Not Restricted
 
@@ -382,6 +392,29 @@ polymarket get-market --market-id 0xabc123...
 
 ---
 
+### `balance` — View Wallet Balances
+
+Show POL and USDC.e balances for the EOA wallet and proxy wallet (if initialized).
+
+```
+polymarket balance
+```
+
+**Auth required:** No (reads on-chain via Polygon RPC)
+
+**Output fields:**
+- `eoa_wallet`: `address`, `pol`, `usdc_e`, `usdc_e_contract`
+- `proxy_wallet` (only shown if proxy wallet is initialized): `address`, `pol`, `usdc_e`, `usdc_e_contract`
+
+`usdc_e_contract` is shown in truncated format (`0x2791...a84174`) — verify it matches before bridging funds.
+
+**Example:**
+```bash
+polymarket balance
+```
+
+---
+
 ### `get-positions` — View Open Positions
 
 ```
@@ -391,11 +424,15 @@ polymarket get-positions [--address <wallet_address>]
 **Flags:**
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--address` | Wallet address to query | Active onchainos wallet |
+| `--address` | Wallet address to query | Active onchainos wallet (or proxy wallet if POLY_PROXY mode) |
 
 **Auth required:** No (uses public Data API)
 
-**Output fields:** `title`, `outcome`, `size` (shares), `avg_price`, `cur_price`, `current_value`, `cash_pnl`, `percent_pnl`, `realized_pnl`, `redeemable`, `end_date`
+**Default behavior (no `--address`):**
+- POLY_PROXY mode → queries proxy wallet
+- EOA mode → queries EOA wallet + shows `pol_balance` and `usdc_e_balance`
+
+**Output fields:** `title`, `outcome`, `size` (shares), `avg_price`, `initial_value`, `total_bought`, `cur_price`, `current_value`, `cash_pnl`, `percent_pnl`, `realized_pnl`, `percent_realized_pnl`, `redeemable`, `redeemable_note`, `mergeable`, `opposite_outcome`, `opposite_asset`, `event_id`, `event_slug`, `end_date`
 
 **Example:**
 ```
@@ -426,11 +463,12 @@ polymarket buy --market-id <id> --outcome <outcome> --amount <usdc> [--price <0-
 | `--round-up` | If amount is too small for divisibility constraints, snap up to the minimum valid amount rather than erroring. Logs the rounded amount to stderr and includes `rounded_up: true` in output. | false |
 | `--post-only` | Maker-only: reject if the order would immediately cross the spread (become a taker). Requires `--order-type GTC`. Qualifies for Polymarket maker rebates (up to 50% of fees returned daily). Incompatible with `--order-type FOK`. | false |
 | `--expires` | Unix timestamp (seconds, UTC) at which the order auto-cancels. Minimum 90 seconds in the future (CLOB enforces a "now + 1 min 30 s" security threshold). Automatically sets `order_type` to `GTD` (Good Till Date) — do not also pass `--order-type GTC`. Example: `--expires $(date -d '+1 hour' +%s)` | — |
+| `--mode` | Override trading mode for this order only: `eoa` or `proxy`. Does not change the stored default. | — |
 | `--confirm` | Confirm a previously gated action (reserved for future use) | false |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
-**On-chain ops:** If USDC.e allowance is insufficient, runs `onchainos wallet contract-call --chain 137 --to <USDC.e> --input-data <approve_calldata> --force` automatically.
+**On-chain ops (EOA mode only):** If USDC.e allowance is insufficient, runs `onchainos wallet contract-call` automatically. In POLY_PROXY mode, no on-chain approve is needed — the relayer handles settlement.
 
 > ⚠️ **Approval notice**: Before each buy, the plugin checks the current USDC.e allowance and, if insufficient, submits an `approve(exchange, amount)` transaction for **exactly the order amount** — no more. This fires automatically with no additional onchainos confirmation gate. **Agent confirmation before calling `buy` is the sole safety gate for this approval.**
 
@@ -483,11 +521,12 @@ polymarket sell --market-id <id> --outcome <outcome> --shares <amount> [--price 
 | `--post-only` | Maker-only: reject if the order would immediately cross the spread. Requires `--order-type GTC`. Qualifies for maker rebates. Incompatible with `--order-type FOK`. | false |
 | `--expires` | Unix timestamp (seconds, UTC) at which the order auto-cancels. Minimum 90 seconds in the future. Auto-sets `order_type` to `GTD`. | — |
 | `--dry-run` | Simulate without submitting the order or triggering any on-chain approval. Prints a confirmation JSON and exits. Use to verify parameters before a real sell. | false |
+| `--mode` | Override trading mode for this order only: `eoa` or `proxy`. Does not change the stored default. | — |
 | `--confirm` | Confirm a low-price market sell that was previously gated | false |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
-**On-chain ops:** If CTF token allowance is insufficient, runs `onchainos wallet contract-call --chain 137 --to <CTF> --input-data <setApprovalForAll_calldata> --force` automatically.
+**On-chain ops (EOA mode only):** If CTF token allowance is insufficient, submits `setApprovalForAll` automatically. In POLY_PROXY mode, no on-chain approval is needed.
 
 > ⚠️ **setApprovalForAll notice**: The CTF token approval calls `setApprovalForAll(exchange, true)` — this grants the exchange contract blanket approval over **all** ERC-1155 outcome tokens in the wallet, not just the tokens being sold. This is the standard ERC-1155 approval model (per-token amounts are not supported by the standard) and is the same mechanism used by Polymarket's own web interface. Always confirm the user understands this before their first sell.
 
@@ -617,6 +656,124 @@ polymarket redeem --market-id will-trump-win-2024 --dry-run
 # After user confirms:
 polymarket redeem --market-id will-trump-win-2024
 ```
+
+---
+
+### `setup-proxy` — Create a Proxy Wallet (Gasless Trading)
+
+Deploy a Polymarket proxy wallet and switch to POLY_PROXY mode. One-time POL gas cost; all subsequent trading is relayer-paid (no POL needed per order).
+
+```
+polymarket setup-proxy [--dry-run]
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview the action without submitting any transaction |
+
+**Auth required:** Yes — onchainos wallet
+
+**Flow:**
+1. If proxy wallet already exists and mode is already POLY_PROXY → returns current config
+2. If proxy wallet exists but mode is EOA → switches mode to POLY_PROXY (no gas cost)
+3. If no proxy wallet → calls `PROXY_FACTORY.proxy([])` on-chain (one POL gas tx) → resolves proxy address from the transaction trace → saves proxy wallet + mode to creds
+
+**Output fields:** `status` (already_configured | mode_switched | created), `proxy_wallet`, `mode`, `deploy_tx` (if new proxy was created)
+
+**Agent flow:**
+1. Run `polymarket setup-proxy --dry-run` to preview
+2. After user confirms, run `polymarket setup-proxy`
+3. Follow up with `polymarket deposit --amount <N>` to fund the proxy wallet
+
+**Example:**
+```bash
+polymarket setup-proxy --dry-run
+polymarket setup-proxy
+```
+
+---
+
+### `deposit` — Fund the Proxy Wallet
+
+Transfer USDC.e from the EOA wallet to the proxy wallet. Only applicable in POLY_PROXY mode. Requires `setup-proxy` to have been run first.
+
+```
+polymarket deposit --amount <usdc> [--dry-run]
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--amount` | USDC.e amount to transfer, e.g. `50` = $50.00 | required |
+| `--dry-run` | Preview the transfer without submitting |
+
+**Auth required:** Yes — onchainos wallet (signs the on-chain ERC-20 transfer)
+
+**Output fields:** `tx_hash`, `from` (EOA), `to` (proxy wallet), `token`, `amount`
+
+**Example:**
+```bash
+polymarket deposit --amount 100 --dry-run
+polymarket deposit --amount 100
+```
+
+---
+
+### `withdraw` — Withdraw from Proxy Wallet
+
+Transfer USDC.e from the proxy wallet back to the EOA wallet. Only applicable in POLY_PROXY mode.
+
+```
+polymarket withdraw --amount <usdc> [--dry-run]
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--amount` | USDC.e amount to withdraw, e.g. `50` = $50.00 | required |
+| `--dry-run` | Preview the withdrawal without submitting |
+
+**Auth required:** Yes — onchainos wallet (signs via proxy factory)
+
+**Output fields:** `tx_hash`, `from` (proxy wallet), `to` (EOA), `token`, `amount`
+
+**Example:**
+```bash
+polymarket withdraw --amount 50 --dry-run
+polymarket withdraw --amount 50
+```
+
+---
+
+### `switch-mode` — Change Default Trading Mode
+
+Permanently change the stored default trading mode between EOA and POLY_PROXY.
+
+```
+polymarket switch-mode --mode <eoa|proxy>
+```
+
+**Flags:**
+| Flag | Description |
+|------|-------------|
+| `--mode` | Trading mode: `eoa` or `proxy` | required |
+
+**Auth required:** Yes (reads stored credentials)
+
+**Modes:**
+- **EOA** — maker = onchainos wallet; each buy requires a USDC.e `approve` tx (POL gas)
+- **POLY_PROXY** — maker = proxy wallet; Polymarket's relayer pays gas; no POL needed per trade
+
+**Output fields:** `mode`, `description`, `proxy_wallet`
+
+**Example:**
+```bash
+polymarket switch-mode --mode proxy
+polymarket switch-mode --mode eoa
+```
+
+> **Note:** `--mode eoa|proxy` on `buy`/`sell` is a one-time override for a single order. `switch-mode` changes the persistent default.
 
 ---
 
@@ -785,4 +942,3 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.2.6** (2026-04-12).
-

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
-name: polymarket-plugin
-version: "0.2.6"
+name: polymarket
+version: "0.3.0"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky
@@ -21,9 +21,11 @@ components:
 
 build:
   lang: rust
-  binary_name: polymarket-plugin
+  binary_name: polymarket
 
 api_calls:
   - "https://clob.polymarket.com"
   - "https://gamma-api.polymarket.com"
   - "https://data-api.polymarket.com"
+  - "polygon.drpc.org"
+  - "polygon-bor-rpc.publicnode.com"

--- a/skills/polymarket-plugin/src/api.rs
+++ b/skills/polymarket-plugin/src/api.rs
@@ -178,23 +178,40 @@ pub struct Position {
     pub size: Option<f64>,
     #[serde(rename = "avgPrice")]
     pub avg_price: Option<f64>,
+    #[serde(rename = "initialValue")]
+    pub initial_value: Option<f64>,
     #[serde(rename = "currentValue")]
     pub current_value: Option<f64>,
     #[serde(rename = "cashPnl")]
     pub cash_pnl: Option<f64>,
     #[serde(rename = "percentPnl")]
     pub percent_pnl: Option<f64>,
+    #[serde(rename = "totalBought")]
+    pub total_bought: Option<f64>,
     #[serde(rename = "realizedPnl")]
     pub realized_pnl: Option<f64>,
+    #[serde(rename = "percentRealizedPnl")]
+    pub percent_realized_pnl: Option<f64>,
     #[serde(rename = "curPrice")]
     pub cur_price: Option<f64>,
     #[serde(default)]
     pub redeemable: bool,
+    #[serde(default)]
+    pub mergeable: bool,
     pub title: Option<String>,
     pub slug: Option<String>,
+    pub icon: Option<String>,
+    #[serde(rename = "eventId")]
+    pub event_id: Option<String>,
+    #[serde(rename = "eventSlug")]
+    pub event_slug: Option<String>,
     pub outcome: Option<String>,
     #[serde(rename = "outcomeIndex")]
     pub outcome_index: Option<u32>,
+    #[serde(rename = "oppositeOutcome")]
+    pub opposite_outcome: Option<String>,
+    #[serde(rename = "oppositeAsset")]
+    pub opposite_asset: Option<String>,
     #[serde(rename = "endDate")]
     pub end_date: Option<String>,
     #[serde(rename = "negativeRisk", default)]

--- a/skills/polymarket-plugin/src/auth.rs
+++ b/skills/polymarket-plugin/src/auth.rs
@@ -160,6 +160,7 @@ pub async fn create_api_key(client: &Client, wallet_addr: &str, nonce: u64) -> R
         nonce,
         signing_address: wallet_addr.to_string(),
         proxy_wallet: api_key_resp.proxy_wallet,
+        mode: crate::config::TradingMode::default(),
     };
     save_credentials(&creds)?;
     Ok(creds)
@@ -190,6 +191,7 @@ pub async fn derive_api_key(client: &Client, wallet_addr: &str, nonce: u64) -> R
         nonce,
         signing_address: wallet_addr.to_string(),
         proxy_wallet: api_key_resp.proxy_wallet,
+        mode: crate::config::TradingMode::default(),
     };
     save_credentials(&creds)?;
     Ok(creds)
@@ -197,7 +199,13 @@ pub async fn derive_api_key(client: &Client, wallet_addr: &str, nonce: u64) -> R
 
 /// Load stored credentials or auto-derive them using the onchainos wallet.
 /// Re-derives if the cached credentials were for a different wallet address.
+///
+/// On first use (no creds stored), auto-detects trading mode:
+///   - If Polymarket returns a proxy wallet address → mode = PolyProxy
+///   - Otherwise → mode = EOA, with a hint to run `polymarket setup-proxy`
 pub async fn ensure_credentials(client: &Client, wallet_addr: &str) -> Result<Credentials> {
+    use crate::config::TradingMode;
+
     // Check environment variables first
     let env_key = std::env::var("POLYMARKET_API_KEY").unwrap_or_default();
     let env_secret = std::env::var("POLYMARKET_SECRET").unwrap_or_default();
@@ -211,6 +219,7 @@ pub async fn ensure_credentials(client: &Client, wallet_addr: &str) -> Result<Cr
             nonce: 0,
             signing_address: wallet_addr.to_string(),
             proxy_wallet: None,
+            mode: TradingMode::Eoa,
         });
     }
 
@@ -224,8 +233,33 @@ pub async fn ensure_credentials(client: &Client, wallet_addr: &str) -> Result<Cr
 
     // Auto-derive via onchainos wallet EIP-712 signing
     eprintln!("[polymarket] Deriving API credentials for wallet {}...", wallet_addr);
-    match derive_api_key(client, wallet_addr, 0).await {
-        Ok(c) => Ok(c),
-        Err(_) => create_api_key(client, wallet_addr, 0).await,
+    let mut creds = match derive_api_key(client, wallet_addr, 0).await {
+        Ok(c) => c,
+        Err(_) => create_api_key(client, wallet_addr, 0).await?,
+    };
+
+    // Auto-detect trading mode based on whether a proxy wallet exists.
+    // The API key response already includes proxyWallet if set; fall back to /profile.
+    if creds.proxy_wallet.is_none() {
+        if let Ok(Some(proxy)) = crate::api::get_proxy_wallet(client, wallet_addr).await {
+            creds.proxy_wallet = Some(proxy);
+        }
     }
+
+    creds.mode = if creds.proxy_wallet.is_some() {
+        eprintln!(
+            "[polymarket] Proxy wallet detected: {}. Using POLY_PROXY mode (no POL needed for trading).",
+            creds.proxy_wallet.as_deref().unwrap_or("")
+        );
+        TradingMode::PolyProxy
+    } else {
+        eprintln!(
+            "[polymarket] No proxy wallet found. Using EOA mode (requires POL for gas).\n\
+             Tip: run `polymarket setup-proxy` to create a proxy wallet and switch to gasless trading."
+        );
+        TradingMode::Eoa
+    };
+
+    crate::config::save_credentials(&creds)?;
+    Ok(creds)
 }

--- a/skills/polymarket-plugin/src/commands/balance.rs
+++ b/skills/polymarket-plugin/src/commands/balance.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use crate::onchainos::{get_pol_balance, get_usdc_balance, get_wallet_address};
+
+/// Truncate a contract address to "0xABCD...xyz789" format (first 4 + last 6 hex chars).
+fn short_addr(addr: &str) -> String {
+    let hex = addr.trim_start_matches("0x");
+    if hex.len() <= 10 {
+        return addr.to_string();
+    }
+    format!("0x{}...{}", &hex[..4], &hex[hex.len() - 6..])
+}
+
+pub async fn run() -> Result<()> {
+    let eoa = get_wallet_address().await?;
+    let proxy = crate::config::load_credentials()
+        .ok()
+        .flatten()
+        .and_then(|c| c.proxy_wallet);
+
+    let usdc_e_contract = crate::config::Contracts::USDC_E;
+    let usdc_e_short = short_addr(usdc_e_contract);
+
+    // Fetch EOA balances (POL + USDC.e) in parallel
+    let (pol_result, usdc_result) = tokio::join!(
+        get_pol_balance(&eoa),
+        get_usdc_balance(&eoa),
+    );
+
+    let eoa_pol = match pol_result {
+        Ok(v)  => format!("{:.4} POL", v),
+        Err(e) => format!("error: {}", e),
+    };
+    let eoa_usdc = match usdc_result {
+        Ok(v)  => format!("${:.2}", v),
+        Err(e) => format!("error: {}", e),
+    };
+
+    let mut data = serde_json::json!({
+        "eoa_wallet": {
+            "address": eoa,
+            "pol": eoa_pol,
+            "usdc_e": eoa_usdc,
+            "usdc_e_contract": usdc_e_short,
+        }
+    });
+
+    // If proxy wallet is initialized, fetch its balances too
+    if let Some(ref proxy_addr) = proxy {
+        let (proxy_pol_result, proxy_usdc_result) = tokio::join!(
+            get_pol_balance(proxy_addr),
+            get_usdc_balance(proxy_addr),
+        );
+        let proxy_pol = match proxy_pol_result {
+            Ok(v)  => format!("{:.4} POL", v),
+            Err(e) => format!("error: {}", e),
+        };
+        let proxy_usdc = match proxy_usdc_result {
+            Ok(v)  => format!("${:.2}", v),
+            Err(e) => format!("error: {}", e),
+        };
+        data["proxy_wallet"] = serde_json::json!({
+            "address": proxy_addr,
+            "pol": proxy_pol,
+            "usdc_e": proxy_usdc,
+            "usdc_e_contract": usdc_e_short,
+        });
+    }
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "data": data,
+    }))?);
+    Ok(())
+}

--- a/skills/polymarket-plugin/src/commands/buy.rs
+++ b/skills/polymarket-plugin/src/commands/buy.rs
@@ -7,10 +7,13 @@ use crate::api::{
     OrderBody, OrderRequest,
 };
 use crate::auth::ensure_credentials;
-use crate::onchainos::{approve_usdc, get_wallet_address};
+use crate::onchainos::{approve_usdc, get_usdc_balance, get_wallet_address};
 use crate::signing::{sign_order_via_onchainos, OrderParams};
 
 /// Run the buy command.
+///
+/// mode_override: optional one-time mode override ("eoa" or "proxy").
+///   Does not persist — use `switch-mode` to change the default.
 pub async fn run(
     market_id: &str,
     outcome: &str,
@@ -22,6 +25,7 @@ pub async fn run(
     round_up: bool,
     post_only: bool,
     expires: Option<u64>,
+    mode_override: Option<&str>,
 ) -> Result<()> {
     // Parse USDC amount early so we can enforce the minimum order size
     // check even on dry-run (the agent needs to know before placing).
@@ -199,48 +203,111 @@ pub async fn run(
 
     // ── Auth phase ────────────────────────────────────────────────────────────
 
-    // onchainos wallet is the signer.
+    use crate::config::{Contracts, TradingMode};
+
+    // onchainos wallet is always the signer.
     let signer_addr = get_wallet_address().await?;
     let creds = ensure_credentials(&client, &signer_addr).await?;
-    let maker_addr = signer_addr.clone();
 
-    // Check USDC balance and allowance.
-    // Balance check fires BEFORE the approval tx to avoid wasting gas on orders
-    // that would be rejected for insufficient funds.
-    use crate::config::Contracts;
-    let allowance_info =
-        get_balance_allowance(&client, &signer_addr, &creds, "COLLATERAL", None).await?;
+    // Resolve effective trading mode (one-time override > stored default).
+    let effective_mode = match mode_override {
+        Some("proxy") => TradingMode::PolyProxy,
+        Some("eoa")   => TradingMode::Eoa,
+        _             => creds.mode.clone(),
+    };
+
+    // Resolve maker address and signature type based on mode.
+    let (maker_addr, sig_type) = match &effective_mode {
+        TradingMode::PolyProxy => {
+            let proxy = creds.proxy_wallet.as_ref().ok_or_else(|| anyhow::anyhow!(
+                "POLY_PROXY mode requires a proxy wallet. \
+                 Run `polymarket setup-proxy` to create one first."
+            ))?.clone();
+            eprintln!("[polymarket] Using POLY_PROXY mode — maker: {}", proxy);
+            (proxy, 1u8)
+        }
+        TradingMode::Eoa => (signer_addr.clone(), 0u8),
+    };
 
     let usdc_needed_raw = maker_amount_raw as u64;
 
-    // Pre-flight: bail if wallet USDC.e balance is insufficient.
-    if let Some(bal_str) = &allowance_info.balance {
-        if let Ok(bal) = bal_str.parse::<u64>() {
-            if bal < usdc_needed_raw {
+    // Determine which address holds the USDC.e for this order.
+    let balance_addr = match &effective_mode {
+        TradingMode::PolyProxy => maker_addr.as_str(),
+        TradingMode::Eoa       => signer_addr.as_str(),
+    };
+
+    // Fetch on-chain USDC.e balance and CLOB allowance info in parallel.
+    // Balance uses direct eth_call (authoritative); allowance uses CLOB API.
+    let (onchain_balance_result, allowance_info) = tokio::join!(
+        get_usdc_balance(balance_addr),
+        get_balance_allowance(&client, balance_addr, &creds, "COLLATERAL", None),
+    );
+    let allowance_info = allowance_info?;
+
+    // Pre-flight: bail if on-chain USDC.e balance is insufficient.
+    match onchain_balance_result {
+        Ok(bal_usdc) => {
+            let bal_raw = (bal_usdc * 1_000_000.0).floor() as u64;
+            if bal_raw < usdc_needed_raw {
+                let tip = match &effective_mode {
+                    TradingMode::PolyProxy => format!(
+                        "Run `polymarket deposit --amount {:.2}` to top up the proxy wallet.",
+                        actual_usdc
+                    ),
+                    TradingMode::Eoa => {
+                        // Check if proxy wallet has enough USDC and hint mode switch.
+                        let proxy_hint = crate::config::load_credentials()
+                            .ok()
+                            .flatten()
+                            .and_then(|c| c.proxy_wallet)
+                            .map(|proxy| format!(
+                                " Or switch to proxy mode (`polymarket switch-mode --mode proxy`) \
+                                 if your USDC.e is already in the proxy wallet ({}).",
+                                proxy
+                            ))
+                            .unwrap_or_default();
+                        format!(
+                            "Top up USDC.e on Polygon before placing this order.{}",
+                            proxy_hint
+                        )
+                    }
+                };
                 bail!(
-                    "Insufficient USDC.e balance: have ${:.6}, need ${:.6}. \
-                     Top up USDC.e on Polygon before placing this order.",
-                    bal as f64 / 1_000_000.0,
-                    actual_usdc
+                    "Insufficient USDC.e balance: have ${:.2}, need ${:.2}. {}",
+                    bal_usdc, actual_usdc, tip
                 );
             }
         }
+        Err(e) => {
+            // On-chain read failed — log and fall through (CLOB will catch it at settlement).
+            eprintln!("[polymarket] Warning: could not verify on-chain USDC.e balance ({}); proceeding.", e);
+        }
     }
 
-    let allowance_raw = if neg_risk {
-        let a_exchange = allowance_info.allowance_for(Contracts::NEG_RISK_CTF_EXCHANGE);
-        let a_adapter  = allowance_info.allowance_for(Contracts::NEG_RISK_ADAPTER);
-        a_exchange.min(a_adapter)
-    } else {
-        allowance_info.allowance_for(Contracts::CTF_EXCHANGE)
-    };
+    // EOA mode: submit on-chain approve if allowance is insufficient.
+    // POLY_PROXY mode: approvals are set once during `setup-proxy` — no per-trade approve needed.
+    if effective_mode == TradingMode::Eoa {
+        let allowance_raw = if neg_risk {
+            let a_exchange = allowance_info.allowance_for(Contracts::NEG_RISK_CTF_EXCHANGE);
+            let a_adapter  = allowance_info.allowance_for(Contracts::NEG_RISK_ADAPTER);
+            a_exchange.min(a_adapter)
+        } else {
+            allowance_info.allowance_for(Contracts::CTF_EXCHANGE)
+        };
 
-    if allowance_raw < usdc_needed_raw || auto_approve {
-        let exchange_label = if neg_risk { "Neg Risk CTF Exchange" } else { "CTF Exchange" };
-        eprintln!("[polymarket] Approving {:.6} USDC.e for {}...", actual_usdc, exchange_label);
-        let tx_hash = approve_usdc(neg_risk, usdc_needed_raw).await?;
-        eprintln!("[polymarket] Approval tx: {}", tx_hash);
+        if allowance_raw < usdc_needed_raw || auto_approve {
+            let exchange_label = if neg_risk { "Neg Risk CTF Exchange" } else { "CTF Exchange" };
+            eprintln!("[polymarket] Approving {:.6} USDC.e for {}...", actual_usdc, exchange_label);
+            let tx_hash = approve_usdc(neg_risk, usdc_needed_raw).await?;
+            eprintln!("[polymarket] Approval tx: {}", tx_hash);
+            eprintln!("[polymarket] Waiting for approval to confirm on-chain...");
+            crate::onchainos::wait_for_tx_receipt(&tx_hash, 30).await?;
+            eprintln!("[polymarket] Approval confirmed.");
+        }
     }
+    // POLY_PROXY mode: approvals are set once during `setup-proxy` and verified on-chain there.
+    // The CLOB server checks allowance independently at order submission — no pre-flight needed.
 
     let salt = rand_salt();
 
@@ -256,7 +323,7 @@ pub async fn run(
         nonce: 0,
         fee_rate_bps,
         side: 0, // BUY
-        signature_type: 0, // EOA
+        signature_type: sig_type,
     };
 
     let signature = sign_order_via_onchainos(&params, neg_risk).await?;
@@ -273,7 +340,7 @@ pub async fn run(
         nonce: "0".to_string(),
         fee_rate_bps: fee_rate_bps.to_string(),
         side: "BUY".to_string(),
-        signature_type: 0,
+        signature_type: sig_type,
         signature,
     };
 
@@ -284,6 +351,9 @@ pub async fn run(
         post_only,
     };
 
+    // The order owner for L2 auth must always be the EOA (API key holder),
+    // regardless of trading mode. In POLY_PROXY mode the maker field in the
+    // order struct is the proxy, but the HTTP owner must match the API key.
     let resp = post_order(&client, &signer_addr, &creds, &order_req).await?;
 
     if resp.success != Some(true) {

--- a/skills/polymarket-plugin/src/commands/deposit.rs
+++ b/skills/polymarket-plugin/src/commands/deposit.rs
@@ -1,0 +1,68 @@
+/// `polymarket deposit` — transfer USDC.e to the proxy wallet.
+///
+/// Only applicable in POLY_PROXY mode. Sends an ERC-20 transfer from the
+/// onchainos wallet to the proxy wallet address.
+///
+/// Prerequisites:
+///   - `polymarket setup-proxy` must have been run first
+///   - EOA wallet must hold enough USDC.e on Polygon (chain 137)
+
+use anyhow::{bail, Result};
+use reqwest::Client;
+
+pub async fn run(amount: &str, dry_run: bool) -> Result<()> {
+    let client = Client::new();
+
+    let signer_addr = crate::onchainos::get_wallet_address().await?;
+    let creds = crate::auth::ensure_credentials(&client, &signer_addr).await?;
+
+    let proxy_wallet = creds.proxy_wallet.as_ref().ok_or_else(|| anyhow::anyhow!(
+        "No proxy wallet configured. Run `polymarket setup-proxy` first."
+    ))?;
+
+    // Parse amount (human-readable USDC.e, 6 decimals).
+    let amount_f: f64 = amount.parse()
+        .map_err(|_| anyhow::anyhow!("invalid amount: {}", amount))?;
+    if amount_f <= 0.0 {
+        bail!("amount must be positive");
+    }
+    let amount_raw = (amount_f * 1_000_000.0).round() as u128;
+
+    if dry_run {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "dry_run": true,
+                "data": {
+                    "from": signer_addr,
+                    "to": proxy_wallet,
+                    "token": "USDC.e",
+                    "amount": amount_f,
+                    "amount_raw": amount_raw,
+                    "note": "dry-run: no transaction submitted"
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    eprintln!("[polymarket] Transferring {} USDC.e to proxy wallet {}...", amount_f, proxy_wallet);
+    let tx_hash = crate::onchainos::transfer_usdc_to_proxy(proxy_wallet, amount_raw).await?;
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "ok": true,
+            "data": {
+                "tx_hash": tx_hash,
+                "from": signer_addr,
+                "to": proxy_wallet,
+                "token": "USDC.e",
+                "amount": amount_f,
+                "note": "USDC.e deposited to proxy wallet. Ready to trade in POLY_PROXY mode."
+            }
+        })
+    );
+    Ok(())
+}

--- a/skills/polymarket-plugin/src/commands/get_positions.rs
+++ b/skills/polymarket-plugin/src/commands/get_positions.rs
@@ -2,24 +2,50 @@ use anyhow::Result;
 use reqwest::Client;
 
 use crate::api::get_positions;
-use crate::onchainos::get_wallet_address;
+use crate::onchainos::{get_pol_balance, get_usdc_balance, get_wallet_address};
 
 pub async fn run(address: Option<&str>) -> Result<()> {
     let client = Client::new();
 
-    let wallet_addr = match address {
-        Some(a) => a.to_string(),
-        None => get_wallet_address().await?,
+    // Determine which wallet to query and whether to show EOA balances.
+    //
+    // Rules (when no --address override):
+    //   - proxy wallet exists in creds → query proxy wallet (no balance info needed;
+    //     proxy holds CTF tokens and USDC.e managed by the relayer)
+    //   - no proxy wallet → query EOA + show POL and USDC.e balances
+    //
+    // If --address is explicitly provided, use it as-is without balance augmentation.
+    let (wallet_addr, show_eoa_balances) = if let Some(a) = address {
+        (a.to_string(), false)
+    } else {
+        let eoa = get_wallet_address().await?;
+        let creds = crate::config::load_credentials().ok().flatten();
+        let use_proxy = creds.as_ref().and_then(|c| {
+            if c.mode == crate::config::TradingMode::PolyProxy {
+                c.proxy_wallet.clone()
+            } else {
+                None
+            }
+        });
+        match use_proxy {
+            Some(p) => (p, false),
+            None    => (eoa, true),
+        }
     };
 
     let positions = get_positions(&client, &wallet_addr).await?;
 
     let output: Vec<serde_json::Value> = positions
         .iter()
+        // Filter out resolved losing positions: redeemable but worth $0.
+        // The Data API does not clear these after on-chain redeem — they persist indefinitely
+        // as noise. Winning redeemable positions (current_value > 0) are always kept.
+        .filter(|p| {
+            let is_zero_value_resolved = p.redeemable
+                && p.current_value.unwrap_or(0.0) < 0.000_001;
+            !is_zero_value_resolved
+        })
         .map(|p| {
-            // Annotate redeemable positions so agents can distinguish winning from losing.
-            // redeemable: true with current_value ≈ 0 means the market resolved against
-            // this outcome — redeeming would cost gas and receive nothing.
             let redeemable_value = p.current_value.unwrap_or(0.0);
             let redeemable_note = if p.redeemable && redeemable_value < 0.000_001 {
                 Some("resolved — losing outcome, redemption would receive $0")
@@ -31,33 +57,85 @@ pub async fn run(address: Option<&str>) -> Result<()> {
             serde_json::json!({
                 "title": p.title,
                 "slug": p.slug,
+                "icon": p.icon,
+                "event_id": p.event_id,
+                "event_slug": p.event_slug,
                 "outcome": p.outcome,
                 "outcome_index": p.outcome_index,
+                "opposite_outcome": p.opposite_outcome,
+                "opposite_asset": p.opposite_asset,
                 "condition_id": p.condition_id,
                 "token_id": p.asset,
                 "size": p.size,
                 "avg_price": p.avg_price,
+                "initial_value": p.initial_value,
+                "total_bought": p.total_bought,
                 "cur_price": p.cur_price,
                 "current_value": p.current_value,
                 "cash_pnl": p.cash_pnl,
                 "percent_pnl": p.percent_pnl,
                 "realized_pnl": p.realized_pnl,
+                "percent_realized_pnl": p.percent_realized_pnl,
                 "redeemable": p.redeemable,
                 "redeemable_note": redeemable_note,
+                "mergeable": p.mergeable,
                 "end_date": p.end_date,
                 "negative_risk": p.negative_risk,
             })
         })
         .collect();
 
-    let result = serde_json::json!({
-        "ok": true,
-        "data": {
+    let data = if show_eoa_balances {
+        // Fetch POL and USDC.e balances in parallel
+        let (pol_result, usdc_result) = tokio::join!(
+            get_pol_balance(&wallet_addr),
+            get_usdc_balance(&wallet_addr),
+        );
+        let pol_balance = match pol_result {
+            Ok(v)  => format!("{:.4} POL", v),
+            Err(e) => format!("error: {}", e),
+        };
+        let usdc_balance = match usdc_result {
+            Ok(v)  => format!("${:.2}", v),
+            Err(e) => format!("error: {}", e),
+        };
+        serde_json::json!({
+            "wallet": wallet_addr,
+            "mode": "eoa",
+            "pol_balance": pol_balance,
+            "usdc_e_balance": usdc_balance,
+            "position_count": output.len(),
+            "positions": output,
+        })
+    } else {
+        // In POLY_PROXY mode: add a note if there are no positions but proxy has USDC.e
+        // (helps users who placed orders in EOA mode by accident).
+        let creds = crate::config::load_credentials().ok().flatten();
+        let mode_note: Option<&str> = match creds.as_ref().map(|c| &c.mode) {
+            Some(crate::config::TradingMode::PolyProxy) => None,
+            Some(crate::config::TradingMode::Eoa) if output.is_empty() => {
+                let has_proxy = creds.as_ref().and_then(|c| c.proxy_wallet.as_ref()).is_some();
+                if has_proxy {
+                    Some("Currently in EOA mode. If you placed orders in POLY_PROXY mode, \
+                          switch with `polymarket switch-mode --mode proxy` to see those positions.")
+                } else { None }
+            }
+            _ => None,
+        };
+        let mut obj = serde_json::json!({
             "wallet": wallet_addr,
             "position_count": output.len(),
             "positions": output,
+        });
+        if let Some(note) = mode_note {
+            obj["note"] = serde_json::Value::String(note.to_string());
         }
-    });
-    println!("{}", serde_json::to_string_pretty(&result)?);
+        obj
+    };
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "data": data,
+    }))?);
     Ok(())
 }

--- a/skills/polymarket-plugin/src/commands/mod.rs
+++ b/skills/polymarket-plugin/src/commands/mod.rs
@@ -1,8 +1,13 @@
+pub mod balance;
 pub mod buy;
+pub mod withdraw;
 pub mod cancel;
 pub mod check_access;
+pub mod deposit;
 pub mod get_market;
 pub mod get_positions;
 pub mod list_markets;
 pub mod redeem;
 pub mod sell;
+pub mod setup_proxy;
+pub mod switch_mode;

--- a/skills/polymarket-plugin/src/commands/sell.rs
+++ b/skills/polymarket-plugin/src/commands/sell.rs
@@ -18,6 +18,7 @@ use super::buy::resolve_market_token;
 /// outcome: outcome label, case-insensitive (e.g. "yes", "no", "trump")
 /// shares: number of token shares to sell (human-readable)
 /// price: limit price in [0, 1], or None for market order (FOK)
+/// mode_override: optional one-time mode override ("eoa" or "proxy").
 pub async fn run(
     market_id: &str,
     outcome: &str,
@@ -28,6 +29,7 @@ pub async fn run(
     dry_run: bool,
     post_only: bool,
     expires: Option<u64>,
+    mode_override: Option<&str>,
 ) -> Result<()> {
     // Parse shares and validate order flags up front (before any network calls).
     let share_amount: f64 = shares.parse().context("invalid shares amount")?;
@@ -169,23 +171,58 @@ pub async fn run(
 
     // ── Auth phase ────────────────────────────────────────────────────────────
 
+    use crate::config::{Contracts, TradingMode};
+
     let signer_addr = get_wallet_address().await?;
     let creds = ensure_credentials(&client, &signer_addr).await?;
-    let maker_addr = signer_addr.clone();
 
-    // Check CTF token balance.
-    let token_balance = get_balance_allowance(&client, &signer_addr, &creds, "CONDITIONAL", Some(&token_id)).await?;
-    let balance_raw = token_balance.balance.as_deref().unwrap_or("0").parse::<u64>().unwrap_or(0);
-    let shares_needed_raw = to_token_units(share_amount);
+    // Resolve effective trading mode.
+    let effective_mode = match mode_override {
+        Some("proxy") => TradingMode::PolyProxy,
+        Some("eoa")   => TradingMode::Eoa,
+        _             => creds.mode.clone(),
+    };
 
-    if balance_raw < shares_needed_raw {
-        bail!(
-            "Insufficient token balance: have {} raw units ({:.6} shares), need {} raw units ({:.6} shares)",
-            balance_raw,
-            balance_raw as f64 / 1_000_000.0,
-            shares_needed_raw,
-            share_amount
-        );
+    let (maker_addr, sig_type) = match &effective_mode {
+        TradingMode::PolyProxy => {
+            let proxy = creds.proxy_wallet.as_ref().ok_or_else(|| anyhow::anyhow!(
+                "POLY_PROXY mode requires a proxy wallet. \
+                 Run `polymarket setup-proxy` to create one first."
+            ))?.clone();
+            eprintln!("[polymarket] Using POLY_PROXY mode — maker: {}", proxy);
+            (proxy, 1u8)
+        }
+        TradingMode::Eoa => (signer_addr.clone(), 0u8),
+    };
+
+    // Check CTF token balance (from maker's address).
+    // EOA mode: use CLOB API (reliable for EOA wallets).
+    // POLY_PROXY mode: CLOB API returns 0 for proxy wallets regardless of actual balance;
+    // skip the pre-flight check and let the CLOB server validate at order submission.
+    if effective_mode == TradingMode::Eoa {
+        let token_balance = get_balance_allowance(&client, &maker_addr, &creds, "CONDITIONAL", Some(&token_id)).await?;
+        let balance_raw = token_balance.balance.as_deref().unwrap_or("0").parse::<u64>().unwrap_or(0);
+        let shares_needed_raw = to_token_units(share_amount);
+
+        if balance_raw < shares_needed_raw {
+            // Check if the proxy wallet might hold these tokens and hint mode switch.
+            let proxy_hint = crate::config::load_credentials()
+                .ok()
+                .flatten()
+                .and_then(|c| c.proxy_wallet)
+                .map(|proxy| format!(
+                    " Your position tokens may be in the proxy wallet ({}). \
+                     Switch modes with: polymarket switch-mode --mode proxy",
+                    proxy
+                ))
+                .unwrap_or_default();
+            bail!(
+                "Insufficient token balance in EOA wallet: have {:.6} shares, need {:.6} shares.{}",
+                balance_raw as f64 / 1_000_000.0,
+                share_amount,
+                proxy_hint
+            );
+        }
     }
 
     // Warn if GCD alignment reduced the share amount.
@@ -198,38 +235,43 @@ pub async fn run(
         );
     }
 
-    // Check CTF token approval via on-chain isApprovedForAll (ERC-1155).
-    use crate::config::Contracts;
-    let already_approved = if neg_risk {
-        let ok1 = match is_ctf_approved_for_all(&signer_addr, Contracts::NEG_RISK_CTF_EXCHANGE).await {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("[polymarket] Note: could not verify NEG_RISK_CTF_EXCHANGE approval ({}); will re-approve (setApprovalForAll is idempotent).", e);
-                false
+    // EOA mode: check and submit CTF setApprovalForAll if needed.
+    // POLY_PROXY mode: no approval tx — relayer handles settlement through the proxy.
+    if effective_mode == TradingMode::Eoa {
+        let already_approved = if neg_risk {
+            let ok1 = match is_ctf_approved_for_all(&signer_addr, Contracts::NEG_RISK_CTF_EXCHANGE).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[polymarket] Note: could not verify NEG_RISK_CTF_EXCHANGE approval ({}); will re-approve.", e);
+                    false
+                }
+            };
+            let ok2 = match is_ctf_approved_for_all(&signer_addr, Contracts::NEG_RISK_ADAPTER).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[polymarket] Note: could not verify NEG_RISK_ADAPTER approval ({}); will re-approve.", e);
+                    false
+                }
+            };
+            ok1 && ok2
+        } else {
+            match is_ctf_approved_for_all(&signer_addr, Contracts::CTF_EXCHANGE).await {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[polymarket] Note: could not verify CTF_EXCHANGE approval ({}); will re-approve.", e);
+                    false
+                }
             }
         };
-        let ok2 = match is_ctf_approved_for_all(&signer_addr, Contracts::NEG_RISK_ADAPTER).await {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("[polymarket] Note: could not verify NEG_RISK_ADAPTER approval ({}); will re-approve (setApprovalForAll is idempotent).", e);
-                false
-            }
-        };
-        ok1 && ok2
-    } else {
-        match is_ctf_approved_for_all(&signer_addr, Contracts::CTF_EXCHANGE).await {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("[polymarket] Note: could not verify CTF_EXCHANGE approval ({}); will re-approve (setApprovalForAll is idempotent).", e);
-                false
-            }
+        if !already_approved || auto_approve {
+            let exchange_label = if neg_risk { "Neg Risk CTF Exchange" } else { "CTF Exchange" };
+            eprintln!("[polymarket] Approving CTF tokens for {}...", exchange_label);
+            let tx_hash = approve_ctf(neg_risk).await?;
+            eprintln!("[polymarket] Approval tx: {}", tx_hash);
+            eprintln!("[polymarket] Waiting for approval to confirm on-chain...");
+            crate::onchainos::wait_for_tx_receipt(&tx_hash, 30).await?;
+            eprintln!("[polymarket] Approval confirmed.");
         }
-    };
-    if !already_approved || auto_approve {
-        let exchange_label = if neg_risk { "Neg Risk CTF Exchange" } else { "CTF Exchange" };
-        eprintln!("[polymarket] Approving CTF tokens for {}...", exchange_label);
-        let tx_hash = approve_ctf(neg_risk).await?;
-        eprintln!("[polymarket] Approval tx: {}", tx_hash);
     }
 
     let salt = rand_salt();
@@ -246,7 +288,7 @@ pub async fn run(
         nonce: 0,
         fee_rate_bps,
         side: 1, // SELL
-        signature_type: 0,
+        signature_type: sig_type,
     };
 
     let signature = sign_order_via_onchainos(&params, neg_risk).await?;
@@ -263,7 +305,7 @@ pub async fn run(
         nonce: "0".to_string(),
         fee_rate_bps: fee_rate_bps.to_string(),
         side: "SELL".to_string(),
-        signature_type: 0,
+        signature_type: sig_type,
         signature,
     };
 
@@ -274,6 +316,9 @@ pub async fn run(
         post_only,
     };
 
+    // The order owner for L2 auth must always be the EOA (API key holder),
+    // regardless of trading mode. In POLY_PROXY mode the maker field in the
+    // order struct is the proxy, but the HTTP owner must match the API key.
     let resp = post_order(&client, &signer_addr, &creds, &order_req).await?;
 
     if resp.success != Some(true) {

--- a/skills/polymarket-plugin/src/commands/setup_proxy.rs
+++ b/skills/polymarket-plugin/src/commands/setup_proxy.rs
@@ -1,0 +1,200 @@
+/// `polymarket setup-proxy` — create a Polymarket proxy wallet and switch to POLY_PROXY mode.
+///
+/// Flow:
+///   1. Check if proxy wallet already exists (via /profile API)
+///   2. If not: call PROXY_FACTORY.proxy([]) on-chain to deploy one (one-time POL gas cost)
+///   3. Re-fetch proxy wallet address from /profile
+///   4. Persist proxy_wallet + mode=PolyProxy in creds.json
+///   5. Set up the 6 one-time USDC.e / CTF approvals on the proxy wallet so trading is gasless:
+///        USDC.e.approve(CTF_EXCHANGE, MAX_UINT)
+///        CTF.setApprovalForAll(CTF_EXCHANGE, true)
+///        USDC.e.approve(NEG_RISK_CTF_EXCHANGE, MAX_UINT)
+///        CTF.setApprovalForAll(NEG_RISK_CTF_EXCHANGE, true)
+///        USDC.e.approve(NEG_RISK_ADAPTER, MAX_UINT)
+///        CTF.setApprovalForAll(NEG_RISK_ADAPTER, true)
+///
+/// After setup, all subsequent buy/sell commands use POLY_PROXY mode (no POL for trading).
+/// Run `polymarket switch-mode --mode eoa` to revert to EOA mode at any time.
+
+use anyhow::{bail, Context as _, Result};
+use reqwest::Client;
+
+pub async fn run(dry_run: bool) -> Result<()> {
+    let client = Client::new();
+
+    let signer_addr = crate::onchainos::get_wallet_address().await?;
+    let mut creds = crate::auth::ensure_credentials(&client, &signer_addr).await?;
+
+    // Step 1: check if proxy wallet already exists.
+    if let Some(ref proxy) = creds.proxy_wallet {
+        if creds.mode == crate::config::TradingMode::PolyProxy {
+            let proxy = proxy.clone();
+            // Approvals might not have been set up by older versions — ensure them now.
+            eprintln!("[polymarket] Proxy wallet already configured. Checking approvals...");
+            ensure_proxy_approvals(&proxy, dry_run).await?;
+            println!(
+                "{}",
+                serde_json::json!({
+                    "ok": true,
+                    "data": {
+                        "status": "already_configured",
+                        "proxy_wallet": proxy,
+                        "mode": "poly_proxy",
+                        "note": "Proxy wallet set up and approvals confirmed. Use `polymarket switch-mode --mode eoa` to revert."
+                    }
+                })
+            );
+            return Ok(());
+        }
+        // Has proxy but mode is EOA — switch mode and ensure approvals.
+        let proxy = proxy.clone();
+        creds.mode = crate::config::TradingMode::PolyProxy;
+        crate::config::save_credentials(&creds)?;
+        ensure_proxy_approvals(&proxy, dry_run).await?;
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "data": {
+                    "status": "mode_switched",
+                    "proxy_wallet": proxy,
+                    "mode": "poly_proxy",
+                    "note": "Switched to POLY_PROXY mode. Deposit USDC.e with `polymarket deposit --amount <N>`."
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    // Step 2: mandatory on-chain check before any deployment.
+    // If the RPC call fails we MUST abort — we cannot distinguish "no proxy exists"
+    // from "RPC error", and deploying a duplicate wastes gas and risks proxy confusion.
+    eprintln!("[polymarket] Checking on-chain for existing proxy wallet...");
+    let existing_proxy = crate::onchainos::get_existing_proxy(&signer_addr).await
+        .map_err(|e| anyhow::anyhow!(
+            "On-chain proxy check failed: {}. \
+             Aborting to prevent duplicate deployment. Retry when the RPC is available.",
+            e
+        ))?;
+
+    if let Some(existing) = existing_proxy {
+        eprintln!("[polymarket] Found existing proxy on-chain: {}", existing);
+        creds.proxy_wallet = Some(existing.clone());
+        creds.mode = crate::config::TradingMode::PolyProxy;
+        crate::config::save_credentials(&creds)?;
+        ensure_proxy_approvals(&existing, dry_run).await?;
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "data": {
+                    "status": "recovered",
+                    "proxy_wallet": existing,
+                    "mode": "poly_proxy",
+                    "note": "Existing proxy wallet found on-chain and saved to creds. No new deployment needed."
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    // Step 3: confirmed no proxy on-chain — deploy one via PROXY_FACTORY.
+    if dry_run {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "dry_run": true,
+                "data": {
+                    "signer": signer_addr,
+                    "action": "would call PROXY_FACTORY.proxy([]) to deploy proxy wallet, then set 6 USDC.e/CTF approvals",
+                    "note": "dry-run: no transaction submitted"
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    eprintln!("[polymarket] Deploying proxy wallet via PROXY_FACTORY (one-time gas cost)...");
+    let tx_hash = crate::onchainos::create_proxy_wallet().await?;
+    eprintln!("[polymarket] Proxy wallet deploy tx: {}", tx_hash);
+
+    // Step 3: resolve the proxy address from the transaction trace.
+    eprintln!("[polymarket] Resolving proxy wallet address from transaction trace...");
+    let proxy_addr = crate::onchainos::get_proxy_address_from_tx(&tx_hash)
+        .await
+        .with_context(|| format!(
+            "Proxy deployed (tx {}) but address could not be resolved. \
+             Check: https://polygonscan.com/tx/{}",
+            tx_hash, tx_hash
+        ))?;
+
+    // Step 4: persist.
+    creds.proxy_wallet = Some(proxy_addr.clone());
+    creds.mode = crate::config::TradingMode::PolyProxy;
+    crate::config::save_credentials(&creds)?;
+
+    // Step 5: set up the 6 one-time approvals so trading is gasless.
+    ensure_proxy_approvals(&proxy_addr, dry_run).await?;
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "ok": true,
+            "data": {
+                "status": "created",
+                "proxy_wallet": proxy_addr,
+                "deploy_tx": tx_hash,
+                "mode": "poly_proxy",
+                "next_step": "Deposit USDC.e with: polymarket deposit --amount <N>"
+            }
+        })
+    );
+    Ok(())
+}
+
+/// Set up the 6 one-time on-chain approvals required for gasless trading in POLY_PROXY mode.
+///
+/// Checks the current USDC.e allowance to CTF_EXCHANGE first. If already non-zero,
+/// skips all 6 (idempotent guard to avoid spending gas on repeat runs).
+async fn ensure_proxy_approvals(proxy_addr: &str, dry_run: bool) -> Result<()> {
+    use crate::config::Contracts;
+
+    // Fast-path: if CTF_EXCHANGE allowance is already set, all 6 were done together.
+    let existing = crate::onchainos::get_usdc_allowance(proxy_addr, Contracts::CTF_EXCHANGE).await
+        .unwrap_or(0);
+    if existing > 0 {
+        eprintln!("[polymarket] USDC.e approvals already set (allowance: {}).", existing);
+        return Ok(());
+    }
+
+    if dry_run {
+        eprintln!("[polymarket] dry-run: would set 6 approvals (USDC.e + CTF × 3 contracts).");
+        return Ok(());
+    }
+
+    eprintln!("[polymarket] Setting up one-time USDC.e / CTF approvals for gasless trading...");
+
+    let approvals: &[(&str, bool, &str)] = &[
+        (Contracts::CTF_EXCHANGE,         false, "CTF Exchange / USDC.e"),
+        (Contracts::CTF_EXCHANGE,         true,  "CTF Exchange / CTF"),
+        (Contracts::NEG_RISK_CTF_EXCHANGE, false, "Neg Risk CTF Exchange / USDC.e"),
+        (Contracts::NEG_RISK_CTF_EXCHANGE, true,  "Neg Risk CTF Exchange / CTF"),
+        (Contracts::NEG_RISK_ADAPTER,     false, "Neg Risk Adapter / USDC.e"),
+        (Contracts::NEG_RISK_ADAPTER,     true,  "Neg Risk Adapter / CTF"),
+    ];
+
+    for (spender, is_ctf, label) in approvals {
+        eprintln!("[polymarket] Approving {} ...", label);
+        let tx = if *is_ctf {
+            crate::onchainos::proxy_ctf_set_approval_for_all(spender).await?
+        } else {
+            crate::onchainos::proxy_usdc_approve(spender).await?
+        };
+        eprintln!("[polymarket] tx: {}", tx);
+        crate::onchainos::wait_for_tx_receipt(&tx, 30).await?;
+    }
+
+    eprintln!("[polymarket] All 6 approvals confirmed. Proxy wallet ready for gasless trading.");
+    Ok(())
+}

--- a/skills/polymarket-plugin/src/commands/switch_mode.rs
+++ b/skills/polymarket-plugin/src/commands/switch_mode.rs
@@ -1,0 +1,75 @@
+/// `polymarket switch-mode` — permanently change the default trading mode.
+///
+/// Modes:
+///   eoa   — EOA wallet is the maker. Requires POL for each approve transaction.
+///   proxy — Proxy wallet is the maker. No POL needed for trading; relayer pays gas.
+///           Requires `polymarket setup-proxy` to have been run first.
+
+use anyhow::{bail, Result};
+use reqwest::Client;
+
+pub async fn run(mode: &str) -> Result<()> {
+    let client = Client::new();
+
+    let signer_addr = crate::onchainos::get_wallet_address().await?;
+    let mut creds = crate::auth::ensure_credentials(&client, &signer_addr).await?;
+
+    let new_mode = match mode.to_lowercase().as_str() {
+        "proxy" | "poly_proxy" | "polyproxy" => crate::config::TradingMode::PolyProxy,
+        "eoa"                                 => crate::config::TradingMode::Eoa,
+        other => bail!(
+            "Unknown mode '{}'. Valid values: eoa, proxy",
+            other
+        ),
+    };
+
+    // Proxy mode requires an existing proxy wallet.
+    if new_mode == crate::config::TradingMode::PolyProxy && creds.proxy_wallet.is_none() {
+        bail!(
+            "Cannot switch to proxy mode: no proxy wallet configured.\n\
+             Run `polymarket setup-proxy` first to deploy a proxy wallet."
+        );
+    }
+
+    let old_mode = creds.mode.clone();
+    if old_mode == new_mode {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "data": {
+                    "mode": mode,
+                    "note": "Already in this mode — no change."
+                }
+            })
+        );
+        return Ok(());
+    }
+
+    creds.mode = new_mode;
+    crate::config::save_credentials(&creds)?;
+
+    let description = match &creds.mode {
+        crate::config::TradingMode::PolyProxy => format!(
+            "POLY_PROXY mode. Maker: {}. No POL needed for trading.",
+            creds.proxy_wallet.as_deref().unwrap_or("(unknown)")
+        ),
+        crate::config::TradingMode::Eoa => format!(
+            "EOA mode. Maker: {}. POL required for approve transactions.",
+            signer_addr
+        ),
+    };
+
+    println!(
+        "{}",
+        serde_json::json!({
+            "ok": true,
+            "data": {
+                "mode": mode,
+                "description": description,
+                "proxy_wallet": creds.proxy_wallet,
+            }
+        })
+    );
+    Ok(())
+}

--- a/skills/polymarket-plugin/src/commands/withdraw.rs
+++ b/skills/polymarket-plugin/src/commands/withdraw.rs
@@ -1,0 +1,69 @@
+/// `polymarket withdraw` — transfer USDC.e from proxy wallet back to EOA wallet.
+///
+/// Uses PROXY_FACTORY.proxy([op]) to execute a USDC.e transfer from the proxy's context.
+/// The op encodes: transfer(eoa_address, amount) on the USDC.e contract.
+
+use anyhow::{bail, Result};
+use crate::onchainos::{get_usdc_balance, get_wallet_address};
+
+pub async fn run(amount: &str, dry_run: bool) -> Result<()> {
+    let eoa = get_wallet_address().await?;
+    let creds = crate::config::load_credentials()
+        .ok()
+        .flatten()
+        .ok_or_else(|| anyhow::anyhow!("No credentials found. Run `polymarket setup-proxy` first."))?;
+    let proxy = creds.proxy_wallet
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("No proxy wallet configured. Run `polymarket setup-proxy` first."))?
+        .clone();
+
+    let amount_f: f64 = amount.parse().map_err(|_| anyhow::anyhow!("invalid amount"))?;
+    if amount_f <= 0.0 {
+        bail!("amount must be positive");
+    }
+    let amount_raw = (amount_f * 1_000_000.0).round() as u128;
+
+    // Check proxy balance on-chain
+    let proxy_bal = get_usdc_balance(&proxy).await?;
+    let proxy_bal_raw = (proxy_bal * 1_000_000.0).floor() as u128;
+    if proxy_bal_raw < amount_raw {
+        bail!(
+            "Insufficient proxy wallet balance: have ${:.2}, need ${:.2}",
+            proxy_bal, amount_f
+        );
+    }
+
+    if dry_run {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "dry_run": true,
+            "data": {
+                "from": proxy,
+                "to": eoa,
+                "token": "USDC.e",
+                "amount": amount_f,
+                "amount_raw": amount_raw,
+                "note": "dry-run: no transaction submitted"
+            }
+        }))?);
+        return Ok(());
+    }
+
+    eprintln!("[polymarket] Withdrawing ${:.2} USDC.e from proxy {} to EOA {}...", amount_f, proxy, eoa);
+    let tx_hash = crate::onchainos::withdraw_usdc_from_proxy(&eoa, amount_raw).await?;
+    eprintln!("[polymarket] Withdraw tx: {}", tx_hash);
+    eprintln!("[polymarket] Waiting for confirmation...");
+    crate::onchainos::wait_for_tx_receipt(&tx_hash, 30).await?;
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "data": {
+            "tx_hash": tx_hash,
+            "from": proxy,
+            "to": eoa,
+            "token": "USDC.e",
+            "amount": amount_f,
+        }
+    }))?);
+    Ok(())
+}

--- a/skills/polymarket-plugin/src/config.rs
+++ b/skills/polymarket-plugin/src/config.rs
@@ -5,6 +5,18 @@ use std::path::PathBuf;
 use std::os::unix::fs::PermissionsExt;
 
 
+/// Trading mode: which wallet acts as the order maker.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TradingMode {
+    /// EOA mode: the onchainos wallet is the maker. Requires POL for gas on every approve.
+    #[default]
+    Eoa,
+    /// PolyProxy mode: a Polymarket proxy contract is the maker. No POL needed for trading;
+    /// Polymarket's relayer covers gas. Requires USDC.e deposited into the proxy wallet.
+    PolyProxy,
+}
+
 /// Persisted API credentials derived via L1 (ClobAuth EIP-712) auth.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Credentials {
@@ -15,9 +27,12 @@ pub struct Credentials {
     /// Ethereum address of the onchainos wallet used to derive these credentials.
     #[serde(default)]
     pub signing_address: String,
-    /// Polymarket proxy wallet address (maker for orders). Populated after polymarket.com onboarding.
+    /// Polymarket proxy wallet address (maker for orders).
     #[serde(default)]
     pub proxy_wallet: Option<String>,
+    /// Active trading mode. Defaults to EOA if not set (backwards-compatible).
+    #[serde(default)]
+    pub mode: TradingMode,
 }
 
 impl Credentials {
@@ -115,5 +130,5 @@ impl Urls {
     pub const CLOB: &'static str = "https://clob.polymarket.com";
     pub const GAMMA: &'static str = "https://gamma-api.polymarket.com";
     pub const DATA: &'static str = "https://data-api.polymarket.com";
-    pub const POLYGON_RPC: &'static str = "https://polygon-rpc.com";
+    pub const POLYGON_RPC: &'static str = "https://polygon.drpc.org";
 }

--- a/skills/polymarket-plugin/src/main.rs
+++ b/skills/polymarket-plugin/src/main.rs
@@ -43,11 +43,15 @@ enum Commands {
     },
 
     /// Get open positions for the active wallet (no auth required — uses public Data API)
+    #[command(alias = "positions")]
     GetPositions {
         /// Wallet address to query (defaults to active onchainos wallet)
         #[arg(long, alias = "wallet")]
         address: Option<String>,
     },
+
+    /// Show POL and USDC.e balances for the EOA wallet (and proxy wallet if initialized)
+    Balance,
 
     /// Buy YES or NO shares in a market (signs via onchainos wallet)
     Buy {
@@ -95,6 +99,11 @@ enum Commands {
         #[arg(long)]
         expires: Option<u64>,
 
+        /// Override trading mode for this order only: eoa or proxy.
+        /// Does not change the stored default — use `switch-mode` for that.
+        #[arg(long, value_parser = ["eoa", "proxy"])]
+        mode: Option<String>,
+
         /// Confirm a previously gated action (reserved for future use)
         #[arg(long)]
         confirm: bool,
@@ -140,9 +149,52 @@ enum Commands {
         #[arg(long)]
         expires: Option<u64>,
 
+        /// Override trading mode for this order only: eoa or proxy.
+        /// Does not change the stored default — use `switch-mode` for that.
+        #[arg(long, value_parser = ["eoa", "proxy"])]
+        mode: Option<String>,
+
         /// Confirm a low-price market sell that was previously gated
         #[arg(long)]
         confirm: bool,
+    },
+
+    /// Create a Polymarket proxy wallet and switch to gasless POLY_PROXY trading mode.
+    /// One-time POL gas cost; all subsequent trading is relayer-paid.
+    SetupProxy {
+        /// Preview the action without submitting any transaction
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Deposit USDC.e into the proxy wallet (POLY_PROXY mode only).
+    /// Requires `setup-proxy` to have been run first.
+    Deposit {
+        /// USDC.e amount to transfer (e.g. "50" = $50.00)
+        #[arg(long)]
+        amount: String,
+
+        /// Preview the transfer without submitting
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Withdraw USDC.e from the proxy wallet back to the EOA wallet.
+    Withdraw {
+        /// USDC.e amount to withdraw (e.g. "10" = $10.00)
+        #[arg(long)]
+        amount: String,
+
+        /// Preview the withdrawal without submitting
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Switch the default trading mode between EOA and POLY_PROXY.
+    SwitchMode {
+        /// Mode to switch to: eoa or proxy
+        #[arg(long, value_parser = ["eoa", "proxy"])]
+        mode: String,
     },
 
     /// Redeem winning outcome tokens after a market resolves (signs via onchainos wallet)
@@ -189,6 +241,9 @@ async fn main() {
         Commands::GetPositions { address } => {
             commands::get_positions::run(address.as_deref()).await
         }
+        Commands::Balance => {
+            commands::balance::run().await
+        }
         Commands::Buy {
             market_id,
             outcome,
@@ -200,9 +255,10 @@ async fn main() {
             round_up,
             post_only,
             expires,
+            mode,
             confirm: _confirm,
         } => {
-            commands::buy::run(&market_id, &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires).await
+            commands::buy::run(&market_id, &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, mode.as_deref()).await
         }
         Commands::Sell {
             market_id,
@@ -214,9 +270,22 @@ async fn main() {
             dry_run,
             post_only,
             expires,
+            mode,
             confirm: _confirm,
         } => {
-            commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires).await
+            commands::sell::run(&market_id, &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, mode.as_deref()).await
+        }
+        Commands::SetupProxy { dry_run } => {
+            commands::setup_proxy::run(dry_run).await
+        }
+        Commands::Deposit { amount, dry_run } => {
+            commands::deposit::run(&amount, dry_run).await
+        }
+        Commands::Withdraw { amount, dry_run } => {
+            commands::withdraw::run(&amount, dry_run).await
+        }
+        Commands::SwitchMode { mode } => {
+            commands::switch_mode::run(&mode).await
         }
         Commands::Redeem { market_id, dry_run } => {
             commands::redeem::run(&market_id, dry_run).await

--- a/skills/polymarket-plugin/src/onchainos.rs
+++ b/skills/polymarket-plugin/src/onchainos.rs
@@ -109,6 +109,491 @@ fn pad_u256(val: u128) -> String {
     format!("{:064x}", val)
 }
 
+// ─── Proxy wallet ─────────────────────────────────────────────────────────────
+
+/// Resolve the proxy wallet address created in `tx_hash` by inspecting the call trace.
+///
+/// Uses `debug_traceTransaction` with the callTracer to find the CREATE/CREATE2 sub-call
+/// emitted by PROXY_FACTORY and extract the resulting contract address.
+///
+/// Resolve the proxy wallet address from `tx_hash` by inspecting the call trace.
+///
+/// Uses `debug_traceTransaction` with the callTracer on two RPCs (drpc + publicnode).
+/// If neither RPC returns a verifiable EIP-1167 proxy address, returns an error — the
+/// caller must NOT proceed with an unverified address, as depositing to a wrong EOA
+/// will permanently lose user funds.
+pub async fn get_proxy_address_from_tx(tx_hash: &str) -> Result<String> {
+    use crate::config::Urls;
+
+    let rpcs = [Urls::POLYGON_RPC, "https://polygon-bor-rpc.publicnode.com"];
+    for rpc_url in &rpcs {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "debug_traceTransaction",
+            "params": [tx_hash, {"tracer": "callTracer"}],
+            "id": 1
+        });
+        let resp = reqwest::Client::new()
+            .post(*rpc_url)
+            .json(&body)
+            .send()
+            .await;
+        if let Ok(r) = resp {
+            if let Ok(v) = r.json::<Value>().await {
+                if v.get("error").is_none() {
+                    if let Some(addr) = find_create_in_trace(&v["result"]) {
+                        // Mandatory: verify the resolved address is an EIP-1167 proxy.
+                        // A wrong address (e.g. an EOA) would silently accept deposits and
+                        // permanently lock user funds.
+                        if verify_eip1167_proxy(&addr).await {
+                            return Ok(addr);
+                        }
+                        anyhow::bail!(
+                            "Resolved address {} from tx {} is not an EIP-1167 proxy contract. \
+                             Refusing to proceed to protect funds. \
+                             Check: https://polygonscan.com/tx/{}",
+                            addr, tx_hash, tx_hash
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // No nonce-based fallback: guessing an address without on-chain verification risks
+    // sending funds to a random EOA. Fail loudly instead.
+    anyhow::bail!(
+        "Could not retrieve proxy address from tx {} via debug_traceTransaction on any RPC. \
+         This may be a temporary RPC outage — wait a few seconds and retry setup-proxy. \
+         Do NOT deposit until the proxy address is confirmed on-chain. \
+         Check: https://polygonscan.com/tx/{}",
+        tx_hash, tx_hash
+    )
+}
+
+/// Search a callTracer trace for any call (CREATE, CREATE2, or CALL) made BY PROXY_FACTORY.
+/// The factory always calls the proxy wallet as its first sub-call — whether creating a new one
+/// (CREATE/CREATE2) or forwarding calls to an existing one (CALL). The `to` field is the proxy.
+fn find_create_in_trace(trace: &Value) -> Option<String> {
+    use crate::config::Contracts;
+    let factory = Contracts::PROXY_FACTORY.to_lowercase();
+
+    // Check direct sub-calls of the current frame
+    if let Some(calls) = trace["calls"].as_array() {
+        for sub in calls {
+            let from = sub["from"].as_str().unwrap_or("").to_lowercase();
+            let call_type = sub["type"].as_str().unwrap_or("");
+            let to = sub["to"].as_str().unwrap_or("");
+
+            // Any call FROM the factory is to the proxy (new or existing)
+            if from == factory && !to.is_empty()
+                && matches!(call_type, "CREATE" | "CREATE2" | "CALL")
+            {
+                return Some(to.to_string());
+            }
+
+            // Recurse deeper
+            if let Some(addr) = find_create_in_trace(sub) {
+                return Some(addr);
+            }
+        }
+    }
+    None
+}
+
+/// Compute the CREATE address for a deployment from `deployer` at `nonce`.
+/// Formula: keccak256(rlp([deployer, nonce]))[12:]
+fn compute_create_address(deployer: &str, nonce: u64) -> Result<String> {
+    use sha3::{Digest, Keccak256};
+
+    let addr_bytes = hex::decode(deployer.trim_start_matches("0x"))
+        .context("decoding deployer address")?;
+    anyhow::ensure!(addr_bytes.len() == 20, "deployer must be 20 bytes");
+
+    // RLP-encode address (20 bytes): 0x94 prefix (0x80 + 20)
+    let rlp_addr: Vec<u8> = [&[0x94u8][..], &addr_bytes].concat();
+
+    // RLP-encode nonce
+    let rlp_nonce: Vec<u8> = if nonce == 0 {
+        vec![0x80]
+    } else {
+        let b = {
+            let mut tmp = nonce;
+            let mut bytes = Vec::new();
+            while tmp > 0 {
+                bytes.push((tmp & 0xFF) as u8);
+                tmp >>= 8;
+            }
+            bytes.reverse();
+            bytes
+        };
+        if b.len() == 1 && b[0] < 0x80 {
+            b
+        } else {
+            [[0x80 + b.len() as u8].as_slice(), &b].concat()
+        }
+    };
+
+    // RLP-encode list: payload = rlp_addr + rlp_nonce
+    let payload: Vec<u8> = [rlp_addr, rlp_nonce].concat();
+    let list_prefix: Vec<u8> = if payload.len() < 56 {
+        vec![0xC0 + payload.len() as u8]
+    } else {
+        let len_bytes = {
+            let l = payload.len();
+            let mut tmp = l;
+            let mut bytes = Vec::new();
+            while tmp > 0 {
+                bytes.push((tmp & 0xFF) as u8);
+                tmp >>= 8;
+            }
+            bytes.reverse();
+            bytes
+        };
+        [[0xF7 + len_bytes.len() as u8].as_slice(), &len_bytes].concat()
+    };
+    let encoded: Vec<u8> = [list_prefix, payload].concat();
+
+    let hash = Keccak256::digest(&encoded);
+    Ok(format!("0x{}", hex::encode(&hash[12..])))
+}
+
+/// Check whether an address has EIP-1167 minimal proxy bytecode deployed.
+async fn verify_eip1167_proxy(addr: &str) -> bool {
+    use crate::config::Urls;
+    const EIP1167_PREFIX: &str = "363d3d373d3d3d363d73";
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getCode",
+        "params": [addr, "latest"],
+        "id": 1
+    });
+    if let Ok(r) = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+    {
+        if let Ok(v) = r.json::<Value>().await {
+            if let Some(code) = v["result"].as_str() {
+                return code.trim_start_matches("0x").starts_with(EIP1167_PREFIX);
+            }
+        }
+    }
+    false
+}
+
+/// Create a Polymarket proxy wallet via PROXY_FACTORY.proxy([]).
+///
+/// Calls `proxy((uint8,address,uint256,bytes)[])` with an empty calls array.
+/// The factory deploys a minimal-proxy clone keyed to msg.sender (this wallet).
+/// Returns the tx hash; call `get_proxy_address_from_tx(tx_hash)` to resolve the address.
+///
+/// NOTE: One-time gas cost in POL. All subsequent trading via the proxy is relayer-paid.
+/// Query PROXY_FACTORY via debug_traceCall to check if a proxy already exists for `eoa_addr`.
+///
+/// Returns:
+/// - `Ok(Some(addr))` — proxy exists on-chain and is a valid EIP-1167 contract
+/// - `Ok(None)`       — no proxy exists yet (safe to deploy)
+/// - `Err(...)`       — RPC call failed; caller MUST NOT proceed with deployment,
+///                      as we cannot distinguish "no proxy" from "RPC error"
+pub async fn get_existing_proxy(eoa_addr: &str) -> Result<Option<String>> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::{Contracts, Urls};
+
+    let selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let selector_hex = hex::encode(&selector[..4]);
+    let calldata = format!(
+        "0x{}\
+         0000000000000000000000000000000000000000000000000000000000000020\
+         0000000000000000000000000000000000000000000000000000000000000000",
+        selector_hex
+    );
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "debug_traceCall",
+        "params": [
+            { "from": eoa_addr, "to": Contracts::PROXY_FACTORY, "data": calldata },
+            "latest",
+            { "tracer": "callTracer" }
+        ],
+        "id": 1
+    });
+
+    let resp = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+        .context("debug_traceCall RPC request failed")?;
+
+    let v: serde_json::Value = resp.json().await
+        .context("debug_traceCall response parse failed")?;
+
+    if let Some(err) = v.get("error") {
+        anyhow::bail!(
+            "debug_traceCall returned an error while checking for existing proxy: {}. \
+             Cannot safely determine whether a proxy exists — aborting to prevent duplicate deployment.",
+            err
+        );
+    }
+
+    Ok(find_create_in_trace(&v["result"]))
+}
+
+pub async fn create_proxy_wallet() -> Result<String> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::Contracts;
+
+    // Function selector: keccak256("proxy((uint8,address,uint256,bytes)[])")
+    let selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let selector_hex = hex::encode(&selector[..4]);
+
+    // ABI-encode empty dynamic array: offset=0x20 (32), length=0
+    let calldata = format!(
+        "0x{}\
+         0000000000000000000000000000000000000000000000000000000000000020\
+         0000000000000000000000000000000000000000000000000000000000000000",
+        selector_hex
+    );
+
+    let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
+/// Transfer USDC.e directly to a proxy wallet address.
+/// Uses ERC-20 transfer(address recipient, uint256 amount).
+/// Selector: 0xa9059cbb
+/// Withdraw USDC.e from the proxy wallet back to the EOA.
+///
+/// Encodes `PROXY_FACTORY.proxy([(0, USDC_E, 0, transfer(eoa, amount))])`.
+/// The factory routes the op to the proxy, which executes transfer from its own context.
+pub async fn withdraw_usdc_from_proxy(eoa_addr: &str, amount: u128) -> Result<String> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::Contracts;
+
+    // Inner calldata: transfer(eoa_addr, amount) on USDC.e
+    // selector: keccak256("transfer(address,uint256)") = 0xa9059cbb
+    let transfer_data = format!(
+        "a9059cbb{}{}",
+        pad_address(eoa_addr),
+        pad_u256(amount)
+    );
+    let transfer_bytes = hex::decode(&transfer_data).expect("transfer calldata hex");
+    let transfer_len = transfer_bytes.len(); // 68 bytes
+
+    // ABI-encode proxy((uint8,address,uint256,bytes)[]) with one element:
+    //   (op=1, to=USDC_E, value=0, data=transfer_bytes)
+    //
+    // op=1 means CALL; op=0 is DELEGATECALL in this proxy implementation.
+    //
+    // Layout (all 32-byte words, after the 4-byte selector):
+    //   [0]  0x20       array offset
+    //   [1]  0x01       array length = 1
+    //   --- tuple[0] ---
+    //   [2]  0x01       op = CALL
+    //   [3]  USDC_E     to (address padded)
+    //   [4]  0x00       value = 0
+    //   [5]  0x80       data offset from start of tuple = 4 * 32 = 128
+    //   [6]  len        data length
+    //   [7+] data       transfer calldata (padded to 32-byte multiple)
+
+    let selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let selector_hex = hex::encode(&selector[..4]);
+    let usdc_padded = pad_address(Contracts::USDC_E);
+    let data_len_padded = format!("{:064x}", transfer_len);
+    // Pad transfer_bytes to next 32-byte boundary
+    let pad_len = (32 - transfer_len % 32) % 32;
+    let data_padded = format!("{}{}", transfer_data, "00".repeat(pad_len));
+
+    // Correct ABI encoding for (uint8,address,uint256,bytes)[] with one tuple element.
+    // The tuple contains a dynamic type (bytes), so the tuple itself is dynamic and
+    // needs an offset pointer inside the array.
+    //
+    // Layout after selector (each line = 32 bytes):
+    //   [0x20]  params -> array offset
+    //   [0x01]  array length = 1
+    //   [0x20]  array[0] offset from start of array data (32 bytes after length word)
+    //   [0x00]  tuple.op = 0 (CALL)
+    //   [to]    tuple.to = USDC_E
+    //   [0x00]  tuple.value = 0
+    //   [0x80]  tuple.data offset from start of tuple (4 * 32 = 128)
+    //   [len]   tuple.data length
+    //   [data]  tuple.data padded
+    let calldata = format!(
+        "0x{}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}",
+        selector_hex,
+        "0000000000000000000000000000000000000000000000000000000000000020", // params -> array offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // array length = 1
+        "0000000000000000000000000000000000000000000000000000000000000020", // array[0] tuple offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // op = 1 (CALL)
+        usdc_padded,    // to = USDC_E
+        "0000000000000000000000000000000000000000000000000000000000000000", // value = 0
+        "0000000000000000000000000000000000000000000000000000000000000080", // data offset in tuple
+        data_len_padded,
+        data_padded,
+    );
+
+    let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
+/// Get USDC.e ERC-20 allowance for owner → spender. Returns raw amount (6 decimals).
+pub async fn get_usdc_allowance(owner: &str, spender: &str) -> Result<u128> {
+    use crate::config::{Contracts, Urls};
+    // allowance(address,address) selector = 0xdd62ed3e
+    let data = format!("0xdd62ed3e{}{}", pad_address(owner), pad_address(spender));
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "params": [{ "to": Contracts::USDC_E, "data": data }, "latest"],
+        "id": 1
+    });
+    let v: serde_json::Value = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+        .context("Polygon RPC request failed")?
+        .json()
+        .await
+        .context("parsing RPC response")?;
+    if let Some(err) = v.get("error") {
+        anyhow::bail!("Polygon RPC error: {}", err);
+    }
+    let hex = v["result"].as_str().unwrap_or("0x").trim_start_matches("0x");
+    // Allowance can be MAX_UINT256 (256-bit), which overflows u128.
+    // If any hex digit is non-zero the allowance is set — saturate to u128::MAX.
+    if hex.is_empty() || hex.chars().all(|c| c == '0') {
+        return Ok(0);
+    }
+    Ok(u128::from_str_radix(hex, 16).unwrap_or(u128::MAX))
+}
+
+/// Call setApprovalForAll(operator, true) on the CTF contract from the proxy wallet,
+/// via PROXY_FACTORY.proxy([(1, CTF, 0, setApprovalForAll(operator, true))]).
+pub async fn proxy_ctf_set_approval_for_all(operator: &str) -> Result<String> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::Contracts;
+
+    // setApprovalForAll(address,bool) selector = 0xa22cb465
+    let saf_data = format!(
+        "a22cb465{}{}",
+        pad_address(operator),
+        "0000000000000000000000000000000000000000000000000000000000000001" // true
+    );
+    let saf_bytes = hex::decode(&saf_data).expect("setApprovalForAll calldata hex");
+    let saf_len = saf_bytes.len(); // 68 bytes
+
+    let selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let selector_hex = hex::encode(&selector[..4]);
+    let ctf_padded = pad_address(Contracts::CTF);
+    let data_len_padded = format!("{:064x}", saf_len);
+    let pad_len = (32 - saf_len % 32) % 32;
+    let data_padded = format!("{}{}", saf_data, "00".repeat(pad_len));
+
+    let calldata = format!(
+        "0x{}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}",
+        selector_hex,
+        "0000000000000000000000000000000000000000000000000000000000000020",
+        "0000000000000000000000000000000000000000000000000000000000000001",
+        "0000000000000000000000000000000000000000000000000000000000000020",
+        "0000000000000000000000000000000000000000000000000000000000000001", // op = 1 (CALL)
+        ctf_padded,
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000080",
+        data_len_padded,
+        data_padded,
+    );
+
+    let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
+/// Approve USDC.e from the proxy wallet to a spender, via PROXY_FACTORY.proxy().
+///
+/// Encodes `PROXY_FACTORY.proxy([(1, USDC_E, 0, approve(spender, maxUint))])`.
+/// Used in POLY_PROXY mode to grant the CTF Exchange (or NEG_RISK_CTF_EXCHANGE /
+/// NEG_RISK_ADAPTER) spending rights on the proxy wallet's USDC.e.
+/// Returns the tx hash.
+pub async fn proxy_usdc_approve(spender: &str) -> Result<String> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::Contracts;
+
+    // Inner calldata: approve(spender, maxUint) on USDC.e
+    // selector: keccak256("approve(address,uint256)") = 0x095ea7b3
+    let approve_data = format!(
+        "095ea7b3{}{}",
+        pad_address(spender),
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" // uint256 max
+    );
+    let approve_bytes = hex::decode(&approve_data).expect("approve calldata hex");
+    let approve_len = approve_bytes.len(); // 68 bytes
+
+    let selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let selector_hex = hex::encode(&selector[..4]);
+    let usdc_padded = pad_address(Contracts::USDC_E);
+    let data_len_padded = format!("{:064x}", approve_len);
+    let pad_len = (32 - approve_len % 32) % 32;
+    let data_padded = format!("{}{}", approve_data, "00".repeat(pad_len));
+
+    let calldata = format!(
+        "0x{}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}",
+        selector_hex,
+        "0000000000000000000000000000000000000000000000000000000000000020", // params -> array offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // array length = 1
+        "0000000000000000000000000000000000000000000000000000000000000020", // array[0] tuple offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // op = 1 (CALL)
+        usdc_padded,    // to = USDC_E
+        "0000000000000000000000000000000000000000000000000000000000000000", // value = 0
+        "0000000000000000000000000000000000000000000000000000000000000080", // data offset in tuple
+        data_len_padded,
+        data_padded,
+    );
+
+    let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
+pub async fn transfer_usdc_to_proxy(proxy_addr: &str, amount: u128) -> Result<String> {
+    use crate::config::Contracts;
+    let recipient_padded = pad_address(proxy_addr);
+    let amount_padded = pad_u256(amount);
+    let calldata = format!("0xa9059cbb{}{}", recipient_padded, amount_padded);
+    let result = wallet_contract_call(Contracts::USDC_E, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
+// ─── ERC-20 / CTF approvals ────────────────────────────────────────────────────
+
 /// ABI-encode and submit USDC.e approve(spender, amount).
 /// Selector: 0x095ea7b3
 /// To: USDC.e contract
@@ -202,6 +687,101 @@ pub async fn ctf_redeem_positions(condition_id: &str) -> Result<String> {
 
     let result = wallet_contract_call(Contracts::CTF, &calldata).await?;
     extract_tx_hash(&result)
+}
+
+/// Get native POL balance for an address (eth_getBalance). Returns human-readable f64 (POL).
+pub async fn get_pol_balance(addr: &str) -> Result<f64> {
+    use crate::config::Urls;
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [addr, "latest"],
+        "id": 1
+    });
+    let v: serde_json::Value = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+        .context("Polygon RPC request failed")?
+        .json()
+        .await
+        .context("parsing RPC response")?;
+    if let Some(err) = v.get("error") {
+        anyhow::bail!("Polygon RPC error: {}", err);
+    }
+    let hex = v["result"].as_str().unwrap_or("0x0").trim_start_matches("0x");
+    let wei = u128::from_str_radix(hex, 16).context("parsing POL balance")?;
+    Ok(wei as f64 / 1e18)
+}
+
+/// Get USDC.e (ERC-20) balance for an address. Returns human-readable f64 (dollars).
+pub async fn get_usdc_balance(addr: &str) -> Result<f64> {
+    use crate::config::{Contracts, Urls};
+    // balanceOf(address) selector = 0x70a08231
+    let data = format!("0x70a08231{}", pad_address(addr));
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "params": [{ "to": Contracts::USDC_E, "data": data }, "latest"],
+        "id": 1
+    });
+    let v: serde_json::Value = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+        .context("Polygon RPC request failed")?
+        .json()
+        .await
+        .context("parsing RPC response")?;
+    if let Some(err) = v.get("error") {
+        anyhow::bail!("Polygon RPC error: {}", err);
+    }
+    let hex = v["result"].as_str().unwrap_or("0x").trim_start_matches("0x");
+    let raw = u128::from_str_radix(hex, 16).unwrap_or(0);
+    Ok(raw as f64 / 1_000_000.0) // USDC.e has 6 decimals
+}
+
+/// Poll eth_getTransactionReceipt until the tx is mined (or timeout).
+///
+/// Polygon block time is ~2 seconds. We poll every 2 seconds for up to max_wait_secs.
+/// Call this after submitting an approval tx before posting any order.
+pub async fn wait_for_tx_receipt(tx_hash: &str, max_wait_secs: u64) -> Result<()> {
+    use crate::config::Urls;
+    use std::time::{Duration, Instant};
+    use tokio::time::sleep;
+
+    let deadline = Instant::now() + Duration::from_secs(max_wait_secs);
+    loop {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getTransactionReceipt",
+            "params": [tx_hash],
+            "id": 1
+        });
+        let resp = reqwest::Client::new()
+            .post(Urls::POLYGON_RPC)
+            .json(&body)
+            .send()
+            .await;
+        if let Ok(r) = resp {
+            if let Ok(v) = r.json::<serde_json::Value>().await {
+                // receipt is an object (not null) once the tx is mined
+                if v["result"].is_object() {
+                    return Ok(());
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "Approval tx {} not confirmed within {}s. \
+                 Check Polygonscan and retry.",
+                tx_hash, max_wait_secs
+            );
+        }
+        sleep(Duration::from_millis(2000)).await;
+    }
 }
 
 /// Check if the CTF contract has setApprovalForAll set for owner → operator.


### PR DESCRIPTION
## Summary

Adds gasless POLY_PROXY trading mode and 5 new wallet-management commands to `polymarket-plugin`, bumping from v0.2.6 → v0.3.0.

### New commands

| Command | Description |
|---------|-------------|
| `balance` | Show POL + USDC.e for EOA and proxy wallets |
| `setup-proxy` | Deploy Polymarket proxy wallet; run 6 one-time on-chain approvals (idempotent) |
| `deposit` | Transfer USDC.e from EOA → proxy wallet (plain ERC-20 transfer) |
| `withdraw` | Transfer USDC.e from proxy → EOA (via proxy factory) |
| `switch-mode` | Change persistent default trading mode (`eoa`/`proxy`) |

### Changes to existing commands

- `buy --mode eoa|proxy` — per-trade mode override without changing stored default
- `sell --mode eoa|proxy` — same
- `get-positions` — proxy-aware wallet selection (queries proxy wallet in POLY_PROXY mode); adds `pol_balance`/`usdc_e_balance` in EOA mode; filters zero-value resolved losing positions (Data API cache doesn't clear these after on-chain redeem); adds `positions` alias
- `sell` in POLY_PROXY mode — skip CLOB `/balance-allowance` pre-flight (endpoint returns 0 for proxy wallets regardless of actual balance)
- `buy` in POLY_PROXY mode — skip per-trade approve (done once via `setup-proxy`)

### Bug fixes

- `setup-proxy` idempotency: `get_usdc_allowance` was returning 0 for MAX_UINT256 due to u128 overflow on the 64-char `f` hex string — fixed with string-length check before parsing
- Mode-mismatch hints in `buy`/`sell` error messages
- RPC: `polygon-rpc.com` → `polygon.drpc.org` (improved reliability)

## Test plan

- [ ] `polymarket balance` — shows EOA POL + USDC.e; shows proxy wallet if configured
- [ ] `polymarket setup-proxy --dry-run` — preview without tx
- [ ] `polymarket setup-proxy` — deploys proxy, runs 6 approvals, idempotent on re-run
- [ ] `polymarket deposit --amount 10 --dry-run` — preview
- [ ] `polymarket deposit --amount 10` — transfers USDC.e to proxy
- [ ] `polymarket withdraw --amount 5 --dry-run` — preview
- [ ] `polymarket switch-mode --mode proxy` / `--mode eoa`
- [ ] `polymarket buy --market-id <slug> --outcome yes --amount 1 --dry-run` — works in both modes
- [ ] `polymarket sell --market-id <slug> --outcome yes --shares 1 --dry-run` — works in both modes
- [ ] `polymarket positions` (alias) — returns same as `get-positions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)