### PR TITLE
fix(morpho): always pass resolved --from to onchainos on all chains (v0.2.5)

### DIFF
--- a/skills/morpho-plugin/.claude-plugin/plugin.json
+++ b/skills/morpho-plugin/.claude-plugin/plugin.json
@@ -1,10 +1,20 @@
 {
   "name": "morpho",
-  "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "0.2.4",
-  "author": {"name": "GeoGu360", "github": "GeoGu360"},
+  "description": "Supply, borrow and earn yield on Morpho \u2014 a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
+  "version": "0.2.2",
+  "author": {
+    "name": "GeoGu360",
+    "github": "GeoGu360"
+  },
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",
   "license": "MIT",
-  "keywords": ["lending", "borrowing", "defi", "earn", "morpho", "collateral"]
+  "keywords": [
+    "lending",
+    "borrowing",
+    "defi",
+    "earn",
+    "morpho",
+    "collateral"
+  ]
 }

--- a/skills/morpho-plugin/.claude-plugin/plugin.json
+++ b/skills/morpho-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morpho",
   "description": "Supply, borrow and earn yield on Morpho \u2014 a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/morpho-plugin/.claude-plugin/plugin.json
+++ b/skills/morpho-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morpho",
   "description": "Supply, borrow and earn yield on Morpho \u2014 a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/morpho-plugin/.claude-plugin/plugin.json
+++ b/skills/morpho-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morpho",
   "description": "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults.",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/morpho-plugin/Cargo.lock
+++ b/skills/morpho-plugin/Cargo.lock
@@ -1512,8 +1512,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "morpho"
-version = "0.2.2"
+name = "morpho-plugin"
+version = "0.2.3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/morpho-plugin/Cargo.toml
+++ b/skills/morpho-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morpho-plugin"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/morpho-plugin/Cargo.toml
+++ b/skills/morpho-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morpho-plugin"
-version = "0.2.4"
+version = "0.2.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/morpho-plugin/Cargo.toml
+++ b/skills/morpho-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morpho-plugin"
-version = "0.2.3"
+version = "0.2.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/morpho-plugin/SKILL.md
+++ b/skills/morpho-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: morpho-plugin
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults."
-version: "0.2.4"
+version: "0.2.2"
 author: "GeoGu360"
 tags:
   - lending
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/morpho-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.4"
+LOCAL_VER="0.2.2"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then

--- a/skills/morpho-plugin/SKILL.md
+++ b/skills/morpho-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: morpho-plugin
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults."
-version: "0.2.2"
+version: "0.2.3"
 author: "GeoGu360"
 tags:
   - lending
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/morpho-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.2"
+LOCAL_VER="0.2.3"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then

--- a/skills/morpho-plugin/SKILL.md
+++ b/skills/morpho-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: morpho-plugin
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL. Trigger phrases: supply to morpho, deposit to morpho vault, borrow from morpho, repay morpho loan, morpho health factor, my morpho positions, morpho interest rates, claim morpho rewards, morpho markets, metamorpho vaults."
-version: "0.2.3"
+version: "0.2.5"
 author: "GeoGu360"
 tags:
   - lending
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/morpho-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.3"
+LOCAL_VER="0.2.5"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho-plugin@0.2.4/morpho-plugin-${TARGET}${EXT}" -o ~/.local/bin/.morpho-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/morpho-plugin@0.2.5/morpho-plugin-${TARGET}${EXT}" -o ~/.local/bin/.morpho-plugin-core${EXT}
 chmod +x ~/.local/bin/.morpho-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/morpho-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.4" > "$HOME/.plugin-store/managed/morpho-plugin"
+echo "0.2.5" > "$HOME/.plugin-store/managed/morpho-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"morpho-plugin","version":"0.2.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"morpho-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -746,6 +746,10 @@ morpho --chain 8453 vaults --asset WETH
 ---
 
 ## Changelog
+
+### v0.2.5
+- **Fix: resolved wallet address now always forwarded as `--from`** — All 7 write commands (`supply`, `withdraw`, `borrow`, `repay`, `supply-collateral`, `withdraw-collateral`, `claim-rewards`) now pass the resolved wallet address explicitly to onchainos. Previously, when `--from` was omitted, `resolve_wallet()` determined the address but the original `None` was forwarded, causing broadcast failures on Base (chain 8453) where onchainos cannot infer the signer without an explicit address.
+- **Fix: `wait_for_tx` timeout extended to 40s on all chains** — Base (~2s block time) was previously limited to 16s (8 attempts), causing false timeout errors when RPC lag delayed receipt confirmation. All chains now use 20 attempts × 2s = 40s.
 
 ### v0.2.2
 - **Safety: `--confirm` gate for all write operations** — Supply, withdraw, borrow, repay, supply-collateral, withdraw-collateral, and claim-rewards now require `--confirm` to broadcast. Calling without `--confirm` prints a rich `preview` JSON (operation, asset, amount, pending transactions) and exits safely. This prevents accidental on-chain execution.

