### PR TITLE
fix(polymarket): smart deposit advisor, native token guard (v0.4.1)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -350,6 +350,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,10 +381,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -389,8 +426,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1000,13 +1039,14 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64",
  "chrono",
  "clap",
  "dirs",
+ "futures",
  "getrandom 0.2.17",
  "hex",
  "hmac",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [[bin]]
@@ -22,3 +22,4 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
 hex = "0.4"
 getrandom = { version = "0.2", features = ["std"] }
+futures = "0.3"

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit."
-version: "0.4.0"
+version: "0.4.1"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.0"
+LOCAL_VER="0.4.1"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.0/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.1/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/polymarket-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.4.0" > "$HOME/.plugin-store/managed/polymarket-plugin"
+echo "0.4.1" > "$HOME/.plugin-store/managed/polymarket-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -822,7 +822,13 @@ polymarket-plugin deposit --list
 - All other chains (ARB, BASE, OP, BNB, Monad): **$2** minimum
 - Polygon direct: no minimum
 
-**Missing parameters:** If `--amount` is not provided, the command returns `"missing_params": ["amount"]` and a `"hint"` field. The Agent **must ask the user** for the missing value before retrying — do not assume or default the amount.
+**Smart suggestion when `--amount` is omitted:** Instead of a plain error, the command runs a deposit advisor:
+1. Checks EOA USDC.e + POL balance on Polygon — if sufficient, recommends direct Polygon deposit.
+2. If Polygon is insufficient, scans all bridge-supported EVM chains in parallel and returns ranked alternatives sorted by available USD value.
+
+Response includes `"missing_params": ["amount"]`, `"deposit_suggestions"` (with `polygon` status + `alternatives` array), `"recommended_command"`, and `"hint"`. The Agent should present `hint` and `recommended_command` to the user, then ask how much to deposit.
+
+**Native token restriction:** Native coins (ETH, BNB, etc.) cannot be deposited — the bridge only detects ERC-20 transfers. Using `--token ETH` or `--token BNB` returns an error with the wrapped ERC-20 alternative (e.g. `--token WETH`, `--token WBNB`).
 
 **Auth required:** Yes — onchainos wallet
 

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.0"
+version: "0.4.1"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/deposit.rs
+++ b/skills/polymarket-plugin/src/commands/deposit.rs
@@ -114,38 +114,25 @@ pub async fn run(
     }
 
     // ── Normal deposit — amount required ────────────────────────────────────
-    // If amount is missing, return a structured response so the upstream Agent
-    // knows exactly which parameters to ask the user for before retrying.
-    let amount_str = match amount {
-        Some(a) => a,
-        None => {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "ok": false,
-                    "missing_params": ["amount"],
-                    "error": "Missing required parameter: --amount (USD value to deposit, e.g. 50 = $50).",
-                    "hint": "Please ask the user: how much USD do you want to deposit? \
-                             Also confirm: which chain to deposit from (default: polygon) \
-                             and which token to use (default: USDC)."
-                })
-            );
-            return Ok(());
-        }
-    };
+    let signer_addr = crate::onchainos::get_wallet_address().await?;
+    let creds = crate::auth::ensure_credentials(&client, &signer_addr).await?;
+    let proxy_wallet = creds.proxy_wallet.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("No proxy wallet configured. Run `polymarket setup-proxy` first.")
+    })?;
 
+    // If amount is missing: run smart suggestion flow instead of plain error.
+    if amount.is_none() {
+        suggest_deposit(&client, &signer_addr).await?;
+        return Ok(());
+    }
+
+    let amount_str = amount.unwrap();
     let amount_f: f64 = amount_str
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid amount: {}", amount_str))?;
     if amount_f <= 0.0 {
         bail!("amount must be positive");
     }
-
-    let signer_addr = crate::onchainos::get_wallet_address().await?;
-    let creds = crate::auth::ensure_credentials(&client, &signer_addr).await?;
-    let proxy_wallet = creds.proxy_wallet.as_ref().ok_or_else(|| {
-        anyhow::anyhow!("No proxy wallet configured. Run `polymarket setup-proxy` first.")
-    })?;
 
     // ── Resolve chain ────────────────────────────────────────────────────────
     let chain_id = resolve_chain_id(chain).ok_or_else(|| {
@@ -441,4 +428,143 @@ pub async fn run(
             }
         }
     }
