### PR TITLE
feat(curve): v0.2.8 — add quickstart command, confirm gate, price impact checks

### DIFF
--- a/skills/curve-plugin/.claude-plugin/plugin.json
+++ b/skills/curve-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve-plugin/.claude-plugin/plugin.json
+++ b/skills/curve-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve-plugin/.claude-plugin/plugin.json
+++ b/skills/curve-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.9",
+  "version": "0.2.8",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve-plugin/Cargo.lock
+++ b/skills/curve-plugin/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "curve-plugin"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve-plugin/Cargo.lock
+++ b/skills/curve-plugin/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "curve-plugin"
-version = "0.2.9"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve-plugin/Cargo.lock
+++ b/skills/curve-plugin/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "curve-plugin"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve-plugin/Cargo.toml
+++ b/skills/curve-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve-plugin"
-version = "0.2.9"
+version = "0.2.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve-plugin/Cargo.toml
+++ b/skills/curve-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve-plugin"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve-plugin/Cargo.toml
+++ b/skills/curve-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve-plugin"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -137,6 +137,162 @@ fi
 ---
 
 
+## Proactive Onboarding
+
+When a user signals they are **new or just installed** this plugin — e.g. "I just installed curve",
+"how do I get started with Curve", "what can I do with Curve" — **do not wait for them to ask
+specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
+waiting for confirmation before proceeding to the next:
+
+1. **Choose chain** — ask the user which chain they want to use. Supported: Ethereum (1), Arbitrum (42161),
+   Base (8453), Polygon (137), BSC (56). Use their answer for `<CHAIN>` in all subsequent steps.
+   If unsure, suggest Ethereum for stablecoin swaps (deepest liquidity) or Base for low gas fees.
+2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
+   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
+3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. You need at least a small amount
+   of the token you want to swap (e.g. 0.5 USDC, 0.001 stETH). If insufficient, explain what's
+   needed and how to fund (bridge, CEX withdrawal, or swap).
+4. **Explore pools** — run `curve --chain <CHAIN> get-pools` to show available pools. Ask what tokens
+   they hold and want to swap. Use `get-pool-info --pool <address>` for APY / fee details on a
+   specific pool. Use `quote` to preview expected output before committing.
+5. **Preview first write** — run the write command (e.g. `swap`) **without `--confirm`** so the
+   user sees the preview JSON (including calldata and expected output) before any on-chain action.
+   Confirm the `"preview": true` field is present and explain what it means.
+6. **Execute** — once the user confirms, re-run the same command **with `--confirm`** to broadcast.
+   Note: ERC-20 tokens (USDC, DAI, USDT) require an approval tx that fires first; the plugin waits
+   for approval to confirm before submitting the swap.
+
+**Important caveats discovered during live testing:**
+- The `--wallet` flag is required for all write commands (preview and execute). The plugin cannot
+  resolve the active onchainos wallet automatically — always pass `--wallet <address>`.
+- Unsupported chains (any chain not in 1, 42161, 8453, 137, 56) return a clear error JSON and exit 1.
+
+Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+
+---
+
+## Quickstart
+
+New to curve-plugin? Follow these steps to go from zero to your first Curve swap on Ethereum.
+
+### Step 1 — Connect your wallet
+
+```bash
+onchainos wallet login your@email.com
+onchainos wallet addresses --chain 1
+```
+
+Confirm you see your Ethereum address before continuing.
+
+### Step 2 — Check your balance
+
+```bash
+onchainos wallet balance --chain 1
+```
+
+Minimum recommended: any stablecoin (USDC, DAI, USDT) or LST (stETH, weETH) with a non-dust
+balance. For stablecoins, even $0.50 is sufficient for a test swap. If your balance is zero,
+bridge ETH or transfer tokens to Ethereum mainnet first.
+
+### Step 3 — Browse available pools
+
+```bash
+curve --chain 1 get-pools
+```
+
+Returns the top 20 pools by TVL. Note the `address` field — you'll need it for add/remove
+liquidity. For swap, you only need the token symbols (the plugin finds the best pool automatically).
+
+For pool-specific details (fee, virtual price, coin decimals):
+
+```bash
+curve --chain 1 get-pool-info --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
+```
+
+To get a swap quote before committing:
+
+```bash
+curve --chain 1 quote --token-in USDC --token-out DAI --amount 1.0
+```
+
+### Step 4 — Preview before executing
+
+All write commands show a safe preview by default — no on-chain action until you add `--confirm`.
+The `--wallet` flag is required:
+
+```bash
+# Preview (safe — no tx sent):
+curve --chain 1 swap --token-in USDC --token-out DAI --amount 0.5 \
+  --wallet 0xYOUR_WALLET
+
+# Execute (add --confirm):
+curve --chain 1 --confirm swap --token-in USDC --token-out DAI --amount 0.5 \
+  --wallet 0xYOUR_WALLET
+```
+
+Check for `"preview": true` in the preview output and `"note": "Re-run with --confirm..."` before
+confirming.
+
+### Step 5 — Swap tokens
+
+```bash
+curve --chain 1 --confirm swap \
+  --token-in USDC \
+  --token-out DAI \
+  --amount 0.5 \
+  --slippage 0.005 \
+  --wallet 0xYOUR_WALLET
+```
+
+Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer": "https://etherscan.io/tx/..."`.
+
+**Note:** ERC-20 swaps (USDC, DAI, USDT) fire an approve tx first. You will see:
+`Approving USDC for Curve pool...` followed by `Approve tx: 0x... — waiting for confirmation...`
+before the swap tx broadcasts. This is expected and safe.
+
+### Step 6 — (Optional) Add liquidity to 3pool
+
+```bash
+# Preview: add 0.5 USDC to the 3pool (DAI=0, USDC=0.5, USDT=0)
+curve --chain 1 add-liquidity \
+  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
+  --amounts "0,0.5,0" \
+  --wallet 0xYOUR_WALLET
+
+# Execute:
+curve --chain 1 --confirm add-liquidity \
+  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
+  --amounts "0,0.5,0" \
+  --wallet 0xYOUR_WALLET
+```
+
+Amounts are in human-readable units matching pool coin order (DAI, USDC, USDT for 3pool). After
+adding liquidity, check your LP balance with:
+
+```bash
+curve --chain 1 get-balances --wallet 0xYOUR_WALLET
+```
+
+### Step 7 — (Optional) Remove liquidity
+
+```bash
+# Preview: remove all LP as USDC (coin index 1 in 3pool)
+curve --chain 1 remove-liquidity \
+  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
+  --coin-index 1 \
+  --min-amounts 0 \
+  --wallet 0xYOUR_WALLET
+
+# Execute:
+curve --chain 1 --confirm remove-liquidity \
+  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
+  --coin-index 1 \
+  --min-amounts 0 \
+  --wallet 0xYOUR_WALLET
+```
+
+---
+
 ## Do NOT use for
 - Uniswap, Balancer, or other DEX swaps (use the relevant skill)
 - Aave, Compound, or lending protocol operations

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve-plugin
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.9"
+version: "0.2.8"
 author: "GeoGu360"
 tags:
   - dex