--- a/skills/morpho-plugin/SKILL.md
+++ b/skills/morpho-plugin/SKILL.md
@@ -397,6 +397,7 @@ morpho --chain 1 repay --market-id 0xb323... --all --confirm
 - A 0.5% approval buffer is added to cover accrued interest between approval and repay transactions (1% buffer for `--all` mode).
 - Step 1 approves Morpho Blue to spend the loan token — submits immediately via `onchainos wallet contract-call --force`; waits for on-chain confirmation before proceeding.
 - Step 2 calls `repay(...)` — presents to user for confirmation via `onchainos wallet contract-call`.
+- **⚠️ Indexer lag (`--all`)**: The Morpho GraphQL API may lag 10–30 seconds behind on-chain state after opening or modifying a position. If you just opened a borrow position, wait at least 15–30 seconds before running `repay --all`. If `--all` reports zero debt, retry after waiting — the API may not yet reflect the new borrow.
 
 **Expected output:**
 <external-content>
@@ -572,6 +573,8 @@ morpho --chain 1 withdraw-collateral --market-id 0xb323... --all --confirm
 **What it does:**
 1. Fetches `MarketParams` from the Morpho GraphQL API
 2. Calls `withdrawCollateral(marketParams, assets, onBehalf, receiver)` — after user confirmation, submits via `onchainos wallet contract-call`
+
+> **⚠️ Indexer lag (`--all`)**: The Morpho GraphQL API may lag 10–30 seconds behind on-chain state after supplying collateral. If you just supplied collateral, wait at least 15–30 seconds before running `withdraw-collateral --all`. If `--all` reports zero collateral, retry after waiting — the API may not yet reflect the deposit. As a fallback, use `--amount` with the exact balance shown in `morpho positions`.
 
 **Expected output:**
 <external-content>

