### PR TITLE
fix(hyperliquid): balance pre-flight, size/price precision, address default (v0.3.2)

### DIFF
--- a/skills/hyperliquid-plugin/.claude-plugin/plugin.json
+++ b/skills/hyperliquid-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperliquid",
   "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/hyperliquid-plugin/Cargo.lock
+++ b/skills/hyperliquid-plugin/Cargo.lock
@@ -541,8 +541,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperliquid"
-version = "0.3.1"
+name = "hyperliquid-plugin"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/hyperliquid-plugin/Cargo.toml
+++ b/skills/hyperliquid-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperliquid-plugin"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/hyperliquid-plugin/SKILL.md
+++ b/skills/hyperliquid-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyperliquid
 description: Hyperliquid DEX — trade perps & spot, deposit from Arbitrum, withdraw to Arbitrum, transfer between perp and spot accounts, manage gas on HyperEVM.
-version: 0.3.1
+version: 0.3.2
 author: GeoGu360
 tags:
   - perps
@@ -60,7 +60,7 @@ OS=$(uname -s | tr A-Z a-z)
     mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
   esac
   mkdir -p ~/.local/bin
-  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.1/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
+  curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.2/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
   chmod +x ~/.local/bin/.hyperliquid-plugin-core${EXT}
 
 # Generate wrapper script (version check + exec core binary)
@@ -99,7 +99,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"hyperliquid-plugin","version":"0.3.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"hyperliquid-plugin","version":"0.3.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -347,6 +347,15 @@ hyperliquid order \
 
 **Display:** `coin`, `side`, `size`, `type`, `currentMidPrice`, `stopLoss`, `takeProfit`. Do not render raw action payloads.
 
+**Pre-flight balance check:**
+Before each order the binary queries Perp + Spot + Arbitrum USDC balances in parallel and shows a `fund_landscape` table in the preview. If the estimated required margin (`notional / leverage`) exceeds `perp_withdrawable`, the command stops immediately with a `tip` pointing to `transfer` (Spot→Perp) or `deposit` (Arbitrum→Perp).
+
+**Size precision & minimum notional:**
+`--size` is automatically rounded to the coin's `szDecimals` (BTC: 5 dp, ETH: 4 dp, etc.). If the resulting notional is below the exchange minimum of **$10**, one lot is silently added and logged to stderr.
+
+**SL/TP price precision:**
+All prices (trigger + worst-fill limit) are automatically rounded to the coin's tick size via `szDecimals` significant-figure rounding (BTC → integers, ETH → 1 dp, SOL → 2 dp). Raw decimal values like `63683.1` or `77834.9` are rounded without user action.
+
 **Bracket order behavior:**
 - When `--sl-px` or `--tp-px` is provided, the request uses `grouping: normalTpsl`
 - TP/SL child orders are linked to the entry — they activate only when the entry fills
@@ -426,6 +435,8 @@ hyperliquid tpsl --coin BTC --tp-px 110000 --size 0.005 --confirm
 - SL must be **below** current price for longs; **above** for shorts
 - TP must be **above** current price for longs; **below** for shorts
 - Both use market execution with 10% slippage tolerance (matching HL UI default)
+
+**Price precision:** trigger and worst-fill prices are automatically rounded to the coin's tick size (`szDecimals` significant figures). Pass any decimal value — the binary will round it silently (e.g. `63683.1 → 63683` for BTC).
 
 **Note:** SL and TP are placed as independent orders (`grouping: na`). Whichever triggers first closes the position; cancel the other manually or place a new `tpsl` to replace it.
 
@@ -657,14 +668,14 @@ hyperliquid transfer --amount 10 --direction spot-to-perp --confirm
 
 ### 12. `address` — Show Wallet Address & Balances
 