@@ -24,7 +24,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/curve-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.9"
+LOCAL_VER="0.2.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -97,7 +97,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.9/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.8/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
 chmod +x ~/.local/bin/.curve-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -105,7 +105,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/curve-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.9" > "$HOME/.plugin-store/managed/curve-plugin"
+echo "0.2.8" > "$HOME/.plugin-store/managed/curve-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -125,7 +125,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve-plugin","version":"0.2.9"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -244,7 +244,7 @@ curve --chain 1 --confirm swap \
   --wallet 0xYOUR_WALLET
 ```
 
-Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer": "https://etherscan.io/tx/..."`.
+Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer": "<block_explorer_url>"`.
 
 **Note:** ERC-20 swaps (USDC, DAI, USDT) fire an approve tx first. You will see:
 `Approving USDC for Curve pool...` followed by `Approve tx: 0x... — waiting for confirmation...`

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve-plugin
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.8"
+version: "0.2.9"
 author: "GeoGu360"
 tags:
   - dex
@@ -24,7 +24,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/curve-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.8"
+LOCAL_VER="0.2.9"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -97,7 +97,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.8/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.9/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
 chmod +x ~/.local/bin/.curve-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -105,7 +105,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/curve-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.8" > "$HOME/.plugin-store/managed/curve-plugin"
+echo "0.2.9" > "$HOME/.plugin-store/managed/curve-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -125,7 +125,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve-plugin","version":"0.2.9"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -139,157 +139,46 @@ fi
 
 ## Proactive Onboarding
 
-When a user signals they are **new or just installed** this plugin — e.g. "I just installed curve",
-"how do I get started with Curve", "what can I do with Curve" — **do not wait for them to ask
-specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
-waiting for confirmation before proceeding to the next:
+When a user is new or asks "how do I get started", call `curve quickstart` first. This checks their actual wallet state and returns a personalised `next_command` and `onboarding_steps`.
 
-1. **Choose chain** — ask the user which chain they want to use. Supported: Ethereum (1), Arbitrum (42161),
-   Base (8453), Polygon (137), BSC (56). Use their answer for `<CHAIN>` in all subsequent steps.
-   If unsure, suggest Ethereum for stablecoin swaps (deepest liquidity) or Base for low gas fees.
-2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
-   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
-3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. You need at least a small amount
-   of the token you want to swap (e.g. 0.5 USDC, 0.001 stETH). If insufficient, explain what's
-   needed and how to fund (bridge, CEX withdrawal, or swap).
-4. **Explore pools** — run `curve --chain <CHAIN> get-pools` to show available pools. Ask what tokens
-   they hold and want to swap. Use `get-pool-info --pool <address>` for APY / fee details on a
-   specific pool. Use `quote` to preview expected output before committing.
-5. **Preview first write** — run the write command (e.g. `swap`) **without `--confirm`** so the
-   user sees the preview JSON (including calldata and expected output) before any on-chain action.
-   Confirm the `"preview": true` field is present and explain what it means.
-6. **Execute** — once the user confirms, re-run the same command **with `--confirm`** to broadcast.
-   Note: ERC-20 tokens (USDC, DAI, USDT) require an approval tx that fires first; the plugin waits
-   for approval to confirm before submitting the swap.
+```bash
+curve quickstart
+```
 
-**Important caveats discovered during live testing:**
-- The `--wallet` flag is required for all write commands (preview and execute). The plugin cannot
-  resolve the active onchainos wallet automatically — always pass `--wallet <address>`.
+Parse the JSON output:
+- `status: "active"` → has existing positions/balance; run relevant view command
+- `status: "ready"` → wallet funded; follow `next_command`
+- `status: "needs_gas"` → has tokens but no gas; ask user to send ETH/BNB
+- `status: "needs_funds"` → has gas but no tokens; show `onboarding_steps`
+- `status: "no_funds"` → wallet empty; show `onboarding_steps`
+
+**Key caveats:**
+- The `--wallet` flag is required for all write commands (preview and execute). The plugin cannot resolve the active onchainos wallet automatically — always pass `--wallet <address>`.
 - Unsupported chains (any chain not in 1, 42161, 8453, 137, 56) return a clear error JSON and exit 1.
-
-Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+- ERC-20 tokens (USDC, DAI, USDT) require an approval tx before swap; the plugin waits for approval before submitting the swap.
 
 ---
 
-## Quickstart
-
-New to curve-plugin? Follow these steps to go from zero to your first Curve swap on Ethereum.
-
-### Step 1 — Connect your wallet
+## Quickstart Command
 
 ```bash
-onchainos wallet login your@email.com
-onchainos wallet addresses --chain 1
+curve quickstart [--chain <ID>]
 ```
 
-Confirm you see your Ethereum address before continuing.
+Returns a personalised onboarding JSON based on the wallet's actual balances.
 
-### Step 2 — Check your balance
+### Output Fields
 
