### PR TITLE
[new-plugin] trustx-plugin v1.0.0

### DIFF
--- a/skills/trustx-plugin/.claude-plugin/plugin.json
+++ b/skills/trustx-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "trustx-plugin",
+  "description": "ERC-8004 reputation scoring and trust-policy gating for X Layer agents",
+  "version": "1.0.0",
+  "author": {
+    "name": "Alanas"
+  },
+  "license": "MIT",
+  "keywords": ["xlayer", "erc-8004", "reputation", "trust", "risk", "agent"]
+}

--- a/skills/trustx-plugin/.claude-plugin/plugin.json
+++ b/skills/trustx-plugin/.claude-plugin/plugin.json
@@ -3,8 +3,11 @@
   "description": "ERC-8004 reputation scoring and trust-policy gating for X Layer agents",
   "version": "1.0.0",
   "author": {
-    "name": "Alanas"
+    "name": "Alanas",
+    "email": "ananas@users.noreply.github.com"
   },
+  "homepage": "https://github.com/Ananas310/best-x-layer-skill",
+  "repository": "https://github.com/Ananas310/best-x-layer-skill",
   "license": "MIT",
   "keywords": ["xlayer", "erc-8004", "reputation", "trust", "risk", "agent"]
 }

--- a/skills/trustx-plugin/LICENSE
+++ b/skills/trustx-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 skylavis-sky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/trustx-plugin/README.md
+++ b/skills/trustx-plugin/README.md
@@ -1,0 +1,11 @@
+# trustx-plugin
+
+Plugin Store skill wrapper for TrustX (ERC-8004 trust scoring on X Layer).
+
+## Upstream code
+
+- Repo: https://github.com/Ananas310/best-x-layer-skill
+
+## Purpose
+
+Provide AI-agent guidance for trust checks and policy-based allow/sandbox/block decisions before high-risk actions.

--- a/skills/trustx-plugin/README.md
+++ b/skills/trustx-plugin/README.md
@@ -1,11 +1,13 @@
 # trustx-plugin
 
-Plugin Store skill wrapper for TrustX (ERC-8004 trust scoring on X Layer).
+Plugin Store plugin for TrustX (ERC-8004 trust scoring + policy gating on X Layer).
 
-## Upstream code
+## Upstream source (pinned by plugin.yaml)
 
 - Repo: https://github.com/Ananas310/best-x-layer-skill
+- Commit: c1fb4c2c7f7b0484a120ee727124602c0008f2c9
+- Entry: src/cli.js (node)
 
 ## Purpose
 
-Provide AI-agent guidance for trust checks and policy-based allow/sandbox/block decisions before high-risk actions.
+Provide AI-agent guidance and executable CLI integration for trust checks and policy-based allow/sandbox/block decisions before high-risk actions.

--- a/skills/trustx-plugin/SKILL.md
+++ b/skills/trustx-plugin/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: trustx-plugin
+description: "ERC-8004 reputation scoring and trust-policy gating for X Layer agents"
+version: "1.0.0"
+author: "Alanas"
+tags:
+  - xlayer
+  - erc-8004
+  - reputation
+  - trust
+  - risk
+---
+
+# TrustX Plugin
+
+Use this skill when the user asks to assess trust/reputation of an X Layer agent before collaboration, delegation, approvals, wallet-signing, or autonomous execution.
+
+## What it does
+
+TrustX runs an ERC-8004 reputation check and returns a decision packet:
+- `score` (0-100)
+- `confidence` (0-1)
+- `rating` (`high|medium|low|unknown`)
+- policy verdict (`allow|sandbox|block`) via preset rules (`strict|balanced|growth`)
+
+## Preconditions
+
+1. Node.js >= 20.10.0
+2. Repository available: `https://github.com/Ananas310/best-x-layer-skill`
+3. Optional for OnchainOS primary path:
+   - `OKX_ONCHAINOS_API_KEY`
+   - `OKX_ONCHAINOS_SECRET_KEY`
+   - `OKX_ONCHAINOS_PASSPHRASE`
+
+If credentials are missing, TrustX can still run in RPC mode with lower signal coverage.
+
+## Install / Run
+
+```bash
+git clone https://github.com/Ananas310/best-x-layer-skill.git
+cd best-x-layer-skill
+npm install
+npm test
+```
+
+Quick trust check:
+
+```bash
+node src/cli.js --agent 1 --pretty
+```
+
+Strict live check:
+
+```bash
+npm run smoke:live:strict
+```
+
+## Integration Pattern
+
+```js
+import { getReputation, evaluateTrustPolicy } from '8004-reputation-skill';
+
+const report = await getReputation('1', { source: 'auto' });
+const verdict = evaluateTrustPolicy(report, {
+  preset: 'strict',
+  risk: 'high',
+});
+
+// verdict.decision.action => allow | sandbox | block
+```
+
+## When to use which preset
+
+- `strict`: wallet signing, fund control, irreversible actions
+- `balanced`: normal production delegation
+- `growth`: onboarding/new-agent exploration with safeguards
+
+## Error Handling
+
+| Error / Signal | Meaning | Action |
+|---|---|---|
+| `ok: false` | Request failed/invalid input | Stop and ask for valid `agentId/address/handle` |
+| `rating: unknown` | Insufficient trust evidence | Use `sandbox` path and reduce permissions |
+| `meta.indexerError` set | OnchainOS path unavailable/missing credentials | Continue in RPC mode, lower confidence expectations |
+| low `confidence` | Sparse/disagreeing signals | Require human review for high-risk operations |
+
+## Security Notes
+
+- Do not grant signing authority on score alone; gate on score + confidence + policy.
+- For high-risk actions, require `strict` preset and `high` rating.
+- Never expose OnchainOS credentials in logs, prompts, or commits.
+- `.env` must remain untracked in git.