+}
+
+// ── Smart deposit suggestion (called when --amount is omitted) ────────────────
+async fn suggest_deposit(client: &reqwest::Client, signer_addr: &str) -> anyhow::Result<()> {
+    const BRIDGE_CHAINS: &[(&str, &str, &str)] = &[
+        ("ethereum", "1",     "ethereum"),
+        ("arbitrum", "42161", "arbitrum"),
+        ("base",     "8453",  "base"),
+        ("optimism", "10",    "optimism"),
+        ("bnb",      "56",    "bnb"),
+        ("monad",    "143",   "monad"),
+    ];
+
+    // ── Step 1: Polygon check ────────────────────────────────────────────────
+    let (pol_bal, usdc_bal) = tokio::join!(
+        crate::onchainos::get_pol_balance(signer_addr),
+        crate::onchainos::get_usdc_balance(signer_addr),
+    );
+    let pol_balance = pol_bal.unwrap_or(0.0);
+    let usdc_e_usd = usdc_bal.unwrap_or(0.0);
+    let has_polygon_gas = pol_balance >= 0.1;
+
+    let polygon_info = serde_json::json!({
+        "usdc_e_usd": (usdc_e_usd * 100.0).round() / 100.0,
+        "pol_balance": (pol_balance * 10000.0).round() / 10000.0,
+        "has_gas": has_polygon_gas,
+        "command": format!("polymarket deposit --amount {:.0} --chain polygon --token USDC",
+                           usdc_e_usd.floor().max(1.0)),
+        "note": "Direct transfer on Polygon — no bridge fee, instant"
+    });
+
+    if usdc_e_usd >= 1.0 && has_polygon_gas {
+        let hint = format!(
+            "You have ${:.2} USDC.e on Polygon (recommended). \
+             Transfer more USDC.e to {} on Polygon if needed, then specify --amount.",
+            usdc_e_usd, signer_addr
+        );
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "missing_params": ["amount"],
+            "deposit_suggestions": {
+                "eoa_address": signer_addr,
+                "polygon": polygon_info,
+                "alternatives": [],
+                "recommended_command": format!(
+                    "polymarket deposit --amount {:.0} --chain polygon --token USDC",
+                    usdc_e_usd.floor().max(1.0)
+                )
+            },
+            "hint": hint
+        }))?);
+        return Ok(());
+    }
+
+    // ── Step 2: Polygon insufficient — scan bridge chains in parallel ─────────
+    eprintln!("[polymarket] Scanning balances across supported chains...");
+    let assets = crate::api::bridge_supported_assets(client).await.unwrap_or_default();
+
+    let min_usd_map: std::collections::HashMap<(String, String), f64> = assets
+        .iter()
+        .map(|a| ((a.chain_id.clone(), a.token.address.to_lowercase()), a.min_checkout_usd))
+        .collect();
+
+    let balance_futs: Vec<_> = BRIDGE_CHAINS
+        .iter()
+        .map(|(oc_chain, _, _)| crate::onchainos::get_chain_balances(oc_chain))
+        .collect();
+    let all_balances = futures::future::join_all(balance_futs).await;
+
+    let sentinel = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    let mut alternatives: Vec<serde_json::Value> = Vec::new();
+
+    for (i, balances) in all_balances.iter().enumerate() {
+        let (oc_chain, bridge_chain_id, chain_name) = BRIDGE_CHAINS[i];
+        for b in balances {
+            if b.usd_value < 1.0 { continue; }
+            let tok_addr = if b.token_address.is_empty() { sentinel.to_string() } else { b.token_address.clone() };
+            // Skip native tokens (bridge doesn't detect plain value transfers)
+            if tok_addr == sentinel { continue; }
+            let Some(&min) = min_usd_map.get(&(bridge_chain_id.to_string(), tok_addr)) else { continue };
+            if b.usd_value < min { continue; }
+            let deposit_amount = (b.usd_value * 0.98).floor().max(min);
+            alternatives.push(serde_json::json!({
+                "chain": chain_name,
+                "token": b.symbol,
+                "available_usd": (b.usd_value * 100.0).round() / 100.0,
+                "min_deposit_usd": min,
+                "command": format!(
+                    "polymarket deposit --amount {:.0} --chain {} --token {}",
+                    deposit_amount, oc_chain, b.symbol
+                )
+            }));
+        }
+    }
+
+    alternatives.sort_by(|a, b| {
+        b["available_usd"].as_f64().unwrap_or(0.0)
+            .partial_cmp(&a["available_usd"].as_f64().unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for (i, alt) in alternatives.iter_mut().enumerate() {
+        alt["rank"] = serde_json::json!(i + 1);
+    }
+
+    let recommended_command = alternatives
+        .first()
+        .and_then(|a| a["command"].as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!(
+            "Transfer USDC.e to {} on Polygon, then: polymarket deposit --amount <X> --chain polygon --token USDC",
+            signer_addr
+        ));
+
+    let hint = if let Some(top) = alternatives.first() {
+        format!(
+            "Recommended: {} (${:.2} available). Run: {}",
+            top["token"].as_str().unwrap_or(""),
+            top["available_usd"].as_f64().unwrap_or(0.0),
+            top["command"].as_str().unwrap_or("")
+        )
+    } else {
+        format!(
+            "No eligible assets found. Transfer USDC.e to {} on Polygon (chain 137) first.",
+            signer_addr
+        )
+    };
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "missing_params": ["amount"],
+        "deposit_suggestions": {
+            "eoa_address": signer_addr,
+            "polygon": polygon_info,
+            "alternatives": alternatives,
+            "recommended_command": recommended_command
+        },
+        "hint": hint
+    }))?);
+    Ok(())
 }