-Displays your wallet address with USDC balance. Defaults to HyperEVM; use `--arbitrum` or `--all`.
+Displays your wallet address with USDC balance. Defaults to **Arbitrum** (most useful for deposit flow). Use `--hyp-evm` to show HyperEVM (USDC contract TBD), or `--all` for both.
 
 ```bash
-# HyperEVM address (default)
+# Arbitrum address + USDC balance (default)
 hyperliquid address
 
-# Arbitrum address
-hyperliquid address --arbitrum
+# HyperEVM address (opt-in)
+hyperliquid address --hyp-evm
 
 # Both addresses with balances
 hyperliquid address --all
@@ -864,6 +875,13 @@ All data returned by `hyperliquid positions`, `hyperliquid prices`, and exchange
 ---
 
 ## Changelog
+
+### v0.3.2 (2026-04-13)
+
+- **fix**: `order` — balance pre-flight: queries Perp + Spot + Arbitrum USDC in parallel before every order; stops early with fund landscape + deposit/transfer tip if perp balance is insufficient
+- **fix**: `order` — size precision: auto-rounds `--size` to `szDecimals`; auto-bumps by one lot if notional < $10 to meet exchange minimum
+- **fix**: `order` / `tpsl` — SL/TP price precision: trigger and worst-fill limit prices now use `round_px` (szDecimals significant figures) instead of raw `format_px`; eliminates "Price must be divisible by tick size" rejections
+- **fix**: `address` — HyperEVM hidden by default (USDC contract placeholder); Arbitrum is now the default display; use `--hyp-evm` to opt in
 
 ### v0.3.1 (2026-04-12)
 

--- a/skills/hyperliquid-plugin/plugin.yaml
+++ b/skills/hyperliquid-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: hyperliquid-plugin
-version: "0.3.1"
+version: "0.3.2"
 description: "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC"
 author:
   name: GeoGu360

--- a/skills/hyperliquid-plugin/src/commands/address.rs
+++ b/skills/hyperliquid-plugin/src/commands/address.rs
@@ -6,18 +6,23 @@ use crate::config::{USDC_ARBITRUM, USDC_HYPER_EVM};
 
 #[derive(Args)]
 pub struct AddressArgs {
-    /// Show Arbitrum address instead of HyperEVM
+    /// Also show HyperEVM address (hidden by default — USDC contract TBD)
+    #[arg(long)]
+    pub hyp_evm: bool,
+
+    /// Show Arbitrum address (default behaviour, kept for explicitness)
     #[arg(long)]
     pub arbitrum: bool,
 
-    /// Show both addresses
+    /// Show all addresses (Arbitrum + HyperEVM)
     #[arg(long)]
     pub all: bool,
 }
 
 pub async fn run(args: AddressArgs) -> anyhow::Result<()> {
-    let show_hyp = !args.arbitrum || args.all;
-    let show_arb = args.arbitrum || args.all;
+    // HyperEVM is opt-in: USDC contract is still a placeholder (0x0000…).
+    let show_hyp = args.hyp_evm || args.all;
+    let show_arb = !args.hyp_evm || args.all || args.arbitrum;
 
     if show_hyp {
         let wallet = resolve_wallet(CHAIN_ID)?;

--- a/skills/hyperliquid-plugin/src/commands/order.rs
+++ b/skills/hyperliquid-plugin/src/commands/order.rs
@@ -1,11 +1,12 @@
 use clap::Args;
-use crate::api::{get_asset_meta, get_all_mids};
-use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
+use crate::api::{get_asset_meta, get_all_mids, get_clearinghouse_state, get_spot_clearinghouse_state};
+use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID, USDC_ARBITRUM};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
+use crate::rpc::{ARBITRUM_RPC, erc20_balance};
 use crate::signing::{
     build_bracketed_order_action, build_limit_order_action, build_market_order_action,
     build_update_leverage_action,
-    format_px, market_slippage_px, submit_exchange_request,
+    format_px, round_px, market_slippage_px, submit_exchange_request,
 };
 
 #[derive(Args)]
@@ -60,15 +61,25 @@ pub struct OrderArgs {
     pub confirm: bool,
 }
 
+/// Format a size value to exactly `decimals` decimal places, trimming trailing zeros.
+fn fmt_size(sz: f64, decimals: u32) -> String {
+    if decimals == 0 {
+        format!("{:.0}", sz)
+    } else {
+        let s = format!("{:.prec$}", sz, prec = decimals as usize);
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    }
+}
+
 pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     let info = info_url();
     let exchange = exchange_url();
-
     let coin = normalize_coin(&args.coin);
     let is_buy = args.side.to_lowercase() == "buy";
     let nonce = now_ms();
 
-    let _size_check: f64 = args
+    // Validate size is a number
+    let size_f: f64 = args
         .size
         .parse()
         .map_err(|_| anyhow::anyhow!("Invalid size '{}' — must be a number (e.g. 0.01)", args.size))?;
@@ -90,29 +101,156 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         }
     }
 
-    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
+    // ─── Fetch meta + prices concurrently ────────────────────────────────────
+    let ((asset_idx, sz_decimals), mids) = tokio::try_join!(
+        get_asset_meta(info, &coin),
+        get_all_mids(info)
+    )?;
 
-    let mids = get_all_mids(info).await?;
     let current_price = mids
         .get(&coin)
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
-
-    // Slippage-protected price for market orders — 5% tolerance, rounded to HL's
-    // sz_decimals significant figures (matches Python SDK round_to_sz_decimals).
     let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
+
+    // ─── Size: round to szDecimals, then auto-bump if notional < $10 ─────────
+    let sz_factor = 10_f64.powi(sz_decimals as i32);
+    let mut size_rounded = (size_f * sz_factor).round() / sz_factor;
+
+    if mid_f > 0.0 {
+        let n = size_rounded * mid_f;
+        if n > 0.0 && n < 10.0 {
+            let bumped = size_rounded + 1.0 / sz_factor;
+            eprintln!(
+                "[auto-adjust] size {} → {} to meet $10 minimum notional (${:.2} → ${:.2})",
+                fmt_size(size_rounded, sz_decimals),
+                fmt_size(bumped, sz_decimals),
+                n,
+                bumped * mid_f,
+            );
+            size_rounded = bumped;
+        }
+    }
+    let size_str = fmt_size(size_rounded, sz_decimals);
+    let notional = size_rounded * mid_f;
+
+    // Slippage-protected price for market orders
     let slippage_px_str = market_slippage_px(mid_f, is_buy, sz_decimals);
 
+    // ─── SL/TP prices rounded to correct precision ────────────────────────────
+    let sl_px_str = args.sl_px.map(|px| round_px(px, sz_decimals));
+    let tp_px_str = args.tp_px.map(|px| round_px(px, sz_decimals));
+
+    // ─── Balance pre-flight (non-fatal — skip if wallet not connected) ────────
+    // Shows Perp + Spot + Arbitrum. HyperEVM excluded per user preference.
+    let wallet_opt = resolve_wallet(CHAIN_ID).ok();
+    let arb_wallet_opt = resolve_wallet(ARBITRUM_CHAIN_ID).ok();
+
+    struct Balances {
+        perp: f64,
+        spot: f64,
+        arb: f64,
+    }
+
+    let balances_opt: Option<Balances> = if let Some(ref w) = wallet_opt {
+        let aw_clone = arb_wallet_opt.clone();
+        let (perp_res, spot_res, arb_raw) = tokio::join!(
+            get_clearinghouse_state(info, w),
+            get_spot_clearinghouse_state(info, w),
+            async move {
+                match aw_clone.as_deref() {
+                    Some(aw) => erc20_balance(USDC_ARBITRUM, aw, ARBITRUM_RPC)
+                        .await
+                        .unwrap_or(0),
+                    None => 0u128,
+                }
+            }
+        );
+
+        let perp = perp_res
+            .ok()
+            .and_then(|s| s["withdrawable"].as_str()?.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        let spot = spot_res
+            .ok()
+            .and_then(|s| {
+                s["balances"].as_array()?.iter()
+                    .find(|b| b["coin"].as_str() == Some("USDC"))?
+                    ["total"]
+                    .as_str()?
+                    .parse::<f64>()
+                    .ok()
+            })
+            .unwrap_or(0.0);
+
+        Some(Balances { perp, spot, arb: arb_raw as f64 / 1_000_000.0 })
+    } else {
+        None
+    };
+
+    // Estimate required margin; default to 10x if --leverage not provided
+    let effective_leverage = args.leverage.map(|l| l as f64).unwrap_or(10.0);
+    let required_margin = if notional > 0.0 { notional / effective_leverage } else { 0.0 };
+
+    // Build balance landscape JSON (included in preview + stop output)
+    let balance_json = balances_opt.as_ref().map(|b| {
+        serde_json::json!({
+            "perp_withdrawable": format!("{:.4}", b.perp),
+            "spot_usdc":         format!("{:.4}", b.spot),
+            "arbitrum_usdc":     format!("{:.4}", b.arb),
+            "total_usdc":        format!("{:.4}", b.perp + b.spot + b.arb),
+        })
+    });
+
+    // Gate: STOP if perp balance is clearly insufficient
+    if let Some(ref b) = balances_opt {
+        if b.perp < required_margin {
+            let shortfall = required_margin - b.perp;
+            let tip = if b.spot >= shortfall {
+                format!(
+                    "Spot has enough USDC. Run: hyperliquid transfer --amount {:.2} --from spot",
+                    shortfall
+                )
+            } else if b.arb >= shortfall {
+                format!(
+                    "Arbitrum has enough USDC. Run: hyperliquid deposit --amount {:.2}",
+                    shortfall
+                )
+            } else {
+                format!(
+                    "Total across all accounts: ${:.2}. Add ${:.2} more USDC (e.g. via `hyperliquid deposit`).",
+                    b.perp + b.spot + b.arb,
+                    shortfall
+                )
+            };
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": false,
+                    "error": "Insufficient perp balance",
+                    "notional_usd": format!("${:.2}", notional),
+                    "estimated_leverage": format!("{}x", effective_leverage as u32),
+                    "required_margin_est": format!("${:.4}", required_margin),
+                    "shortfall": format!("${:.4}", shortfall),
+                    "fund_landscape": balance_json,
+                    "tip": tip,
+                }))?
+            );
+            return Ok(());
+        }
+    }
+
+    // ─── Build action ────────────────────────────────────────────────────────
     let has_bracket = args.sl_px.is_some() || args.tp_px.is_some();
 
-    // Build the entry order element (without the wrapper)
     let action = if has_bracket {
         let entry_element = match args.r#type.as_str() {
             "market" => serde_json::json!({
                 "a": asset_idx,
                 "b": is_buy,
                 "p": slippage_px_str,
-                "s": args.size,
+                "s": size_str,
                 "r": args.reduce_only,
                 "t": { "limit": { "tif": "Ioc" } }
             }),
@@ -128,7 +266,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                     "a": asset_idx,
                     "b": is_buy,
                     "p": price_str,
-                    "s": args.size,
+                    "s": size_str,
                     "r": args.reduce_only,
                     "t": { "limit": { "tif": "Gtc" } }
                 })
@@ -136,20 +274,18 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
         };
 
-        let sl_px_str = args.sl_px.map(format_px);
-        let tp_px_str = args.tp_px.map(format_px);
-
         build_bracketed_order_action(
             entry_element,
             asset_idx,
             is_buy,
-            &args.size,
+            &size_str,
             sl_px_str.as_deref(),
             tp_px_str.as_deref(),
+            sz_decimals,
         )
     } else {
         match args.r#type.as_str() {
-            "market" => build_market_order_action(asset_idx, is_buy, &args.size, args.reduce_only, &slippage_px_str),
+            "market" => build_market_order_action(asset_idx, is_buy, &size_str, args.reduce_only, &slippage_px_str),
             "limit" => {
                 let price_str = args
                     .price
@@ -158,7 +294,7 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                 let _: f64 = price_str
                     .parse()
                     .map_err(|_| anyhow::anyhow!("Invalid price '{}'", price_str))?;
-                build_limit_order_action(asset_idx, is_buy, price_str, &args.size, args.reduce_only, "Gtc")
+                build_limit_order_action(asset_idx, is_buy, price_str, &size_str, args.reduce_only, "Gtc")
             }
             _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
         }
@@ -168,24 +304,31 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         format!("{}x {}", l, if args.isolated { "isolated" } else { "cross" })
     });
 
+    // ─── Preview ─────────────────────────────────────────────────────────────
+    let mut preview_obj = serde_json::json!({
+        "coin": coin,
+        "assetIndex": asset_idx,
+        "side": args.side,
+        "size": size_str,
+        "notional_usd": format!("{:.2}", notional),
+        "type": args.r#type,
+        "price": args.price,
+        "leverage": leverage_preview,
+        "stopLoss": sl_px_str,
+        "takeProfit": tp_px_str,
+        "reduceOnly": args.reduce_only,
+        "currentMidPrice": current_price,
+        "grouping": if has_bracket { "normalTpsl" } else { "na" },
+        "nonce": nonce
+    });
+    if let Some(ref bj) = balance_json {
+        preview_obj["fund_landscape"] = bj.clone();
+    }
+
     println!(
         "{}",
         serde_json::to_string_pretty(&serde_json::json!({
-            "preview": {
-                "coin": coin,
-                "assetIndex": asset_idx,
-                "side": args.side,
-                "size": args.size,
-                "type": args.r#type,
-                "price": args.price,
-                "leverage": leverage_preview,
-                "stopLoss": args.sl_px.map(format_px),
-                "takeProfit": args.tp_px.map(format_px),
-                "reduceOnly": args.reduce_only,
-                "currentMidPrice": current_price,
-                "grouping": if has_bracket { "normalTpsl" } else { "na" },
-                "nonce": nonce
-            },
+            "preview": preview_obj,
             "action": action
         }))?
     );
@@ -202,7 +345,9 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    // ─── Submit ───────────────────────────────────────────────────────────────
+    let wallet = wallet_opt
+        .ok_or_else(|| anyhow::anyhow!("Cannot resolve wallet. Log in via onchainos."))?;
 
     // Set leverage before placing the order if --leverage was provided
     if let Some(lev) = args.leverage {
@@ -233,10 +378,11 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             "ok": true,
             "coin": coin,
             "side": args.side,
-            "size": args.size,
+            "size": size_str,
+            "notional_usd": format!("{:.2}", notional),
             "type": args.r#type,
-            "stopLoss": args.sl_px.map(format_px),
-            "takeProfit": args.tp_px.map(format_px),
+            "stopLoss": sl_px_str,
+            "takeProfit": tp_px_str,
             "result": result
         }))?
     );

--- a/skills/hyperliquid-plugin/src/commands/tpsl.rs
+++ b/skills/hyperliquid-plugin/src/commands/tpsl.rs
@@ -1,8 +1,8 @@
 use clap::Args;
-use crate::api::{get_asset_index, get_all_mids, get_clearinghouse_state};
+use crate::api::{get_asset_meta, get_all_mids, get_clearinghouse_state};
 use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
-use crate::signing::{build_standalone_tpsl_action, format_px, submit_exchange_request};
+use crate::signing::{build_standalone_tpsl_action, format_px, round_px, submit_exchange_request};
 
 #[derive(Args)]
 pub struct TpslArgs {
@@ -41,7 +41,7 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
     let coin = normalize_coin(&args.coin);
     let nonce = now_ms();
 
-    let asset_idx = get_asset_index(info, &coin).await?;
+    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
     let wallet = resolve_wallet(CHAIN_ID)?;
 
     // Auto-detect position direction and size
@@ -138,8 +138,11 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         None => format!("{}", position_size),
     };
 
-    let sl_px_str = args.sl_px.map(format_px);
-    let tp_px_str = args.tp_px.map(format_px);
+    // Round TP/SL prices to the correct precision for this coin (matches HL's szDecimals rule).
+    // format_px uses raw 6-decimal truncation; round_px applies significant-figure rounding
+    // so BTC prices become integers, ETH/SOL prices round to the correct decimal count.
+    let sl_px_str = args.sl_px.map(|px| round_px(px, sz_decimals));
+    let tp_px_str = args.tp_px.map(|px| round_px(px, sz_decimals));
 
     let action = build_standalone_tpsl_action(
         asset_idx,
@@ -147,18 +150,19 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         &size_str,
         sl_px_str.as_deref(),
         tp_px_str.as_deref(),
+        sz_decimals,
     );
 
     // Compute implied slippage limit prices for display
     let sl_limit_display = args.sl_px.map(|px| {
         let closing_is_buy = !position_is_long;
         let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        format_px(limit)
+        round_px(limit, sz_decimals)
     });
     let tp_limit_display = args.tp_px.map(|px| {
         let closing_is_buy = !position_is_long;
         let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        format_px(limit)
+        round_px(limit, sz_decimals)
     });
 
     println!(
@@ -173,12 +177,12 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
                 "currentMidPrice": current_price_str,
                 "liquidationPrice": liquidation_px_str,
                 "stopLoss": args.sl_px.map(|px| serde_json::json!({
-                    "triggerPx": format_px(px),
+                    "triggerPx": round_px(px, sz_decimals),
                     "executionType": "market",
                     "worstFillPx": sl_limit_display
                 })),
                 "takeProfit": args.tp_px.map(|px| serde_json::json!({
-                    "triggerPx": format_px(px),
+                    "triggerPx": round_px(px, sz_decimals),
                     "executionType": "market",
                     "worstFillPx": tp_limit_display
                 })),

--- a/skills/hyperliquid-plugin/src/signing.rs
+++ b/skills/hyperliquid-plugin/src/signing.rs
@@ -60,13 +60,14 @@ pub fn market_slippage_px(mid_px: f64, is_buy: bool, sz_decimals: u32) -> String
 /// Slippage-protected limit price for market trigger orders.
 /// When a trigger fires as "market", HL still needs a worst-acceptable-price.
 /// Convention: 10% slippage tolerance (same as HL web UI default).
-fn trigger_limit_px(trigger_px: f64, is_buy: bool) -> String {
+/// Uses round_px so the limit price obeys the same tick-size rules as the trigger price.
+fn trigger_limit_px(trigger_px: f64, is_buy: bool, sz_decimals: u32) -> String {
     let px = if is_buy {
         trigger_px * 1.1
     } else {
         trigger_px * 0.9
     };
-    format_px(px)
+    round_px(px, sz_decimals)
 }
 
 // ─── Entry orders ────────────────────────────────────────────────────────────
@@ -171,6 +172,7 @@ pub fn build_trigger_order_element(
     trigger_px_str: &str,
     is_market: bool,
     limit_px_override: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let is_buy = !position_is_long; // close opposite of entry
 
@@ -178,7 +180,7 @@ pub fn build_trigger_order_element(
         Some(px) => px.to_string(),
         None if is_market => {
             let trigger_px: f64 = trigger_px_str.parse().unwrap_or(0.0);
-            trigger_limit_px(trigger_px, is_buy)
+            trigger_limit_px(trigger_px, is_buy, sz_decimals)
         }
         None => trigger_px_str.to_string(),
     };
@@ -208,17 +210,18 @@ pub fn build_standalone_tpsl_action(
     size_str: &str,
     sl_px: Option<&str>,
     tp_px: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let mut orders = vec![];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "sl", px, true, None,
+            asset, position_is_long, size_str, "sl", px, true, None, sz_decimals,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "tp", px, true, None,
+            asset, position_is_long, size_str, "tp", px, true, None, sz_decimals,
         ));
     }
 
@@ -239,18 +242,19 @@ pub fn build_bracketed_order_action(
     size_str: &str,
     sl_px: Option<&str>,
     tp_px: Option<&str>,
+    sz_decimals: u32,
 ) -> Value {
     let entry_is_long = position_is_long;
     let mut orders = vec![entry_order];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "sl", px, true, None,
+            asset, entry_is_long, size_str, "sl", px, true, None, sz_decimals,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "tp", px, true, None,
+            asset, entry_is_long, size_str, "tp", px, true, None, sz_decimals,
         ));
     }
 


### PR DESCRIPTION
## Summary

Three UX bugs reported by users, verified with live on-chain tests:

- **Balance pre-flight** (`order`): query Perp + Spot + Arbitrum USDC in parallel before every order; stop immediately with `fund_landscape` table + deposit/transfer tip if perp balance is insufficient. Eliminates the "place order → fail → user doesn't know where their money is" loop.

- **Size & minimum notional** (`order`): auto-round `--size` to `szDecimals` precision; if rounded notional < \$10 (exchange minimum), silently add one lot and log to stderr. Verified: `0.00014 BTC` → `0.00015 BTC`, order filled.

- **SL/TP price precision** (`order`, `tpsl`): trigger prices and worst-fill limit prices now use `round_px` (szDecimals significant-figure rounding) instead of `format_px` (raw 6-decimal). Eliminates repeated `"Price must be divisible by tick size"` rejections. Verified: `63683.1 → 63683`, `77834.9 → 77835`, both orders `resting`.

- **`address` default** (`address`): HyperEVM hidden by default (USDC contract is still `0x0000…` placeholder); Arbitrum is now the default view; `--hyp-evm` opts in.

## Test plan

- [x] Bug 1: `order --size 2 --confirm` → stopped before API, fund landscape shown
- [x] Bug 2: `order --size 0.00014 --confirm` → auto-bumped to `0.00015`, filled on-chain (oid 379580281695)
- [x] Bug 3: `tpsl --sl-px 63683.1 --tp-px 77834.9 --confirm` → prices rounded to integers, both orders resting (oid 379581844512/513)
- [x] `address` → shows Arbitrum only by default; `--hyp-evm` and `--all` work correctly
- [x] `cargo build` clean at v0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)