--- a/skills/trustx-plugin/SKILL.md
+++ b/skills/trustx-plugin/SKILL.md
@@ -36,20 +36,29 @@ If credentials are missing, TrustX can still run in RPC mode with lower signal c
 
 ## Install / Run
 
+Primary (plugin install path):
+
+```bash
+npx skills add okx/plugin-store --skill trustx-plugin
+```
+
+Then run the installed command:
+
+```bash
+rep8004 --agent 1 --pretty
+```
+
+Source fallback (for local development/debug):
+
 ```bash
 git clone https://github.com/Ananas310/best-x-layer-skill.git
 cd best-x-layer-skill
 npm install
 npm test
-```
-
-Quick trust check:
-
-```bash
 node src/cli.js --agent 1 --pretty
 ```
 
-Strict live check:
+Strict live check (source repo flow):
 
 ```bash
 npm run smoke:live:strict

--- a/skills/trustx-plugin/SKILL_SUMMARY.md
+++ b/skills/trustx-plugin/SKILL_SUMMARY.md
@@ -1,0 +1,1 @@
+Use TrustX to decide if an agent should be allowed, sandboxed, or blocked before delegation/signing.

--- a/skills/trustx-plugin/SUMMARY.md
+++ b/skills/trustx-plugin/SUMMARY.md
@@ -1,0 +1,1 @@
+TrustX provides ERC-8004 reputation scoring plus policy gating presets (strict, balanced, growth) for X Layer agents.

--- a/skills/trustx-plugin/plugin.yaml
+++ b/skills/trustx-plugin/plugin.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+name: trustx-plugin
+version: "1.0.0"
+description: "ERC-8004 reputation scoring and trust-policy gating for X Layer agents"
+author:
+  name: "Alanas"
+  github: "Ananas310"
+license: MIT
+category: security
+tags:
+  - xlayer
+  - erc-8004
+  - reputation
+  - trust
+  - risk
+  - agent
+
+components:
+  skill:
+    dir: .
+
+api_calls:
+  - "https://www.oklink.com/api/v5/explorer/log/by-address-and-topic"
+  - "https://xlayerrpc.okx.com"
+  - "https://rpc.xlayer.tech"

--- a/skills/trustx-plugin/plugin.yaml
+++ b/skills/trustx-plugin/plugin.yaml
@@ -19,6 +19,14 @@ components:
   skill:
     dir: .
 
+build:
+  lang: node
+  source_repo: "Ananas310/best-x-layer-skill"
+  source_commit: "c1fb4c2c7f7b0484a120ee727124602c0008f2c9"
+  source_dir: "."
+  binary_name: "rep8004"
+  main: "src/cli.js"
+
 api_calls:
   - "https://www.oklink.com/api/v5/explorer/log/by-address-and-topic"
   - "https://xlayerrpc.okx.com"


### PR DESCRIPTION
## Summary
Add new Skill-only plugin: trustx-plugin.

## What it does
- ERC-8004 reputation scoring guidance for X Layer agents
- Trust-policy gating presets (strict / balanced / growth)
- Clear install/run/integration instructions pointing to public upstream repo

## Validation
- plugin-store lint skills/trustx-plugin ✅

## Scope
- Only adds files under skills/trustx-plugin/