--- a/skills/morpho-plugin/src/commands/borrow.rs
+++ b/skills/morpho-plugin/src/commands/borrow.rs
@@ -64,7 +64,7 @@ pub async fn run(
         chain_id,
         cfg.morpho_blue,
         &borrow_calldata,
-        from,
+        Some(borrower),
         None,
         dry_run,
         false,

--- a/skills/morpho-plugin/src/commands/claim_rewards.rs
+++ b/skills/morpho-plugin/src/commands/claim_rewards.rs
@@ -65,7 +65,7 @@ pub async fn run(
         chain_id,
         cfg.merkl_distributor,
         &claim_calldata,
-        from,
+        Some(user),
         None,
         dry_run,
         false,

--- a/skills/morpho-plugin/src/commands/repay.rs
+++ b/skills/morpho-plugin/src/commands/repay.rs
@@ -106,7 +106,7 @@ pub async fn run(
     if dry_run {
         eprintln!("[morpho] [dry-run] Would approve: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, loan_token, approve_calldata);
     }
-    let approve_result = onchainos::wallet_contract_call(chain_id, &loan_token, &approve_calldata, from, None, dry_run, true).await?;  // --force: approval is a prerequisite step
+    let approve_result = onchainos::wallet_contract_call(chain_id, &loan_token, &approve_calldata, Some(borrower), None, dry_run, true).await?;  // --force: approval is a prerequisite step
     let approve_tx = onchainos::extract_tx_hash_or_err(&approve_result)?;
     onchainos::wait_for_tx(&approve_tx, cfg.rpc_url, chain_id).await?;
 
@@ -123,7 +123,7 @@ pub async fn run(
         chain_id,
         cfg.morpho_blue,
         &repay_calldata,
-        from,
+        Some(borrower),
         None,
         dry_run,
         false,

--- a/skills/morpho-plugin/src/commands/supply.rs
+++ b/skills/morpho-plugin/src/commands/supply.rs
@@ -60,7 +60,7 @@ pub async fn run(
     if dry_run {
         eprintln!("[morpho] [dry-run] Would approve: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, asset_addr, approve_calldata);
     }
-    let approve_result = onchainos::wallet_contract_call(chain_id, &asset_addr, &approve_calldata, from, None, dry_run, true).await?;
+    let approve_result = onchainos::wallet_contract_call(chain_id, &asset_addr, &approve_calldata, Some(wallet_addr.as_str()), None, dry_run, true).await?;
     let approve_tx = onchainos::extract_tx_hash_or_err(&approve_result)?;
     onchainos::wait_for_tx(&approve_tx, cfg.rpc_url, chain_id).await?;
 
@@ -69,7 +69,7 @@ pub async fn run(
     if dry_run {
         eprintln!("[morpho] [dry-run] Would deposit: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, vault, deposit_calldata);
     }
-    let deposit_result = onchainos::wallet_contract_call(chain_id, vault, &deposit_calldata, from, None, dry_run, false).await?;
+    let deposit_result = onchainos::wallet_contract_call(chain_id, vault, &deposit_calldata, Some(wallet_addr.as_str()), None, dry_run, false).await?;
     let deposit_tx = onchainos::extract_tx_hash_or_err(&deposit_result)?;
 
     let output = serde_json::json!({

--- a/skills/morpho-plugin/src/commands/supply_collateral.rs
+++ b/skills/morpho-plugin/src/commands/supply_collateral.rs
@@ -61,7 +61,7 @@ pub async fn run(
     if dry_run {
         eprintln!("[morpho] [dry-run] Would approve: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, collateral_token, approve_calldata);
     }
-    let approve_result = onchainos::wallet_contract_call(chain_id, &collateral_token, &approve_calldata, from, None, dry_run, true).await?;  // --force: approval is a prerequisite step
+    let approve_result = onchainos::wallet_contract_call(chain_id, &collateral_token, &approve_calldata, Some(supplier), None, dry_run, true).await?;  // --force: approval is a prerequisite step
     let approve_tx = onchainos::extract_tx_hash_or_err(&approve_result)?;
     onchainos::wait_for_tx(&approve_tx, cfg.rpc_url, chain_id).await?;
 
@@ -77,7 +77,7 @@ pub async fn run(
         chain_id,
         cfg.morpho_blue,
         &supply_calldata,
-        from,
+        Some(supplier),
         None,
         dry_run,
         false,

--- a/skills/morpho-plugin/src/commands/withdraw.rs
+++ b/skills/morpho-plugin/src/commands/withdraw.rs
@@ -71,7 +71,7 @@ pub async fn run(
         eprintln!("[morpho] [dry-run] Would call: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, vault, calldata_hex);
     }
 
-    let result = onchainos::wallet_contract_call(chain_id, vault, &calldata_hex, from, None, dry_run, false).await?;
+    let result = onchainos::wallet_contract_call(chain_id, vault, &calldata_hex, Some(owner), None, dry_run, false).await?;
     let tx_hash = onchainos::extract_tx_hash_or_err(&result)?;
 
     let output = serde_json::json!({

--- a/skills/morpho-plugin/src/commands/withdraw_collateral.rs
+++ b/skills/morpho-plugin/src/commands/withdraw_collateral.rs
@@ -85,7 +85,7 @@ pub async fn run(
         chain_id,
         cfg.morpho_blue,
         &withdraw_calldata,
-        from,
+        Some(owner),
         None,
         dry_run,
         false,

--- a/skills/morpho-plugin/src/onchainos.rs
+++ b/skills/morpho-plugin/src/onchainos.rs
@@ -59,12 +59,12 @@ pub async fn wallet_contract_call(
 
 /// Poll until a transaction is confirmed on-chain.
 /// Called after approve --force so the main op simulation sees the updated allowance.
-/// Uses chain-aware timeouts: Ethereum mainnet (~12s blocks) polls up to 40s; Base (~2s blocks) polls up to 16s.
-pub async fn wait_for_tx(tx_hash: &str, rpc_url: &str, chain_id: u64) -> anyhow::Result<()> {
+/// Uses 20 attempts × 2s = 40s for all chains (Base ~2s blocks still needs headroom for RPC lag).
+pub async fn wait_for_tx(tx_hash: &str, rpc_url: &str, _chain_id: u64) -> anyhow::Result<()> {
     if tx_hash == "0x0000000000000000000000000000000000000000000000000000000000000000" {
         return Ok(()); // dry-run stub hash — nothing to wait for
     }
-    let max_attempts: u32 = if chain_id == 1 { 20 } else { 8 }; // 40s for ETH mainnet, 16s for Base
+    let max_attempts: u32 = 20; // 40s — same for all chains
     let client = reqwest::Client::new();
     for _ in 0..max_attempts {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;


### PR DESCRIPTION
## Summary

- **Fix: resolved wallet address always forwarded as \`--from\`** — All 7 write commands resolved the wallet via \`resolve_wallet()\` but then passed the original \`from: None\` to \`wallet_contract_call\`, so onchainos never received \`--from\`. On Base (chain 8453), onchainos cannot infer the signer without an explicit address, causing all approve and write transactions to fail silently.
- **Fix: \`wait_for_tx\` timeout extended to 40s on all chains** — Base was previously limited to 8 attempts × 2s = 16s, causing false timeout errors despite the tx confirming fine. Now uniform 20 attempts × 2s = 40s across all chains.

## Affected commands
`supply`, `withdraw`, `borrow`, `repay`, `supply-collateral`, `withdraw-collateral`, `claim-rewards`

## Test plan
- [x] Built locally from worktree and ran `morpho --chain 8453 --confirm supply` without `--from`
- [x] Nonce incremented 193 → 195 (+2 for approve + deposit) on Base — both txs broadcast successfully
- [x] Approve tx: `0xad0c3397603a66ffe3f120eee9577ce2ed1f418f80703895a49610e4eacecad5`
- [x] Supply tx: `0x58247a50a6aeb8a0d8c0beacdf99697cde0ebba7ffdde0874a0f7032a84bd4a1`

## Version
`0.2.4` (main) → `0.2.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)