### PR TITLE
fix(lido): v0.2.8 — quickstart, async process, float precision, User-Agent

### DIFF
--- a/skills/lido-plugin/.claude-plugin/plugin.json
+++ b/skills/lido-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lido",
   "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/lido-plugin/Cargo.lock
+++ b/skills/lido-plugin/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "lido-plugin"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/lido-plugin/Cargo.toml
+++ b/skills/lido-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lido-plugin"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/lido-plugin/SKILL.md
+++ b/skills/lido-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lido-plugin
 description: Stake ETH with Lido liquid staking protocol to receive stETH, manage withdrawals, and track staking rewards. Supports staking, balance queries, withdrawal requests, withdrawal status, and claiming finalized withdrawals on Ethereum mainnet.
-version: "0.2.7"
+version: "0.2.8"
 author: GeoGu360
 ---
 
@@ -18,7 +18,7 @@ author: GeoGu360
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/lido-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.7"
+LOCAL_VER="0.2.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -91,7 +91,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido-plugin@0.2.7/lido-plugin-${TARGET}${EXT}" -o ~/.local/bin/.lido-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido-plugin@0.2.8/lido-plugin-${TARGET}${EXT}" -o ~/.local/bin/.lido-plugin-core${EXT}
 chmod +x ~/.local/bin/.lido-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -99,7 +99,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/lido-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.7" > "$HOME/.plugin-store/managed/lido-plugin"
+echo "0.2.8" > "$HOME/.plugin-store/managed/lido-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -119,7 +119,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"lido-plugin","version":"0.2.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"lido-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/lido-plugin/plugin.yaml
+++ b/skills/lido-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: lido-plugin
-version: "0.2.7"
+version: "0.2.8"
 description: "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet"
 author:
   name: GeoGu360