-```bash
-onchainos wallet balance --chain 1
-```
-
-Minimum recommended: any stablecoin (USDC, DAI, USDT) or LST (stETH, weETH) with a non-dust
-balance. For stablecoins, even $0.50 is sufficient for a test swap. If your balance is zero,
-bridge ETH or transfer tokens to Ethereum mainnet first.
-
-### Step 3 — Browse available pools
-
-```bash
-curve --chain 1 get-pools
-```
-
-Returns the top 20 pools by TVL. Note the `address` field — you'll need it for add/remove
-liquidity. For swap, you only need the token symbols (the plugin finds the best pool automatically).
-
-For pool-specific details (fee, virtual price, coin decimals):
-
-```bash
-curve --chain 1 get-pool-info --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
-```
-
-To get a swap quote before committing:
-
-```bash
-curve --chain 1 quote --token-in USDC --token-out DAI --amount 1.0
-```
-
-### Step 4 — Preview before executing
-
-All write commands show a safe preview by default — no on-chain action until you add `--confirm`.
-The `--wallet` flag is required:
-
-```bash
-# Preview (safe — no tx sent):
-curve --chain 1 swap --token-in USDC --token-out DAI --amount 0.5 \
-  --wallet 0xYOUR_WALLET
-
-# Execute (add --confirm):
-curve --chain 1 --confirm swap --token-in USDC --token-out DAI --amount 0.5 \
-  --wallet 0xYOUR_WALLET
-```
-
-Check for `"preview": true` in the preview output and `"note": "Re-run with --confirm..."` before
-confirming.
-
-### Step 5 — Swap tokens
-
-```bash
-curve --chain 1 --confirm swap \
-  --token-in USDC \
-  --token-out DAI \
-  --amount 0.5 \
-  --slippage 0.005 \
-  --wallet 0xYOUR_WALLET
-```
-
-Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer": "<block_explorer_url>"`.
-
-**Note:** ERC-20 swaps (USDC, DAI, USDT) fire an approve tx first. You will see:
-`Approving USDC for Curve pool...` followed by `Approve tx: 0x... — waiting for confirmation...`
-before the swap tx broadcasts. This is expected and safe.
-
-### Step 6 — (Optional) Add liquidity to 3pool
-
-```bash
-# Preview: add 0.5 USDC to the 3pool (DAI=0, USDC=0.5, USDT=0)
-curve --chain 1 add-liquidity \
-  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
-  --amounts "0,0.5,0" \
-  --wallet 0xYOUR_WALLET
-
-# Execute:
-curve --chain 1 --confirm add-liquidity \
-  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
-  --amounts "0,0.5,0" \
-  --wallet 0xYOUR_WALLET
-```
-
-Amounts are in human-readable units matching pool coin order (DAI, USDC, USDT for 3pool). After
-adding liquidity, check your LP balance with:
-
-```bash
-curve --chain 1 get-balances --wallet 0xYOUR_WALLET
-```
-
-### Step 7 — (Optional) Remove liquidity
-
-```bash
-# Preview: remove all LP as USDC (coin index 1 in 3pool)
-curve --chain 1 remove-liquidity \
-  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
-  --coin-index 1 \
-  --min-amounts 0 \
-  --wallet 0xYOUR_WALLET
-
-# Execute:
-curve --chain 1 --confirm remove-liquidity \
-  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
-  --coin-index 1 \
-  --min-amounts 0 \
-  --wallet 0xYOUR_WALLET
-```
+| Field | Description |
+|-------|-------------|
+| `about` | Protocol description |
+| `wallet` | Resolved wallet address |
+| `chain` | Chain name |
+| `assets` | Wallet balances (gas token + key protocol tokens) |
+| `status` | `active` / `ready` / `needs_gas` / `needs_funds` / `no_funds` |
+| `suggestion` | Human-readable state description |
+| `next_command` | The single most useful command to run next |
+| `onboarding_steps` | Ordered steps to follow |
 
 ---
 
@@ -328,6 +217,7 @@ curve --chain 1 --confirm remove-liquidity \
 
 | User Intent | Command |
 |-------------|---------|
+| "I'm new to Curve / how do I start?" | `quickstart` |
 | "Show Curve pools on Ethereum" | `get-pools` |
 | "What's the APY for Curve 3pool?" | `get-pool-info` |
 | "How much LP do I have in Curve?" | `get-balances` |

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve-plugin
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.7"
+version: "0.2.8"
 author: "GeoGu360"
 tags:
   - dex
@@ -24,7 +24,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/curve-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.7"
+LOCAL_VER="0.2.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -97,7 +97,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.7/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.8/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
 chmod +x ~/.local/bin/.curve-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -105,7 +105,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/curve-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.7" > "$HOME/.plugin-store/managed/curve-plugin"
+echo "0.2.8" > "$HOME/.plugin-store/managed/curve-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -125,7 +125,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve-plugin","version":"0.2.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/curve-plugin/plugin.yaml
+++ b/skills/curve-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve-plugin
-version: "0.2.9"
+version: "0.2.8"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve-plugin/plugin.yaml
+++ b/skills/curve-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve-plugin
-version: "0.2.8"
+version: "0.2.9"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve-plugin/plugin.yaml
+++ b/skills/curve-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve-plugin
-version: "0.2.7"
+version: "0.2.8"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve-plugin/src/commands/add_liquidity.rs
+++ b/skills/curve-plugin/src/commands/add_liquidity.rs
@@ -9,6 +9,7 @@ pub async fn run(
     min_mint_str: String,
     wallet: Option<String>,
     dry_run: bool,
+    confirm: bool,
 ) -> Result<()> {
     let chain_name = config::chain_name(chain_id);
     let rpc_url = config::rpc_url(chain_id);
@@ -66,10 +67,54 @@ pub async fn run(
     // Parse min_mint as LP tokens (always 18 decimals)
     let min_mint = rpc::parse_human_amount(&min_mint_str, 18)?;
 
+    // Build calldata using (potentially capped) amounts — needed for preview output too
+    let calldata = match n_coins {
+        2 => curve_abi::encode_add_liquidity_2([amounts[0], amounts[1]], min_mint),
+        3 => curve_abi::encode_add_liquidity_3([amounts[0], amounts[1], amounts[2]], min_mint),
+        4 => curve_abi::encode_add_liquidity_4(
+            [amounts[0], amounts[1], amounts[2], amounts[3]],
+            min_mint,
+        ),
+        _ => anyhow::bail!("Unsupported pool size: {} coins", n_coins),
+    };
+
+    // Confirm gate: show preview and exit if --confirm not given (and not dry-run)
+    if !dry_run && !confirm {
+        let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
+        let amounts_display: Vec<String> = if let Some(p) = pool {
+            amounts.iter().enumerate().map(|(i, &a)| {
+                let dec: u8 = p.coins.get(i)
+                    .and_then(|c| c.decimals.as_deref())
+                    .and_then(|d| d.parse().ok())
+                    .unwrap_or(18);
+                format!("{:.6}", a as f64 / 10f64.powi(dec as i32))
+            }).collect()
+        } else {
+            amounts.iter().map(|&a| format!("{:.6}", a as f64 / 1e18)).collect()
+        };
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "preview": true,
+                "operation": "add-liquidity",
+                "chain": chain_name,
+                "pool_address": pool_address,
+                "pool_name": pool_name,
+                "amounts": amounts_display,
+                "amounts_raw": amounts.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+                "min_mint_raw": min_mint.to_string(),
+                "calldata": calldata,
+                "note": "Re-run with --confirm to execute on-chain."
+            })
+        );
+        return Ok(());
+    }
+
     // Pre-flight balance check — verify wallet holds enough of each token before approving.
     // Slippage from a prior swap can leave a small shortfall (e.g. 1.499471 USDT when 1.5 was
     // requested). Cap down if gap ≤ 1%; bail with a human-readable error if gap > 1%.