--- a/skills/polymarket-plugin/src/onchainos.rs
+++ b/skills/polymarket-plugin/src/onchainos.rs
@@ -862,6 +862,69 @@ pub async fn transfer_native_on_chain(chain: &str, to: &str, amount_wei: u128) -
     extract_tx_hash(&result)
 }
 
+/// A single token balance entry returned by `onchainos wallet balance`.
+#[derive(Debug, Clone)]
+pub struct ChainTokenBalance {
+    pub symbol: String,
+    pub token_address: String, // lowercase; empty string for native coin
+    pub usd_value: f64,
+    pub balance: String,
+    pub decimal: u8,
+}
+
+/// Call `onchainos wallet balance --chain <chain>` and return all token balances.
+/// Returns an empty vec on failure (non-fatal — used for best-effort suggestions).
+pub async fn get_chain_balances(chain: &str) -> Vec<ChainTokenBalance> {
+    let output = tokio::process::Command::new("onchainos")
+        .args(["wallet", "balance", "--chain", chain])
+        .output()
+        .await;
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return vec![],
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = match serde_json::from_str(stdout.trim()) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+    let assets = match v["data"]["details"]
+        .as_array()
+        .and_then(|d| d.first())
+        .and_then(|d| d["tokenAssets"].as_array())
+    {
+        Some(a) => a.clone(),
+        None => return vec![],
+    };
+    assets
+        .iter()
+        .filter_map(|a| {
+            let usd_value = a["usdValue"]
+                .as_str()
+                .and_then(|s| s.parse::<f64>().ok())
+                .or_else(|| a["usdValue"].as_f64())
+                .unwrap_or(0.0);
+            if usd_value <= 0.0 {
+                return None;
+            }
+            Some(ChainTokenBalance {
+                symbol: a["symbol"].as_str().unwrap_or("").to_string(),
+                token_address: a["tokenAddress"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_lowercase(),
+                usd_value,
+                balance: a["balance"].as_str().unwrap_or("0").to_string(),
+                decimal: a["decimal"]
+                    .as_str()
+                    .and_then(|s| s.parse().ok())
+                    .or_else(|| a["decimal"].as_u64().map(|n| n as u8))
+                    .unwrap_or(18),
+            })
+        })
+        .collect()
+}
+
 pub async fn is_ctf_approved_for_all(owner: &str, operator: &str) -> Result<bool> {
     use crate::config::{Contracts, Urls};
     // isApprovedForAll(address,address) selector = 0xe985e9c5


### PR DESCRIPTION
## Summary

- **Smart deposit advisor**: when `--amount` is omitted, instead of a plain error the command now checks Polygon USDC.e + POL balance first; if insufficient, scans all bridge-supported EVM chains in parallel and returns alternatives ranked by available USD value. Response includes `recommended_command` and `hint` for the Agent to present directly to the user.
- **Native token guard**: native coins (ETH, BNB, etc.) are now blocked before any on-chain action — the bridge only detects ERC-20 Transfer events, so native value transfers would be silently lost. The error message suggests the wrapped ERC-20 alternative (WETH, WBNB).
- **New `get_chain_balances(chain)`** in onchainos.rs: calls `onchainos wallet balance` and returns token list with usd_value; returns empty vec on failure (non-fatal).
- Added `futures = "0.3"` dependency for `join_all` parallel chain scanning.

## Test plan

- [ ] `polymarket deposit` (no args) → returns `deposit_suggestions` JSON with Polygon info and `recommended_command`
- [ ] `polymarket deposit --amount 10 --chain bnb --token BNB` → error with suggestion to use `--token WBNB`
- [ ] `polymarket deposit --amount 10 --chain ethereum --token ETH` → error with suggestion to use `--token WETH`
- [ ] `polymarket deposit --amount 2 --chain bnb --token WBNB` → bridge deposit completes successfully
- [ ] `polymarket deposit --amount 10 --chain polygon --token USDC` → direct Polygon transfer works

🤖 Generated with [Claude Code](https://claude.com/claude-code)