--- a/skills/lido-plugin/src/commands/balance.rs
+++ b/skills/lido-plugin/src/commands/balance.rs
@@ -11,10 +11,10 @@ pub struct BalanceArgs {
 pub async fn run(args: BalanceArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
-    let address = args
-        .address
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let address = match args.address.clone() {
+        Some(a) => a,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if address.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --address or ensure onchainos is logged in.");
     }

--- a/skills/lido-plugin/src/commands/claim_withdrawal.rs
+++ b/skills/lido-plugin/src/commands/claim_withdrawal.rs
@@ -27,10 +27,10 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
     }
 
     // Resolve wallet address — must not be zero
-    let wallet = args
-        .from
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let wallet = match args.from.clone() {
+        Some(f) => f,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if wallet.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }

--- a/skills/lido-plugin/src/commands/get_withdrawals.rs
+++ b/skills/lido-plugin/src/commands/get_withdrawals.rs
@@ -11,10 +11,10 @@ pub struct GetWithdrawalsArgs {
 pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
-    let address = args
-        .address
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let address = match args.address.clone() {
+        Some(a) => a,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if address.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --address or ensure onchainos is logged in.");
     }
@@ -140,7 +140,7 @@ async fn fetch_wait_times(ids: &[u128]) -> Option<Vec<Option<String>>> {
     let client = reqwest::Client::new();
     let resp = client
         .get(&url)
-        .header("User-Agent", "lido-plugin/0.1.0")
+        .header("User-Agent", "lido-plugin/0.2.8")
         .send()
         .await
         .ok()?;
@@ -159,14 +159,23 @@ async fn fetch_wait_times(ids: &[u128]) -> Option<Vec<Option<String>>> {
                 if entry["status"].as_str() == Some("finalized") {
                     return None;
                 }
-                entry["requestInfo"]["finalizationIn"]
-                    .as_str()
-                    .map(|s| Some(s.to_string()))
-                    .unwrap_or_else(|| {
-                        entry["expectedWaitTimeSeconds"]
-                            .as_u64()
-                            .map(|s| format!("{}s", s))
+                // finalizationIn is a millisecond integer, not a string
+                if let Some(ms) = entry["requestInfo"]["finalizationIn"].as_u64() {
+                    let hours = ms / 3_600_000;
+                    let days = hours / 24;
+                    Some(if days > 0 {
+                        format!("~{} day{}", days, if days == 1 { "" } else { "s" })
+                    } else if hours > 0 {
+                        format!("~{} hour{}", hours, if hours == 1 { "" } else { "s" })
+                    } else {
+                        format!("~{} min", ms / 60_000)
                     })
+                } else {
+                    // Fallback: older API shape uses expectedWaitTimeSeconds
+                    entry["expectedWaitTimeSeconds"]
+                        .as_u64()
+                        .map(|s| format!("~{}s", s))
+                }
             })
             .collect(),
     )

--- a/skills/lido-plugin/src/commands/mod.rs
+++ b/skills/lido-plugin/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod balance;
 pub mod claim_withdrawal;
 pub mod get_apy;
 pub mod get_withdrawals;
+pub mod quickstart;
 pub mod request_withdrawal;
 pub mod stake;
 pub mod unwrap;

--- a/skills/lido-plugin/src/commands/quickstart.rs
+++ b/skills/lido-plugin/src/commands/quickstart.rs
@@ -1,0 +1,168 @@
+use serde_json::json;
+
+const ABOUT: &str = "Lido is the leading liquid staking protocol on Ethereum — stake ETH to \
+    receive stETH (rebasing yield token) or wstETH (wrapped, compatible with DeFi). $35B+ TVL.";
+
+const RPC_URL: &str = "https://ethereum.publicnode.com";
+
+// stETH balance threshold for "active" classification: 0.001 stETH
+const MIN_STETH_ACTIVE: u128 = 1_000_000_000_000_000; // 0.001 × 1e18
+
+// Minimum ETH for gas to be considered "ready": 0.005 ETH
+const MIN_ETH_READY_WEI: u128 = 5_000_000_000_000_000; // 0.005 × 1e18
+
+async fn eth_balance_wei(wallet: &str, rpc_url: &str) -> u128 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [wallet, "latest"],
+        "id": 1
+    });
+    match client.post(rpc_url).json(&body).send().await {
+        Ok(resp) => {
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => val["result"].as_str()
+                    .and_then(|s| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                    .unwrap_or(0),
+                Err(_) => 0,
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+pub async fn run() -> anyhow::Result<()> {
+    let wallet = crate::onchainos::resolve_wallet(1).await
+        .map_err(|e| anyhow::anyhow!("Cannot resolve wallet: {e}"))?;
+
+    if wallet.is_empty() {
+        anyhow::bail!("No wallet found. Run: onchainos wallet login your@email.com");
+    }
+
+    eprintln!(
+        "Checking assets for {}... on Ethereum...",
+        &wallet[..10.min(wallet.len())]
+    );
+
+    // Fetch balances in parallel
+    let (eth_wei, steth_raw, wsteth_raw) = tokio::join!(
+        eth_balance_wei(&wallet, RPC_URL),
+        async {
+            let calldata = crate::rpc::calldata_single_address(
+                crate::config::SEL_BALANCE_OF,
+                &wallet,
+            );
+            match crate::onchainos::eth_call(1, crate::config::STETH_ADDRESS, &calldata).await {
+                Ok(val) => {
+                    match crate::rpc::extract_return_data(&val) {
+                        Ok(hex) => crate::rpc::decode_uint256(&hex).unwrap_or(0),
+                        Err(_) => 0,
+                    }
+                }
+                Err(_) => 0,
+            }
+        },
+        async {
+            let calldata = crate::rpc::calldata_single_address(
+                crate::config::SEL_BALANCE_OF,
+                &wallet,
+            );
+            match crate::onchainos::eth_call(1, crate::config::WSTETH_ADDRESS, &calldata).await {
+                Ok(val) => {
+                    match crate::rpc::extract_return_data(&val) {
+                        Ok(hex) => crate::rpc::decode_uint256(&hex).unwrap_or(0),
+                        Err(_) => 0,
+                    }
+                }
+                Err(_) => 0,
+            }
+        },
+    );
+
+    let eth_balance = eth_wei as f64 / 1e18;
+    let steth_balance = steth_raw as f64 / 1e18;
+    let wsteth_balance = wsteth_raw as f64 / 1e18;
+
+    let has_staked = steth_raw >= MIN_STETH_ACTIVE || wsteth_raw >= MIN_STETH_ACTIVE;
+    let has_gas = eth_wei >= MIN_ETH_READY_WEI;
+
+    let (status, suggestion, onboarding_steps, next_command): (&str, &str, Vec<String>, String) =
+        if has_staked {
+            (
+                "active",
+                "You have an active Lido position. Check your stETH balance and accruing rewards.",
+                vec![],
+                format!("lido-plugin balance"),
+            )
+        } else if has_gas {
+            (
+                "ready",
+                "Your wallet has ETH. Stake to receive stETH and start earning yield.",
+                vec![
+                    "1. Check the current staking APR:".to_string(),
+                    "   lido-plugin get-apy".to_string(),
+                    "2. Preview stake (no tx sent):".to_string(),
+                    format!("   lido-plugin stake --amount-eth {:.4}", (eth_balance * 0.5).max(0.01)),
+                    "3. Execute stake:".to_string(),
+                    format!(
+                        "   lido-plugin --confirm stake --amount-eth {:.4}",
+                        (eth_balance * 0.5).max(0.01)
+                    ),
+                    "4. Check your stETH balance:".to_string(),
+                    "   lido-plugin balance".to_string(),
+                ],
+                "lido-plugin get-apy".to_string(),
+            )
+        } else if !has_gas && (steth_raw > 0 || wsteth_raw > 0) {
+            // Has some tokens but below active threshold, no gas
+            (
+                "needs_gas",
+                "You have stETH/wstETH but need more ETH for gas. Send ETH to your wallet.",
+                vec![
+                    "1. Send at least 0.005 ETH (gas) to:".to_string(),
+                    format!("   {}", wallet),
+                    "2. Run quickstart again:".to_string(),
+                    "   lido-plugin quickstart".to_string(),
+                ],
+                "lido-plugin quickstart".to_string(),
+            )
+        } else {
+            (
+                "no_funds",
+                "No ETH found. Send ETH to your wallet on Ethereum mainnet to start staking.",
+                vec![
+                    "1. Send ETH to your wallet on Ethereum mainnet:".to_string(),
+                    format!("   {}", wallet),
+                    "   Minimum recommended: 0.01 ETH (covers gas + meaningful stake)".to_string(),
+                    "2. Run quickstart again:".to_string(),
+                    "   lido-plugin quickstart".to_string(),
+                    "3. Check the current APR:".to_string(),
+                    "   lido-plugin get-apy".to_string(),
+                ],
+                "lido-plugin quickstart".to_string(),
+            )
+        };
+
+    let mut out = json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "chain": "Ethereum",
+        "assets": {
+            "eth_balance": format!("{:.6}", eth_balance),
+            "steth_balance": format!("{:.6}", steth_balance),
+            "wsteth_balance": format!("{:.6}", wsteth_balance),
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = json!(onboarding_steps);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}

--- a/skills/lido-plugin/src/commands/request_withdrawal.rs
+++ b/skills/lido-plugin/src/commands/request_withdrawal.rs
@@ -23,15 +23,16 @@ pub async fn run(args: RequestWithdrawalArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
     // Resolve wallet address — must not be zero
-    let wallet = args
-        .from
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let wallet = match args.from.clone() {
+        Some(f) => f,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if wallet.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    let amount_wei = (args.amount_eth * 1e18) as u128;
+    // Convert stETH to wei — round() avoids f64 truncation on values like 0.1 ETH
+    let amount_wei = (args.amount_eth * 1e18_f64).round() as u128;
     if amount_wei < config::MIN_WITHDRAWAL_WEI {
         anyhow::bail!(
             "Withdrawal amount {} wei is below minimum {} wei",

--- a/skills/lido-plugin/src/commands/stake.rs
+++ b/skills/lido-plugin/src/commands/stake.rs
@@ -27,16 +27,16 @@ pub async fn run(args: StakeArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
     // Resolve wallet address
-    let wallet = args
-        .from
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let wallet = match args.from.clone() {
+        Some(f) => f,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if wallet.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    // Convert ETH to wei
-    let amount_wei = (args.amount_eth * 1e18) as u128;
+    // Convert ETH to wei — round() avoids f64 truncation on values like 0.1 ETH
+    let amount_wei = (args.amount_eth * 1e18_f64).round() as u128;
     if amount_wei == 0 {
         anyhow::bail!("Stake amount must be greater than 0");
     }

--- a/skills/lido-plugin/src/commands/unwrap.rs
+++ b/skills/lido-plugin/src/commands/unwrap.rs
@@ -20,15 +20,15 @@ pub struct UnwrapArgs {
 pub async fn run(args: UnwrapArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
-    let wallet = args
-        .from
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let wallet = match args.from.clone() {
+        Some(f) => f,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if wallet.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    let amount_wei = (args.amount_wsteth * 1e18) as u128;
+    let amount_wei = (args.amount_wsteth * 1e18_f64).round() as u128;
     if amount_wei == 0 {
         anyhow::bail!("Amount must be greater than 0.");
     }

--- a/skills/lido-plugin/src/commands/wrap.rs
+++ b/skills/lido-plugin/src/commands/wrap.rs
@@ -20,15 +20,15 @@ pub struct WrapArgs {
 pub async fn run(args: WrapArgs) -> anyhow::Result<()> {
     let chain_id = config::CHAIN_ID;
 
-    let wallet = args
-        .from
-        .clone()
-        .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+    let wallet = match args.from.clone() {
+        Some(f) => f,
+        None => onchainos::resolve_wallet(chain_id).await.unwrap_or_default(),
+    };
     if wallet.is_empty() {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    let amount_wei = (args.amount_steth * 1e18) as u128;
+    let amount_wei = (args.amount_steth * 1e18_f64).round() as u128;
     if amount_wei == 0 {
         anyhow::bail!("Amount must be greater than 0.");
     }

--- a/skills/lido-plugin/src/main.rs
+++ b/skills/lido-plugin/src/main.rs
@@ -6,7 +6,7 @@ mod rpc;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "lido", about = "Lido liquid staking plugin for onchainos")]
+#[command(name = "lido", version, about = "Lido liquid staking plugin for onchainos")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -30,6 +30,8 @@ enum Commands {
     Wrap(commands::wrap::WrapArgs),
     /// Unwrap wstETH back to stETH
     Unwrap(commands::unwrap::UnwrapArgs),
+    /// Check wallet state and get guided next steps
+    Quickstart,
 }
 
 #[tokio::main]
@@ -44,5 +46,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::ClaimWithdrawal(args) => commands::claim_withdrawal::run(args).await,
         Commands::Wrap(args) => commands::wrap::run(args).await,
         Commands::Unwrap(args) => commands::unwrap::run(args).await,
+        Commands::Quickstart => commands::quickstart::run().await,
     }
 }

--- a/skills/lido-plugin/src/onchainos.rs
+++ b/skills/lido-plugin/src/onchainos.rs
@@ -1,11 +1,11 @@
-use std::process::Command;
+use tokio::process::Command;
 use serde_json::Value;
 
-pub fn resolve_wallet(chain_id: u64) -> anyhow::Result<String> {
+pub async fn resolve_wallet(chain_id: u64) -> anyhow::Result<String> {
     let chain_str = chain_id.to_string();
     let output = Command::new("onchainos")
         .args(["wallet", "balance", "--chain", &chain_str])
-        .output()?;
+        .output().await?;
     let json: Value = serde_json::from_str(&String::from_utf8_lossy(&output.stdout))?;
     // Try data.address first (legacy), then data.details[0].tokenAssets[0].address
     if let Some(addr) = json["data"]["address"].as_str() {
@@ -61,7 +61,7 @@ pub async fn wallet_contract_call(
         if force {
         args.push("--force");
     }
-    let output = Command::new("onchainos").args(&args).output()?;
+    let output = Command::new("onchainos").args(&args).output().await?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(serde_json::from_str(&stdout)?)
 }


### PR DESCRIPTION
## Summary

1. **`quickstart` command added** (`src/commands/quickstart.rs`)
   - Resolves wallet, fetches ETH + stETH + wstETH balances in parallel via `tokio::join!`
   - Classifies state: `active` / `ready` / `needs_gas` / `no_funds`
   - Returns JSON with `about`, `wallet`, `assets`, `status`, `suggestion`, `next_command`, `onboarding_steps`

2. **Async process fix** (`src/onchainos.rs` + all 8 command files)
   - Bug: `std::process::Command::output()` blocks the tokio thread in async functions
   - Fix: switch to `tokio::process::Command`; `resolve_wallet` made async; all 8 callers updated from `unwrap_or_else` to explicit `match/await` pattern
   - Affected: `stake`, `request-withdrawal`, `claim-withdrawal`, `get-withdrawals`, `balance`, `wrap`, `unwrap`, `quickstart`

3. **Float precision fix** (`stake.rs`, `request_withdrawal.rs`, `wrap.rs`, `unwrap.rs`)
   - Bug: `(amount * 1e18) as u128` truncates for f64 values like 0.1 ETH
   - Fix: `.round()` before cast eliminates f64 representation error

4. **Stale User-Agent** (`get_withdrawals.rs`)
   - Bug: `User-Agent: lido-plugin/0.1.0` — stale since v0.1.0
   - Fix: updated to `lido-plugin/0.2.8`

5. **`--version` flag** (`main.rs`)
   - Added `version` attribute so `lido --version` returns the current version string

6. **Version bump → 0.2.8** — all 8 locations consistent (Cargo.toml, Cargo.lock, SKILL.md, plugin.yaml, plugin.json, LOCAL_VER, download URL, telemetry)

## Files Changed

| File | Change |
|------|--------|
| `src/commands/quickstart.rs` | New — quickstart command |
| `src/commands/mod.rs` | Add `pub mod quickstart` |
| `src/main.rs` | Add `version`, wire `Quickstart` subcommand |
| `src/onchainos.rs` | `std::process::Command` → `tokio::process::Command`; `resolve_wallet` async |
| `src/commands/stake.rs` | Async wallet resolution; float precision `.round()` |
| `src/commands/request_withdrawal.rs` | Async wallet resolution; float precision `.round()` |
| `src/commands/balance.rs` | Async wallet resolution |
| `src/commands/claim_withdrawal.rs` | Async wallet resolution |
| `src/commands/get_withdrawals.rs` | Async wallet resolution; User-Agent 0.1.0→0.2.8 |
| `src/commands/wrap.rs` | Async wallet resolution; float precision `.round()` |
| `src/commands/unwrap.rs` | Async wallet resolution; float precision `.round()` |
| `Cargo.toml`, `Cargo.lock` | Version 0.2.8 |
| `SKILL.md`, `plugin.yaml`, `plugin.json` | Version 0.2.8; Proactive Onboarding + Quickstart sections |

## Live Verification

```
$ lido stake --amount-eth 0.001 --confirm
=== Lido Stake ===
From:        0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9
Amount:      0.001 ETH (1000000000000000 wei)
...
Transaction submitted: 0xa0dcbadd510b481df3573503bcd9e0d62b142ccad20b52bdbba25e336625f070
```

tx_hash: `0xa0dcbadd510b481df3573503bcd9e0d62b142ccad20b52bdbba25e336625f070` (Ethereum mainnet, chain 1)

```
$ lido get-withdrawals
{"ok":true,"address":"0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9","count":0,"requests":[]}
```

## Checklist

- [x] All 8 version locations consistent at 0.2.8
- [x] `lido --version` returns `lido 0.2.8`
- [x] `tokio::process::Command` — no blocking thread in async runtime
- [x] Float precision fix — `0.1 ETH` → `100000000000000000 wei` (not truncated)
- [x] User-Agent updated to current version
- [x] PR modifies only `skills/lido-plugin/`
- [x] Live end-to-end verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Proactive Onboarding

When a user signals they are **new or just installed** this plugin — e.g. "I just installed lido", "how do I stake ETH", "what can I do with this", "help me get started with Lido" — **do not wait for them to ask specific questions.** Proactively walk them through the Quickstart in order, one step at a time, waiting for confirmation before proceeding to the next:

1. **Check wallet** — run `onchainos wallet addresses --chain 1`. If no address, direct them to connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
2. **Check balance** — run `onchainos wallet balance --chain 1`. Look for ETH balance. Very small amounts (< 0.01 ETH) are uneconomical after gas; suggest a reasonable amount.
3. **Show current APR** — run `lido get-apy` to show the current staking rate. This sets expectations before any commitment.
4. **Preview stake** — run `lido stake --amount-eth <X>` without `--confirm` to show the preview. Confirm wallet address and amount look correct.
5. **Execute** — once they confirm, re-run with `--confirm`.
6. **Explain what happens next** — stETH balance grows daily via rebase; no action needed. If they want to exit, explain the withdrawal queue (1–5 days).

Do not dump all steps at once. Guide conversationally — confirm each step before moving on.

---

## Quickstart

New to Lido? Follow these steps to go from zero to your first stETH position.

### Step 1 — Connect your wallet

```bash
onchainos wallet login your@email.com
onchainos wallet addresses --chain 1
```

Confirm an Ethereum mainnet address is active before proceeding.

### Step 2 — Check your balance and current APR

```bash
onchainos wallet balance --chain 1
lido get-apy
```

You need ETH on Ethereum mainnet (chain 1). Very small amounts (< 0.01 ETH) are uneconomical after gas costs. The `get-apy` output shows the current annualized staking rate.

### Step 3 — Preview before staking

All write commands show a safe preview by default — no on-chain action until you add `--confirm`:

```bash
# Preview (safe — no tx sent):
lido stake --amount-eth 0.1

# Execute (add --confirm):
lido stake --amount-eth 0.1 --confirm
```

### Step 4 — Stake ETH to receive stETH

```bash
lido stake --amount-eth 0.1 --confirm
```

You will receive stETH at approximately 1:1. Your stETH balance grows automatically every day via protocol rebase — no claiming or staking actions required.

### Step 5 — Monitor your balance

```bash
lido balance
```

stETH balance increases daily. No action is needed to accumulate rewards.

### Step 6 — (Optional) Wrap stETH to wstETH

wstETH is a non-rebasing ERC-20 suitable for DeFi protocols:

```bash
lido wrap --amount-steth 0.1 --confirm
```

To unwrap back to stETH:

```bash
lido unwrap --amount-wsteth 0.1 --confirm
```

### Step 7 — (Optional) Withdraw back to ETH

**Step 7a — Request withdrawal** (mints a WithdrawalNFT):
```bash
lido request-withdrawal --amount-eth 0.1 --confirm
```

**Step 7b — Monitor status**:
```bash
lido get-withdrawals
```

Withdrawals typically take 1–5 days. Once status is `READY_TO_CLAIM`:

**Step 7c — Claim ETH**:
```bash
lido claim-withdrawal --ids <ID> --confirm
```

---