-    if !dry_run {
+    if !dry_run && confirm {
         if let Some(p) = pool {
             for (i, coin) in p.coins.iter().enumerate() {
                 if amounts[i] == 0 {
@@ -109,7 +154,7 @@ pub async fn run(
         }
     }
 
-    // Build add_liquidity calldata using (potentially capped) amounts
+    // Rebuild calldata after potential pre-flight balance cap (amounts may have changed)
     let calldata = match n_coins {
         2 => curve_abi::encode_add_liquidity_2([amounts[0], amounts[1]], min_mint),
         3 => curve_abi::encode_add_liquidity_3([amounts[0], amounts[1], amounts[2]], min_mint),
@@ -181,6 +226,10 @@ pub async fn run(
         }
     }
 
+    // Snapshot LP balance before so we can report minted amount after
+    let lp_token = rpc::lp_token_address(&pool_address, rpc_url).await;
+    let lp_before = rpc::balance_of(&lp_token, &wallet_addr, rpc_url).await.unwrap_or(0);
+
     // Execute add_liquidity — requires --force
     let result = onchainos::wallet_contract_call(
         chain_id,
@@ -196,6 +245,16 @@ pub async fn run(
     let tx_hash = onchainos::extract_tx_hash_or_err(&result)?;
     let explorer = config::explorer_url(chain_id, &tx_hash);
     let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
+
+    // Wait for confirmation then compute LP delta
+    let _ = onchainos::wait_for_tx(chain_id, tx_hash.clone(), wallet_addr.clone()).await;
+    let lp_after = rpc::balance_of(&lp_token, &wallet_addr, rpc_url).await.unwrap_or(lp_before);
+    let lp_minted = lp_after.saturating_sub(lp_before);
+    let lp_received = if lp_minted > 0 {
+        format!("{:.8}", lp_minted as f64 / 1e18)
+    } else {
+        "unknown (check explorer)".to_string()
+    };
 
     let amounts_display: Vec<String> = if let Some(p) = pool {
         amounts.iter().enumerate().map(|(i, &a)| {
@@ -219,6 +278,7 @@ pub async fn run(
             "amounts": amounts_display,
             "amounts_raw": amounts.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
             "min_mint_raw": min_mint.to_string(),
+            "lp_received": lp_received,
             "tx_hash": tx_hash,
             "explorer": explorer
         })

--- a/skills/curve-plugin/src/commands/get_pool_info.rs
+++ b/skills/curve-plugin/src/commands/get_pool_info.rs
@@ -63,19 +63,11 @@ pub async fn run(chain_id: u64, pool_address: String) -> Result<()> {
             })
         );
     } else {
-        // Pool not found in API — still show on-chain data
-        println!(
-            "{}",
-            serde_json::json!({
-                "ok": true,
-                "pool": {
-                    "address": pool_address,
-                    "virtual_price_raw": virtual_price.to_string(),
-                    "fee_pct": format!("{:.4}%", fee_pct),
-                    "fee_raw": fee_raw.to_string(),
-                    "note": "Pool not found in Curve API registry"
-                }
-            })
+        // Pool not found in API registry
+        anyhow::bail!(
+            "Pool {} not found in the Curve API registry for this chain. \
+            Use `get-pools` to list available pools.",
+            pool_address
         );
     }
     Ok(())

--- a/skills/curve-plugin/src/commands/mod.rs
+++ b/skills/curve-plugin/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod add_liquidity;
 pub mod get_balances;
 pub mod get_pool_info;
 pub mod get_pools;
+pub mod quickstart;
 pub mod quote;
 pub mod remove_liquidity;
 pub mod swap;

--- a/skills/curve-plugin/src/commands/quickstart.rs
+++ b/skills/curve-plugin/src/commands/quickstart.rs
@@ -1,0 +1,200 @@
+// commands/quickstart.rs — Curve Finance wallet-state onboarding
+use crate::config;
+use crate::onchainos;
+use crate::rpc;
+use serde_json::{json, Value};
+
+const ABOUT: &str = "Curve Finance is the leading stablecoin and LST DEX — swap between \
+    stablecoins with minimal slippage, provide liquidity to earn trading fees and CRV rewards. \
+    $3B+ TVL.";
+
+// Canonical stablecoin addresses on Ethereum (chain 1)
+const USDC_ETHEREUM: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDT_ETHEREUM: &str = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+
+// USDC on other chains
+const USDC_ARBITRUM: &str = "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8";
+const USDC_BASE: &str    = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const USDC_POLYGON: &str = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+const USDC_BSC: &str     = "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d";
+
+// USDT on other chains
+const USDT_ARBITRUM: &str = "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9";
+const USDT_BSC: &str     = "0x55d398326f99059fF775485246999027B3197955";
+const USDT_POLYGON: &str = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
+
+// Minimum native gas needed
+const MIN_GAS_ETHEREUM_WEI: u128 = 3_000_000_000_000_000; // 0.003 ETH
+const MIN_GAS_L2_WEI: u128      = 100_000_000_000_000;     // 0.0001 ETH (L2)
+
+// Minimum meaningful stablecoin balance (1 USDC/USDT = 1_000_000 raw)
+const MIN_STABLE_RAW: u128 = 1_000_000; // 1 USDC/USDT (6 decimals)
+
+async fn eth_balance_wei(wallet: &str, rpc_url: &str) -> u128 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [wallet, "latest"],
+        "id": 1
+    });
+    match client.post(rpc_url).json(&body).send().await {
+        Ok(resp) => {
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => val["result"].as_str()
+                    .and_then(|s| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                    .unwrap_or(0),
+                Err(_) => 0,
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+pub async fn run(chain_id: u64, wallet: Option<&str>) -> anyhow::Result<Value> {
+    let rpc_url = config::rpc_url(chain_id);
+
+    let chain_display = match chain_id {
+        1     => "Ethereum",
+        56    => "BSC",
+        137   => "Polygon",
+        8453  => "Base",
+        42161 => "Arbitrum",
+        _     => "Ethereum",
+    };
+
+    let resolved = if let Some(addr) = wallet {
+        addr.to_string()
+    } else {
+        onchainos::resolve_wallet(chain_id)
+            .map_err(|e| anyhow::anyhow!("Cannot resolve wallet: {e}"))?
+    };
+
+    eprintln!(
+        "Checking assets for {}... on {}...",
+        &resolved[..10.min(resolved.len())],
+        chain_display
+    );
+
+    // Choose stablecoin addresses for this chain
+    let (usdc_addr, usdt_addr) = match chain_id {
+        1     => (USDC_ETHEREUM, USDT_ETHEREUM),
+        42161 => (USDC_ARBITRUM, USDT_ARBITRUM),
+        8453  => (USDC_BASE,     USDC_BASE),  // no native USDT on Base; use USDC twice
+        137   => (USDC_POLYGON,  USDT_POLYGON),
+        56    => (USDC_BSC,      USDT_BSC),
+        _     => (USDC_ETHEREUM, USDT_ETHEREUM),
+    };
+
+    let min_gas_wei = if chain_id == 1 { MIN_GAS_ETHEREUM_WEI } else { MIN_GAS_L2_WEI };
+
+    let (eth_wei, usdc_raw, usdt_raw) = tokio::join!(
+        eth_balance_wei(&resolved, rpc_url),
+        rpc::balance_of(usdc_addr, &resolved, rpc_url),
+        rpc::balance_of(usdt_addr, &resolved, rpc_url),
+    );
+
+    let usdc_raw = usdc_raw.unwrap_or(0);
+    let usdt_raw = usdt_raw.unwrap_or(0);
+
+    let eth_balance  = eth_wei  as f64 / 1e18;
+    let usdc_balance = usdc_raw as f64 / 1_000_000.0;
+    let usdt_balance = usdt_raw as f64 / 1_000_000.0;
+
+    let has_gas    = eth_wei >= min_gas_wei;
+    let has_tokens = usdc_raw >= MIN_STABLE_RAW || usdt_raw >= MIN_STABLE_RAW;
+
+    let chain_flag = if chain_id != 1 {
+        format!("--chain {} ", chain_id)
+    } else {
+        String::new()
+    };
+    let wallet_flag = format!("--wallet {}", resolved);
+
+    let (status, suggestion, next_command, onboarding_steps): (&str, &str, String, Vec<String>) =
+        if has_gas && has_tokens {
+            let (token, amount) = if usdc_balance >= 1.0 {
+                ("USDC", format!("{:.2}", (usdc_balance * 0.9).max(1.0).min(usdc_balance)))
+            } else {
+                ("USDT", format!("{:.2}", (usdt_balance * 0.9).max(1.0).min(usdt_balance)))
+            };
+            (
+                "ready",
+                "Your wallet is funded. Use Curve to swap stablecoins with minimal slippage.",
+                format!("curve {}get-pools", chain_flag),
+                vec![
+                    "1. Browse available pools:".to_string(),
+                    format!("   curve {}get-pools", chain_flag),
+                    "2. Get a swap quote:".to_string(),
+                    format!("   curve {}quote --token-in {} --token-out DAI --amount {}", chain_flag, token, amount),
+                    "3. Preview swap (no --confirm = safe):".to_string(),
+                    format!("   curve {}swap --token-in {} --token-out DAI --amount {} {}", chain_flag, token, amount, wallet_flag),
+                    "4. Execute swap (add --confirm):".to_string(),
+                    format!("   curve {}--confirm swap --token-in {} --token-out DAI --amount {} {}", chain_flag, token, amount, wallet_flag),
+                ],
+            )
+        } else if has_tokens && !has_gas {
+            (
+                "needs_gas",
+                "You have stablecoins but need ETH for gas fees. Send ETH to your wallet.",
+                format!("curve {}quickstart {}", chain_flag, wallet_flag),
+                vec![
+                    format!("1. Send at least {:.4} ETH (gas) to:", min_gas_wei as f64 / 1e18),
+                    format!("   {}", resolved),
+                    "2. Run quickstart again:".to_string(),
+                    format!("   curve {}quickstart {}", chain_flag, wallet_flag),
+                ],
+            )
+        } else if has_gas && !has_tokens {
+            (
+                "needs_funds",
+                "You have ETH for gas but no USDC/USDT to swap. Transfer stablecoins to your wallet.",
+                format!("curve {}get-pools", chain_flag),
+                vec![
+                    "1. Send USDC or USDT to your wallet:".to_string(),
+                    format!("   {}", resolved),
+                    "2. Run quickstart again after funding:".to_string(),
+                    format!("   curve {}quickstart {}", chain_flag, wallet_flag),
+                    "3. Browse available pools:".to_string(),
+                    format!("   curve {}get-pools", chain_flag),
+                ],
+            )
+        } else {
+            (
+                "no_funds",
+                "No ETH or tokens found. Send ETH (for gas) and stablecoins to get started.",
+                format!("curve {}get-pools", chain_flag),
+                vec![
+                    "1. Send ETH (for gas) and USDC or USDT to your wallet:".to_string(),
+                    format!("   {}", resolved),
+                    format!("   Minimum gas: {:.4} ETH", min_gas_wei as f64 / 1e18),
+                    "2. Run quickstart again:".to_string(),
+                    format!("   curve {}quickstart {}", chain_flag, wallet_flag),
+                    "3. Browse available pools and rates:".to_string(),
+                    format!("   curve {}get-pools", chain_flag),
+                ],
+            )
+        };
+
+    let mut out = json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": resolved,
+        "chain": chain_display,
+        "chainId": chain_id,
+        "assets": {
+            "eth_balance": format!("{:.6}", eth_balance),
+            "usdc_balance": format!("{:.2}", usdc_balance),
+            "usdt_balance": format!("{:.2}", usdt_balance),
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = json!(onboarding_steps);
+    }
+
+    Ok(out)
+}

--- a/skills/curve-plugin/src/commands/remove_liquidity.rs
+++ b/skills/curve-plugin/src/commands/remove_liquidity.rs
@@ -10,6 +10,7 @@ pub async fn run(
     min_amount_strs: Vec<String>,  // human-readable min amounts per coin
     wallet: Option<String>,
     dry_run: bool,
+    confirm: bool,
 ) -> Result<()> {
     let chain_name = config::chain_name(chain_id);
     let rpc_url = config::rpc_url(chain_id);
@@ -43,8 +44,9 @@ pub async fn run(
         None => None,
     };
 
-    // Get LP balance
-    let lp_balance = if dry_run {
+    // Get LP balance. Skip live lookup for dry-run and preview (no --confirm) paths —
+    // both just need a plausible amount to build calldata / estimate output.
+    let lp_balance = if dry_run || !confirm {
         parsed_lp_amount.unwrap_or(1_000_000_000_000_000_000u128) // 1e18 placeholder
     } else {
         let bal = rpc::balance_of(lp_token_addr, &wallet_addr, rpc_url).await?;
@@ -143,7 +145,33 @@ pub async fn run(
         }
     };
 
+    // Confirm gate: show preview and exit if --confirm not given (and not dry-run)
+    if !dry_run && !confirm {
+        let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
+        let min_amounts_raw: Vec<String> = min_amounts.iter().map(|a| a.to_string()).collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "preview": true,
+                "operation": "remove-liquidity",
+                "chain": chain_name,
+                "pool_address": pool_address,
+                "pool_name": pool_name,
+                "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
+                "lp_amount_raw": actual_lp_amount.to_string(),
+                "coin_index": coin_index,
+                "min_amounts_raw": min_amounts_raw,
+                "calldata": calldata,
+                "note": "Re-run with --confirm to execute on-chain."
+            })
+        );
+        return Ok(());
+    }
+
     if dry_run {
+        let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
+        let min_amounts_raw: Vec<String> = min_amounts.iter().map(|a| a.to_string()).collect();
         println!(
             "{}",
             serde_json::json!({
@@ -151,12 +179,26 @@ pub async fn run(
                 "dry_run": true,
                 "chain": chain_name,
                 "pool_address": pool_address,
+                "pool_name": pool_name,
                 "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
                 "lp_amount_raw": actual_lp_amount.to_string(),
-                "calldata": calldata
+                "coin_index": coin_index,
+                "min_amounts_raw": min_amounts_raw,
+                "calldata": calldata,
+                "note": "Re-run with --confirm to execute on-chain."
             })
         );
         return Ok(());
+    }
+
+    // Snapshot coin balances before execution to report received amounts after confirmation
+    let coin_addrs: Vec<String> = pool
+        .map(|p| p.coins.iter().map(|c| c.address.clone()).collect())
+        .unwrap_or_default();
+    let mut balances_before: Vec<u128> = Vec::new();
+    for addr in &coin_addrs {
+        let b = rpc::balance_of(addr, &wallet_addr, rpc_url).await.unwrap_or(0);
+        balances_before.push(b);
     }
 
     // Execute remove_liquidity — requires --force
@@ -175,6 +217,28 @@ pub async fn run(
     let explorer = config::explorer_url(chain_id, &tx_hash);
     let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
 
+    let _ = onchainos::wait_for_tx(chain_id, tx_hash.clone(), wallet_addr.clone()).await;
+    let mut received: Vec<serde_json::Value> = Vec::new();
+    for (i, addr) in coin_addrs.iter().enumerate() {
+        let coin_symbol = pool
+            .and_then(|p| p.coins.get(i))
+            .map(|c| c.symbol.as_str())
+            .unwrap_or("token");
+        let coin_decimals: u8 = pool
+            .and_then(|p| p.coins.get(i))
+            .and_then(|c| c.decimals.as_deref())
+            .and_then(|d| d.parse().ok())
+            .unwrap_or(18);
+        let after = rpc::balance_of(addr, &wallet_addr, rpc_url).await.unwrap_or(*balances_before.get(i).unwrap_or(&0));
+        let delta = after.saturating_sub(*balances_before.get(i).unwrap_or(&0));
+        received.push(serde_json::json!({
+            "symbol": coin_symbol,
+            "address": addr,
+            "amount_raw": delta.to_string(),
+            "amount_human": format!("{:.6}", delta as f64 / 10f64.powi(coin_decimals as i32))
+        }));
+    }
+
     println!(
         "{}",
         serde_json::json!({
@@ -184,6 +248,7 @@ pub async fn run(
             "pool_name": pool_name,
             "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
             "lp_amount_raw": actual_lp_amount.to_string(),
+            "coins_received": received,
             "tx_hash": tx_hash,
             "explorer": explorer
         })

--- a/skills/curve-plugin/src/commands/swap.rs
+++ b/skills/curve-plugin/src/commands/swap.rs
@@ -17,6 +17,7 @@ pub async fn run(
     slippage: f64,
     wallet: Option<String>,
     dry_run: bool,
+    confirm: bool,
 ) -> Result<()> {
     let chain_name = config::chain_name(chain_id);
     let rpc_url = config::rpc_url(chain_id);
@@ -92,6 +93,16 @@ pub async fn run(
 
     let min_expected = (amount_out as f64 * (1.0 - slippage)) as u128;
 
+    // Compute price impact: normalise both amounts to 18-decimal space for comparison
+    const NORM: u32 = 18;
+    let in_norm = amount_minimal as f64 * 10f64.powi(NORM as i32 - in_decimals as i32);
+    let out_norm = amount_out as f64 * 10f64.powi(NORM as i32 - out_decimals as i32);
+    let price_impact_pct = if in_norm > 0.0 {
+        ((in_norm - out_norm) / in_norm * 100.0).max(0.0)
+    } else {
+        0.0
+    };
+
     // Build exchange calldata
     // Selector: 0x3df02124 = exchange(int128,int128,uint256,uint256) for StableSwap pools
     // Selector: 0x5b41b908 = exchange(uint256,uint256,uint256,uint256) for CryptoSwap/factory-v2 pools
@@ -100,6 +111,34 @@ pub async fn run(
     } else {
         curve_abi::encode_exchange(in_idx as i64, out_idx as i64, amount_minimal, min_expected)
     };
+
+    // Confirm gate: show preview and exit if --confirm not given (and not dry-run)
+    if !dry_run && !confirm {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "preview": true,
+                "operation": "swap",
+                "chain": chain_name,
+                "pool": { "id": pool.id, "name": pool.name, "address": pool.address },
+                "token_in": { "symbol": in_symbol, "address": token_in_addr, "index": in_idx },
+                "token_out": { "symbol": out_symbol, "address": token_out_addr, "index": out_idx },
+                "amount_in": format!("{:.6}", amount_minimal as f64 / 10f64.powi(in_decimals as i32)),
+                "amount_in_raw": amount_minimal.to_string(),
+                "expected_out": format!("{:.6}", amount_out as f64 / 10f64.powi(out_decimals as i32)),
+                "expected_out_raw": amount_out.to_string(),
+                "min_expected": format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32)),
+                "min_expected_raw": min_expected.to_string(),
+                "slippage_pct": slippage * 100.0,
+                "price_impact_pct": format!("{:.4}", price_impact_pct),
+                "calldata": calldata,
+                "target_contract": pool.address,
+                "note": "Re-run with --confirm to execute this swap on-chain."
+            })
+        );
+        return Ok(());
+    }
 
     if dry_run {
         println!(
@@ -118,6 +157,7 @@ pub async fn run(
                 "min_expected": format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32)),
                 "min_expected_raw": min_expected.to_string(),
                 "slippage_pct": slippage * 100.0,
+                "price_impact_pct": format!("{:.4}", price_impact_pct),
                 "calldata": calldata,
                 "target_contract": pool.address
             })
@@ -191,6 +231,7 @@ pub async fn run(
             "expected_out_raw": amount_out.to_string(),
             "min_expected": format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32)),
             "min_expected_raw": min_expected.to_string(),
+            "price_impact_pct": format!("{:.4}", price_impact_pct),
             "tx_hash": tx_hash,
             "explorer": explorer
         })

--- a/skills/curve-plugin/src/config.rs
+++ b/skills/curve-plugin/src/config.rs
@@ -60,7 +60,8 @@ pub fn resolve_token_address(symbol: &str, chain_id: u64) -> String {
         ("FRAX", 1) => "0x853d955aCEf822Db058eb8505911ED77F175b99e".to_string(),
         ("STETH", 1) | ("WSTETH", 1) => "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84".to_string(),
         // Arbitrum (42161)
-        ("USDC", 42161) => "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8".to_string(),
+        // Curve pools on Arbitrum use bridged USDC.e, not native USDC
+        ("USDC", 42161) | ("USDC.E", 42161) => "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8".to_string(),
         ("USDT", 42161) => "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9".to_string(),
         ("WETH", 42161) => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1".to_string(),
         ("DAI", 42161) => "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1".to_string(),

--- a/skills/curve-plugin/src/main.rs
+++ b/skills/curve-plugin/src/main.rs
@@ -137,6 +137,13 @@ enum Commands {
         #[arg(long)]
         wallet: Option<String>,
     },
+
+    /// Check wallet state and get personalised onboarding steps
+    Quickstart {
+        /// Wallet address to check (default: onchainos active wallet)
+        #[arg(long)]
+        wallet: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -219,6 +226,16 @@ async fn main() {
                 cli.confirm,
             )
             .await
+        }
+
+        Commands::Quickstart { wallet } => {
+            match commands::quickstart::run(chain_id, wallet.as_deref()).await {
+                Ok(val) => {
+                    println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
         }
     };
 

--- a/skills/curve-plugin/src/main.rs
+++ b/skills/curve-plugin/src/main.rs
@@ -9,7 +9,7 @@ mod rpc;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "curve", about = "Curve DEX plugin — swap, add/remove liquidity, query pools")]
+#[command(name = "curve", version, about = "Curve DEX plugin — swap, add/remove liquidity, query pools")]
 struct Cli {
     /// Chain ID (1=Ethereum, 42161=Arbitrum, 8453=Base, 137=Polygon, 56=BSC)
     #[arg(long, default_value = "1")]
@@ -18,6 +18,10 @@ struct Cli {
     /// Simulate without broadcasting on-chain transactions
     #[arg(long)]
     dry_run: bool,
+
+    /// Execute write operations on-chain (swap, add-liquidity, remove-liquidity). Without this flag write operations show a preview and exit. Has no effect on read-only commands.
+    #[arg(long)]
+    confirm: bool,
 
     #[command(subcommand)]
     command: Commands,
@@ -139,6 +143,17 @@ enum Commands {
 async fn main() {
     let cli = Cli::parse();
     let chain_id = cli.chain;
+    const SUPPORTED_CHAINS: &[u64] = &[1, 42161, 8453, 137, 56];
+    if !SUPPORTED_CHAINS.contains(&chain_id) {
+        eprintln!(
+            "{}",
+            serde_json::json!({"ok": false, "error": format!(
+                "Chain {} is not supported. Supported chains: 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 137 (Polygon), 56 (BSC)",
+                chain_id
+            )})
+        );
+        std::process::exit(1);
+    }
     let dry_run = cli.dry_run;
 
     let result = match cli.command {
@@ -166,7 +181,7 @@ async fn main() {
             slippage,
             wallet,
         } => {
-            commands::swap::run(chain_id, token_in, token_out, amount, slippage, wallet, dry_run)
+            commands::swap::run(chain_id, token_in, token_out, amount, slippage, wallet, dry_run, cli.confirm)
                 .await
         }
         Commands::AddLiquidity {
@@ -179,7 +194,7 @@ async fn main() {
                 .split(',')
                 .map(|s| s.trim().to_string())
                 .collect();
-            commands::add_liquidity::run(chain_id, pool, amount_strs, min_mint, wallet, dry_run)
+            commands::add_liquidity::run(chain_id, pool, amount_strs, min_mint, wallet, dry_run, cli.confirm)
                 .await
         }
         Commands::RemoveLiquidity {
@@ -201,6 +216,7 @@ async fn main() {
                 min_amount_strs,
                 wallet,
                 dry_run,
+                cli.confirm,
             )
             .await
         }


### PR DESCRIPTION
## Summary

1. **`--confirm` gate on all write commands** (swap, add-liquidity, remove-liquidity) — print \`{"ok":true,"preview":true,...}\` and exit 0 when \`--confirm\` is omitted. Previously executed immediately with no confirmation step.

2. **\`price_impact_pct\` in all swap outputs** — preview, dry_run, and confirmed tx all include normalized price impact percentage.

3. **Human-readable display fields** — \`amount_in\`, \`expected_out\`, \`min_expected\` (swap); \`amounts\` (add-liquidity); \`lp_amount\`, \`estimated_out\`, \`min_amount\` (remove-liquidity single-coin dry_run).

4. **\`lp_received\` in add-liquidity confirm output** — reports actual LP tokens minted via before/after balance delta.

5. **\`coins_received\` array in remove-liquidity confirm output** — per-coin delta with symbol, address, raw and human amounts.

6. **Pre-flight balance checks** — swap: bail if ERC-20 balance < amount; add-liquidity: cap down if ≤1% shortfall (slippage gap from prior swap), bail if >1%.

7. **Remove-liquidity preview gate fix** — LP balance lookup now skipped for preview path (was failing with "No LP token balance" for wallets with no LP).

8. **Arbitrum USDC → USDC.e** — Curve Arbitrum pools use bridged USDC.e (0xFF970A…); native USDC address restored. Both \`USDC\` and \`USDC.E\` symbols resolve to USDC.e.

9. **get-pool-info unknown pool** — now returns \`{"ok":false,"error":"..."}\` instead of \`{"ok":true,"note":"Pool not found..."}\`.

10. **\`--version\` flag** — \`curve-plugin --version\` now prints version string.

11. **Unsupported chain gate** — chains outside {1, 42161, 8453, 137, 56} return clear error JSON and exit 1.

12. **Proactive Onboarding + Quickstart sections** added to SKILL.md.

Merges our changes with upstream v0.2.7 (pre-flight balance checks + human-readable display fields) into v0.2.8.

## Files Changed

| File | Change |
|------|--------|
| \`src/main.rs\` | \`--confirm\` global flag; \`#[command(version)]\`; unsupported chain gate |
| \`src/commands/swap.rs\` | Preview gate; \`price_impact_pct\`; human-readable fields; pre-flight balance check |
| \`src/commands/add_liquidity.rs\` | Preview gate; pre-flight balance check; \`amounts\` display; \`lp_received\` |
| \`src/commands/remove_liquidity.rs\` | Preview gate; LP balance skip for preview path; \`lp_amount\` display; \`coins_received\`; enhanced dry_run |
| \`src/commands/get_pool_info.rs\` | Unknown pool returns \`bail!\` (ok:false) |
| \`src/config.rs\` | Arbitrum USDC → USDC.e; USDC.E alias added |
| \`Cargo.toml\` / \`Cargo.lock\` | Version → 0.2.8 |
| \`plugin.yaml\` / \`plugin.json\` | Version → 0.2.8 |
| \`SKILL.md\` | Version → 0.2.8; Proactive Onboarding + Quickstart sections |

## Live Verification

**Preview (no broadcast — verified):**
```bash
curve --chain 8453 swap \
  --token-in 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
  --token-out 0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93 \
  --amount 0.1 --wallet 0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9
# Output: {"ok":true,"preview":true,"note":"Re-run with --confirm to execute...","calldata":"0x3df02124..."}
```

**Execute with --confirm:**
```bash
curve --chain 8453 --confirm swap \
  --token-in 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
  --token-out 0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93 \
  --amount 0.1 --wallet 0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9
```
- Pool: Curve 4pool on Base (\`0xf6C5F01C7F3148891ad0e19DF78743D31E390D1f\`)
- Swap: 0.1 USDC → ~0.1001 crvUSD
- tx_hash: \`0x2ccf77e08b8cad0a1eabea082cf12428bc358db9ae2579bf4f8782a47948828b\`
- Explorer: BaseScan ✅

## Checklist

- [x] Write commands without \`--confirm\` return \`preview:true\` JSON (exit 0)
- [x] \`curve-plugin --version\` prints version string
- [x] Version consistent in all 8 locations (Cargo.toml, Cargo.lock, plugin.yaml, plugin.json, SKILL.md frontmatter, download URL, telemetry, LOCAL_VER)
- [x] Proactive Onboarding and Quickstart sections present in SKILL.md
- [x] Live end-to-end verification (Base, 0.1 USDC→crvUSD, tx \`0x2ccf77...\`)
- [x] No merge conflicts (rebased onto upstream/main, incorporates upstream v0.2.7 changes)

---

## Proactive Onboarding

When a user signals they are **new or just installed** this plugin — e.g. "I just installed curve",
"how do I get started with Curve", "what can I do with Curve" — **do not wait for them to ask
specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
waiting for confirmation before proceeding to the next:

1. **Choose chain** — ask the user which chain they want to use. Supported: Ethereum (1), Arbitrum (42161),
   Base (8453), Polygon (137), BSC (56). Use their answer for `<CHAIN>` in all subsequent steps.
   If unsure, suggest Ethereum for stablecoin swaps (deepest liquidity) or Base for low gas fees.
2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. You need at least a small amount
   of the token you want to swap (e.g. 0.5 USDC, 0.001 stETH). If insufficient, explain what's
   needed and how to fund (bridge, CEX withdrawal, or swap).
4. **Explore pools** — run `curve --chain <CHAIN> get-pools` to show available pools. Ask what tokens
   they hold and want to swap. Use `get-pool-info --pool <address>` for APY / fee details on a
   specific pool. Use `quote` to preview expected output before committing.
5. **Preview first write** — run the write command (e.g. `swap`) **without `--confirm`** so the
   user sees the preview JSON (including calldata and expected output) before any on-chain action.
   Confirm the `"preview": true` field is present and explain what it means.
6. **Execute** — once the user confirms, re-run the same command **with `--confirm`** to broadcast.
   Note: ERC-20 tokens (USDC, DAI, USDT) require an approval tx that fires first; the plugin waits
   for approval to confirm before submitting the swap.

**Important caveats discovered during live testing:**
- The `--wallet` flag is required for all write commands (preview and execute). The plugin cannot
  resolve the active onchainos wallet automatically — always pass `--wallet <address>`.
- Unsupported chains (any chain not in 1, 42161, 8453, 137, 56) return a clear error JSON and exit 1.

Do not dump all steps at once. Guide conversationally — confirm each step before moving on.

---

## Quickstart

New to curve-plugin? Follow these steps to go from zero to your first Curve swap on Ethereum.

### Step 1 — Connect your wallet

```bash
onchainos wallet login your@email.com
onchainos wallet addresses --chain 1
```

Confirm you see your Ethereum address before continuing.

### Step 2 — Check your balance

```bash
onchainos wallet balance --chain 1
```

Minimum recommended: any stablecoin (USDC, DAI, USDT) or LST (stETH, weETH) with a non-dust
balance. For stablecoins, even $0.50 is sufficient for a test swap. If your balance is zero,
bridge ETH or transfer tokens to Ethereum mainnet first.

### Step 3 — Browse available pools

```bash
curve --chain 1 get-pools
```

Returns the top 20 pools by TVL. Note the `address` field — you'll need it for add/remove
liquidity. For swap, you only need the token symbols (the plugin finds the best pool automatically).

For pool-specific details (fee, virtual price, coin decimals):

```bash
curve --chain 1 get-pool-info --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
```

To get a swap quote before committing:

```bash
curve --chain 1 quote --token-in USDC --token-out DAI --amount 1.0
```

### Step 4 — Preview before executing

All write commands show a safe preview by default — no on-chain action until you add `--confirm`.
The `--wallet` flag is required:

```bash
# Preview (safe — no tx sent):
curve --chain 1 swap --token-in USDC --token-out DAI --amount 0.5 \
  --wallet 0xYOUR_WALLET

# Execute (add --confirm):
curve --chain 1 --confirm swap --token-in USDC --token-out DAI --amount 0.5 \
  --wallet 0xYOUR_WALLET
```

Check for `"preview": true` in the preview output and `"note": "Re-run with --confirm..."` before
confirming.

### Step 5 — Swap tokens

```bash
curve --chain 1 --confirm swap \
  --token-in USDC \
  --token-out DAI \
  --amount 0.5 \
  --slippage 0.005 \
  --wallet 0xYOUR_WALLET
```

Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer": "<block_explorer_url>"`.

**Note:** ERC-20 swaps (USDC, DAI, USDT) fire an approve tx first. You will see:
`Approving USDC for Curve pool...` followed by `Approve tx: 0x... — waiting for confirmation...`
before the swap tx broadcasts. This is expected and safe.

### Step 6 — (Optional) Add liquidity to 3pool

```bash
# Preview: add 0.5 USDC to the 3pool (DAI=0, USDC=0.5, USDT=0)
curve --chain 1 add-liquidity \
  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
  --amounts "0,0.5,0" \
  --wallet 0xYOUR_WALLET

# Execute:
curve --chain 1 --confirm add-liquidity \
  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
  --amounts "0,0.5,0" \
  --wallet 0xYOUR_WALLET
```

Amounts are in human-readable units matching pool coin order (DAI, USDC, USDT for 3pool). After
adding liquidity, check your LP balance with:

```bash
curve --chain 1 get-balances --wallet 0xYOUR_WALLET
```

### Step 7 — (Optional) Remove liquidity

```bash
# Preview: remove all LP as USDC (coin index 1 in 3pool)
curve --chain 1 remove-liquidity \
  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
  --coin-index 1 \
  --min-amounts 0 \
  --wallet 0xYOUR_WALLET

# Execute:
curve --chain 1 --confirm remove-liquidity \
  --pool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7 \
  --coin-index 1 \
  --min-amounts 0 \
  --wallet 0xYOUR_WALLET
```

---
