### PR TITLE
feat(clanker): v0.2.5 — add quickstart command, deploy-token preview gate

### DIFF
--- a/skills/clanker-plugin/.claude-plugin/plugin.json
+++ b/skills/clanker-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clanker",
   "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/clanker-plugin/.claude-plugin/plugin.json
+++ b/skills/clanker-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clanker",
   "description": "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/clanker-plugin/Cargo.lock
+++ b/skills/clanker-plugin/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clanker-plugin"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/clanker-plugin/Cargo.lock
+++ b/skills/clanker-plugin/Cargo.lock
@@ -500,8 +500,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clanker"
-version = "0.2.1"
+name = "clanker-plugin"
+version = "0.2.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/clanker-plugin/Cargo.toml
+++ b/skills/clanker-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clanker-plugin"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -145,7 +145,7 @@ Before running any command, verify:
    ```bash
    npx skills add clanker --global
    ```
-2. **`onchainos` is installed and logged in** — check with `onchainos wallet addresses`. If not logged in, run `onchainos login`.
+2. **`onchainos` is installed and logged in** — check with `onchainos wallet addresses`. If not logged in, run `onchainos wallet login`.
 3. **For write operations** (`deploy-token`, `claim-rewards`): ensure the wallet has sufficient ETH for gas on the target chain.
 
 ## Do NOT use for
@@ -493,6 +493,7 @@ clanker claim-rewards --token-address 0xTokenAddress --from 0xYourWallet --confi
 </external-content>
 
 **No rewards scenario:** If there are no claimable rewards, the plugin returns:
+<external-content>
 ```json
 {
   "ok": true,
@@ -502,6 +503,7 @@ clanker claim-rewards --token-address 0xTokenAddress --from 0xYourWallet --confi
   }
 }
 ```
+</external-content>
 
 ---
 

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -263,7 +263,7 @@ normal for newly deployed tokens.
 ### Step 6 — Preview a token deployment (safe — no tx sent)
 
 All write commands require `--dry-run` for preview or `--confirm` to execute. Without either flag,
-the command returns an error explaining what to do next.
+the command returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters — no transaction is sent.
 
 ```bash
 # Preview (safe — no tx sent):

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -345,12 +345,17 @@ clanker [--chain 8453] [--dry-run] deploy-token \
 
 **Example:**
 ```bash
-# Preview
+# Preview without wallet (uses zero address as placeholder)
 clanker --dry-run deploy-token --name "SkyDog" --symbol "SKYDOG"
+
+# Preview with your wallet (shows the deployer address in the preview output)
+clanker --dry-run deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 
 # Deploy (after user confirmation)
 clanker deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 ```
+
+> **Note on `--from` in dry-run:** Passing `--from <wallet_address>` to `--dry-run` affects the preview output — the deployer address shown in the response will be your wallet address instead of a placeholder. This is useful to verify the token admin / fee recipient is set correctly before deploying.
 
 **Expected output:**
 <external-content>

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clanker-plugin
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum. Trigger phrases: deploy token, launch token on Clanker, create token on Base, search Clanker tokens, list latest tokens, claim LP rewards, claim Clanker fees."
-version: "0.2.4"
+version: "0.2.5"
 author: "GeoGu360"
 tags:
   - token-launch
@@ -24,7 +24,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/clanker-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.4"
+LOCAL_VER="0.2.5"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -97,7 +97,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/clanker-plugin@0.2.4/clanker-plugin-${TARGET}${EXT}" -o ~/.local/bin/.clanker-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/clanker-plugin@0.2.5/clanker-plugin-${TARGET}${EXT}" -o ~/.local/bin/.clanker-plugin-core${EXT}
 chmod +x ~/.local/bin/.clanker-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -105,7 +105,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/clanker-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.4" > "$HOME/.plugin-store/managed/clanker-plugin"
+echo "0.2.5" > "$HOME/.plugin-store/managed/clanker-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -125,7 +125,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"clanker-plugin","version":"0.2.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"clanker-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -172,6 +172,7 @@ Do NOT use for: buying/selling Clanker tokens (use a DEX skill), non-Clanker tok
 
 | User Intent | Command | Type |
 |-------------|---------|------|
+| I'm new / how do I start? | `quickstart` | Read |
 | List latest tokens | `list-tokens` | Read |
 | Search by creator | `search-tokens --query <address|username>` | Read |
 | Get token details | `token-info --address <addr>` | Read |
@@ -182,130 +183,46 @@ Do NOT use for: buying/selling Clanker tokens (use a DEX skill), non-Clanker tok
 
 ## Proactive Onboarding
 
-When a user signals they are **new or just installed** this plugin — e.g. "I just installed clanker",
-"how do I get started", "what can I do with this", "how do I deploy a token" — **do not wait for them
-to ask specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
-waiting for confirmation before proceeding to the next:
+When a user is new or asks "how do I get started", call `clanker quickstart` first. This checks their actual wallet state and returns a personalised `next_command` and `onboarding_steps`.
 
-1. **Check wallet** — run `onchainos wallet addresses --chain 8453`. If no address, direct them to
-   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
-2. **Check balance** — run `onchainos wallet balance --chain 8453`. Deploying a token requires ETH for
-   gas (very cheap on Base, typically < $0.05). If insufficient, explain how to bridge ETH to Base.
-3. **Explore read-only** — run `clanker --chain 8453 list-tokens --limit 10` to show recent launches.
-   Ask if they want to search by creator or look up a specific token.
-4. **Preview deployment** — run `clanker --chain 8453 --dry-run deploy-token --name X --symbol Y --from <wallet>`
-   so they see deployment parameters (token admin, reward recipient, LP range) before any on-chain action.
-5. **Execute** — once they confirm, re-run with `--confirm` instead of `--dry-run`.
+```bash
+clanker quickstart
+```
 
-Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+Parse the JSON output:
+- `status: "active"` → has existing positions/balance; run relevant view command
+- `status: "ready"` → wallet funded; follow `next_command`
+- `status: "needs_gas"` → has tokens but no gas; ask user to send ETH/BNB
+- `status: "needs_funds"` → has gas but no tokens; show `onboarding_steps`
+- `status: "no_funds"` → wallet empty; show `onboarding_steps`
 
-**Key points for new users:**
-- `deploy-token` without `--confirm` and without `--dry-run` returns a safe preview (`ok:true, preview:true`) — use `--dry-run` to see full calldata
-- `--dry-run` is a **global flag** — it must come before the subcommand: `clanker --dry-run deploy-token ...`
-- The deployed token contract address is found in the Basescan tx receipt, not the CLI output
-- `claim-rewards` requires the user to have previously deployed a Clanker token and accrued LP fees
+**Key caveats:**
+- `--dry-run` is a global flag and must come before the subcommand: `clanker --dry-run deploy-token ...`
+- The deployed token contract address is found in the Basescan tx receipt, not the CLI output.
+- `claim-rewards` requires the user to have previously deployed a Clanker token and accrued LP fees.
 
 ---
 
-## Quickstart
-
-New to clanker-plugin? Follow these steps to go from zero to your first token deployment on Base.
-
-### Step 1 — Connect your wallet
+## Quickstart Command
 
 ```bash
-onchainos wallet login your@email.com
-onchainos wallet addresses --chain 8453
+clanker quickstart [--chain <ID>]
 ```
 
-### Step 2 — Check your balance
+Returns a personalised onboarding JSON based on the wallet's actual balances.
 
-```bash
-onchainos wallet balance --chain 8453
-```
+### Output Fields
 
-Minimum recommended: ~0.0005 ETH (~$1) for gas on Base. Token deployments on Base cost well under $0.05
-in gas at normal network conditions. If zero, bridge ETH to Base via a CEX withdrawal or bridge.
-
-### Step 3 — Browse recently deployed tokens
-
-```bash
-clanker --chain 8453 list-tokens --limit 10 --sort desc
-```
-
-Returns the 10 most recently deployed Clanker tokens. Each entry includes `contract_address`, `name`,
-`symbol`, `deployed_at`, and `pool_address`. Use `--sort asc` to see the oldest tokens first.
-Note: `--page` pagination is not functional in this version — all calls return the same page of results.
-
-### Step 4 — Search tokens by creator
-
-```bash
-# By Farcaster username:
-clanker search-tokens --query dwr
-
-# By wallet address:
-clanker search-tokens --query 0xYourWalletAddress
-```
-
-Returns all tokens deployed by that creator, with `trust_status` fields indicating whether the token
-is from a verified/trusted deployer. Use `--trusted-only` to filter to trusted creators only.
-
-### Step 5 — Look up a specific token
-
-```bash
-clanker --chain 8453 token-info --address 0xTokenAddress
-```
-
-Returns token metadata (`tokenName`, `tokenSymbol`, `decimal`) and price data if available. When a
-token has no oracle price yet, `price_available: false` and a `price_note` explain why — this is
-normal for newly deployed tokens.
-
-### Step 6 — Preview a token deployment (safe — no tx sent)
-
-For `deploy-token`, running without any flags returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters — no transaction is sent. For `claim-rewards`, `--dry-run` is required to preview; running without `--dry-run` or `--confirm` returns an error asking for confirmation.
-
-```bash
-# Preview (safe — no tx sent):
-clanker --chain 8453 --dry-run deploy-token \
-  --name "MyToken" \
-  --symbol "MTK" \
-  --from 0xYourWalletAddress
-```
-
-Expected output: `"dry_run": true`, shows `token_admin`, `reward_recipient`, `factory`, LP range,
-and hook config. Verify your wallet address appears as `token_admin` and `reward_recipient`.
-
-### Step 7 — Deploy your token
-
-```bash
-# Execute (add --confirm; remove --dry-run):
-clanker --chain 8453 deploy-token \
-  --name "MyToken" \
-  --symbol "MTK" \
-  --from 0xYourWalletAddress \
-  --confirm
-```
-
-Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer_url": "https://basescan.org/tx/0x..."`.
-The deployed contract address is NOT in the CLI output — find it in the Basescan tx receipt under
-"Internal Transactions" or the factory event logs. Wait ~30 seconds then run `token-info` to confirm.
-
-### Step 8 — Claim LP rewards (if you have a deployed token)
-
-```bash
-# Preview:
-clanker --chain 8453 --dry-run claim-rewards \
-  --token-address 0xYourDeployedTokenAddress \
-  --from 0xYourWalletAddress
-
-# Execute:
-clanker --chain 8453 claim-rewards \
-  --token-address 0xYourDeployedTokenAddress \
-  --from 0xYourWalletAddress \
-  --confirm
-```
-
-If no rewards have accrued yet, returns `"status": "no_rewards"` — this is normal for new tokens.
+| Field | Description |
+|-------|-------------|
+| `about` | Protocol description |
+| `wallet` | Resolved wallet address |
+| `chain` | Chain name |
+| `assets` | Wallet balances (gas token + key protocol tokens) |
+| `status` | `active` / `ready` / `needs_gas` / `needs_funds` / `no_funds` |
+| `suggestion` | Human-readable state description |
+| `next_command` | The single most useful command to run next |
+| `onboarding_steps` | Ordered steps to follow |
 
 ---
 

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -262,8 +262,7 @@ normal for newly deployed tokens.
 
 ### Step 6 — Preview a token deployment (safe — no tx sent)
 
-All write commands require `--dry-run` for preview or `--confirm` to execute. Without either flag,
-the command returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters — no transaction is sent.
+For `deploy-token`, running without any flags returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters — no transaction is sent. For `claim-rewards`, `--dry-run` is required to preview; running without `--dry-run` or `--confirm` returns an error asking for confirmation.
 
 ```bash
 # Preview (safe — no tx sent):
@@ -350,6 +349,7 @@ clanker --chain 8453 list-tokens --limit 10 --sort desc
       }
     ],
     "total": 1200,
+    "page": 1,
     "has_more": true
   }
 }
@@ -482,7 +482,7 @@ clanker deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 clanker --dry-run deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 
 # Deploy (after user confirmation):
-clanker --confirm deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
+clanker deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet --confirm
 ```
 
 > **Note:** `--from` is required for all three modes (preview, dry-run, and deploy). The plugin cannot resolve the active onchainos wallet automatically for token deployments. `--dry-run` must be a **global flag** before the subcommand.

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -200,7 +200,7 @@ waiting for confirmation before proceeding to the next:
 Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
 
 **Key points for new users:**
-- `deploy-token` without `--confirm` returns an error — use `--dry-run` to preview first
+- `deploy-token` without `--confirm` and without `--dry-run` returns a safe preview (`ok:true, preview:true`) — use `--dry-run` to see full calldata
 - `--dry-run` is a **global flag** — it must come before the subcommand: `clanker --dry-run deploy-token ...`
 - The deployed token contract address is found in the Basescan tx receipt, not the CLI output
 - `claim-rewards` requires the user to have previously deployed a Clanker token and accrued LP fees

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -180,6 +180,136 @@ Do NOT use for: buying/selling Clanker tokens (use a DEX skill), non-Clanker tok
 
 ---
 
+## Proactive Onboarding
+
+When a user signals they are **new or just installed** this plugin — e.g. "I just installed clanker",
+"how do I get started", "what can I do with this", "how do I deploy a token" — **do not wait for them
+to ask specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
+waiting for confirmation before proceeding to the next:
+
+1. **Check wallet** — run `onchainos wallet addresses --chain 8453`. If no address, direct them to
+   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
+2. **Check balance** — run `onchainos wallet balance --chain 8453`. Deploying a token requires ETH for
+   gas (very cheap on Base, typically < $0.05). If insufficient, explain how to bridge ETH to Base.
+3. **Explore read-only** — run `clanker --chain 8453 list-tokens --limit 10` to show recent launches.
+   Ask if they want to search by creator or look up a specific token.
+4. **Preview deployment** — run `clanker --chain 8453 --dry-run deploy-token --name X --symbol Y --from <wallet>`
+   so they see deployment parameters (token admin, reward recipient, LP range) before any on-chain action.
+5. **Execute** — once they confirm, re-run with `--confirm` instead of `--dry-run`.
+
+Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+
+**Key points for new users:**
+- `deploy-token` without `--confirm` returns an error — use `--dry-run` to preview first
+- `--dry-run` is a **global flag** — it must come before the subcommand: `clanker --dry-run deploy-token ...`
+- The deployed token contract address is found in the Basescan tx receipt, not the CLI output
+- `claim-rewards` requires the user to have previously deployed a Clanker token and accrued LP fees
+
+---
+
+## Quickstart
+
+New to clanker-plugin? Follow these steps to go from zero to your first token deployment on Base.
+
+### Step 1 — Connect your wallet
+
+```bash
+onchainos wallet login your@email.com
+onchainos wallet addresses --chain 8453
+```
+
+### Step 2 — Check your balance
+
+```bash
+onchainos wallet balance --chain 8453
+```
+
+Minimum recommended: ~0.0005 ETH (~$1) for gas on Base. Token deployments on Base cost well under $0.05
+in gas at normal network conditions. If zero, bridge ETH to Base via a CEX withdrawal or bridge.
+
+### Step 3 — Browse recently deployed tokens
+
+```bash
+clanker --chain 8453 list-tokens --limit 10 --sort desc
+```
+
+Returns the 10 most recently deployed Clanker tokens. Each entry includes `contract_address`, `name`,
+`symbol`, `deployed_at`, and `pool_address`. Use `--sort asc` to see the oldest tokens first.
+Note: `--page` pagination is not functional in this version — all calls return the same page of results.
+
+### Step 4 — Search tokens by creator
+
+```bash
+# By Farcaster username:
+clanker search-tokens --query dwr
+
+# By wallet address:
+clanker search-tokens --query 0xYourWalletAddress
+```
+
+Returns all tokens deployed by that creator, with `trust_status` fields indicating whether the token
+is from a verified/trusted deployer. Use `--trusted-only` to filter to trusted creators only.
+
+### Step 5 — Look up a specific token
+
+```bash
+clanker --chain 8453 token-info --address 0xTokenAddress
+```
+
+Returns token metadata (`tokenName`, `tokenSymbol`, `decimal`) and price data if available. When a
+token has no oracle price yet, `price_available: false` and a `price_note` explain why — this is
+normal for newly deployed tokens.
+
+### Step 6 — Preview a token deployment (safe — no tx sent)
+
+All write commands require `--dry-run` for preview or `--confirm` to execute. Without either flag,
+the command returns an error explaining what to do next.
+
+```bash
+# Preview (safe — no tx sent):
+clanker --chain 8453 --dry-run deploy-token \
+  --name "MyToken" \
+  --symbol "MTK" \
+  --from 0xYourWalletAddress
+```
+
+Expected output: `"dry_run": true`, shows `token_admin`, `reward_recipient`, `factory`, LP range,
+and hook config. Verify your wallet address appears as `token_admin` and `reward_recipient`.
+
+### Step 7 — Deploy your token
+
+```bash
+# Execute (add --confirm; remove --dry-run):
+clanker --chain 8453 deploy-token \
+  --name "MyToken" \
+  --symbol "MTK" \
+  --from 0xYourWalletAddress \
+  --confirm
+```
+
+Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer_url": "https://basescan.org/tx/0x..."`.
+The deployed contract address is NOT in the CLI output — find it in the Basescan tx receipt under
+"Internal Transactions" or the factory event logs. Wait ~30 seconds then run `token-info` to confirm.
+
+### Step 8 — Claim LP rewards (if you have a deployed token)
+
+```bash
+# Preview:
+clanker --chain 8453 --dry-run claim-rewards \
+  --token-address 0xYourDeployedTokenAddress \
+  --from 0xYourWalletAddress
+
+# Execute:
+clanker --chain 8453 claim-rewards \
+  --token-address 0xYourDeployedTokenAddress \
+  --from 0xYourWalletAddress \
+  --confirm
+```
+
+If no rewards have accrued yet, returns `"status": "no_rewards"` — this is normal for new tokens.
+
+---
+
 ## Commands
 
 ### list-tokens — List recently deployed tokens
@@ -345,17 +475,17 @@ clanker [--chain 8453] [--dry-run] deploy-token \
 
 **Example:**
 ```bash
-# Preview without wallet (uses zero address as placeholder)
-clanker --dry-run deploy-token --name "SkyDog" --symbol "SKYDOG"
+# Preview (no --confirm, no --dry-run) — shows intent, exits 0:
+clanker deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 
-# Preview with your wallet (shows the deployer address in the preview output)
+# Full calldata preview (--dry-run, requires --from):
 clanker --dry-run deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 
-# Deploy (after user confirmation)
-clanker deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
+# Deploy (after user confirmation):
+clanker --confirm deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWallet
 ```
 
-> **Note on `--from` in dry-run:** Passing `--from <wallet_address>` to `--dry-run` affects the preview output — the deployer address shown in the response will be your wallet address instead of a placeholder. This is useful to verify the token admin / fee recipient is set correctly before deploying.
+> **Note:** `--from` is required for all three modes (preview, dry-run, and deploy). The plugin cannot resolve the active onchainos wallet automatically for token deployments. `--dry-run` must be a **global flag** before the subcommand.
 
 **Expected output:**
 <external-content>

--- a/skills/clanker-plugin/SKILL.md
+++ b/skills/clanker-plugin/SKILL.md
@@ -535,7 +535,7 @@ clanker --confirm deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xYourWa
 ```
 clanker [--chain 8453] [--dry-run] claim-rewards \
   --token-address <TOKEN_ADDRESS> \
-  [--from <wallet-address>] \\
+  [--from <wallet-address>] \
   [--confirm]
 ```
 
@@ -612,6 +612,27 @@ clanker claim-rewards --token-address 0xTokenAddress --from 0xYourWallet --confi
 ---
 
 ## Changelog
+
+### v0.2.4 (2026-04-16)
+
+- **fix**: `deploy-token` without `--dry-run` or `--confirm` now returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters instead of exiting with an error.
+- **fix**: Empty `--name` or `--symbol` now returns a clear error before any network call.
+- **fix**: Invalid `--from` address (not 42-char hex) caught in preview path; returns error instead of `ok: true`.
+- **docs**: Updated Quickstart Step 6 to reflect preview behavior; fixed double-backslash typo in claim-rewards usage block; updated SKILL_SUMMARY.md to remove stale API key reference.
+
+### v0.2.3 (2026-04-14)
+
+- **docs**: Added Proactive Onboarding and Quickstart sections; updated Key Points to reflect on-chain deploy flow (no API key required).
+
+### v0.2.2 (2026-04-13)
+
+- **fix**: `deploy-token` preview gate added — without `--dry-run` or `--confirm`, command now shows intent and exits cleanly instead of proceeding silently.
+- **fix**: Version consistency across all 7 locations (Cargo.toml, Cargo.lock, plugin.yaml, plugin.json, SKILL.md frontmatter, download URL, telemetry).
+
+### v0.2.1 (2026-04-12)
+
+- **fix**: `deploy-token` dry-run uses `0xDRYRUN...` placeholder instead of zero address so output is clearly non-live.
+- **docs**: Version alignment — `.claude-plugin/plugin.json` corrected to `0.2.1`.
 
 ### v0.2.0 (2026-04-11)
 

--- a/skills/clanker-plugin/SKILL_SUMMARY.md
+++ b/skills/clanker-plugin/SKILL_SUMMARY.md
@@ -5,7 +5,7 @@
 The clanker skill enables deployment and management of ERC-20 tokens through the Clanker platform on Base and Arbitrum networks. It provides comprehensive token lifecycle management including deployment via REST API, creator-based search functionality, reward claiming from liquidity provider fees, and real-time token information retrieval with built-in security scanning.
 
 ## Usage
-Install with `npx skills add clanker --global` and ensure `onchainos` is logged in. For deployments, obtain a Clanker partner API key and use `deploy-token` command with user confirmation required.
+Install with `npx skills add okx/plugin-store --skill clanker-plugin --global` and ensure `onchainos` is logged in. Use `deploy-token` to deploy directly on-chain via the Clanker V4 factory — no API key required.
 
 ## Commands
 | Command | Description |
@@ -13,7 +13,7 @@ Install with `npx skills add clanker --global` and ensure `onchainos` is logged 
 | `list-tokens` | List recently deployed Clanker tokens with pagination |
 | `search-tokens --query <address\|username>` | Search tokens by creator address or Farcaster username |
 | `token-info --address <addr>` | Get on-chain token metadata and price information |
-| `deploy-token --name X --symbol Y --api-key K` | Deploy new ERC-20 token via Clanker API (requires confirmation) |
+| `deploy-token --name X --symbol Y` | Deploy new ERC-20 token directly on-chain via Clanker V4 factory (requires confirmation) |
 | `claim-rewards --token-address <addr>` | Claim LP fee rewards for token creators (requires confirmation) |
 
 ## Triggers

--- a/skills/clanker-plugin/plugin.yaml
+++ b/skills/clanker-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: clanker-plugin
-version: "0.2.4"
+version: "0.2.5"
 description: "Deploy and manage Clanker ERC-20 tokens on Base and Arbitrum — launch tokens, search by creator, and claim LP fee rewards"
 author:
   name: GeoGu360

--- a/skills/clanker-plugin/src/commands/claim_rewards.rs
+++ b/skills/clanker-plugin/src/commands/claim_rewards.rs
@@ -118,7 +118,7 @@ pub async fn run(
             "data": {
                 "action": "claim_rewards",
                 "chain_id": chain_id,
-                "to": fee_locker_addr,
+                "fee_locker": fee_locker_addr,
                 "input_data": calldata,
                 "from": wallet,
                 "token_address": token_address,

--- a/skills/clanker-plugin/src/commands/deploy_token.rs
+++ b/skills/clanker-plugin/src/commands/deploy_token.rs
@@ -131,12 +131,28 @@ pub async fn run(
     dry_run: bool,
     confirm: bool,
 ) -> Result<()> {
-    // Require explicit --confirm for live deployments
+    // Preview gate: show intent without broadcasting when neither --dry-run nor --confirm
     if !dry_run && !confirm {
-        bail!(
-            "Deployment requires explicit confirmation. Run with --dry-run first to preview, \
-             then re-run with --confirm to execute."
-        );
+        let wallet_preview = from
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
+        if wallet_preview.is_empty() {
+            bail!("Cannot determine wallet address — pass --from or ensure onchainos is logged in");
+        }
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "message": "Add --dry-run to see full calldata, or --confirm to deploy on-chain",
+            "data": {
+                "chain": chain_id,
+                "name": name,
+                "symbol": symbol,
+                "deployer": wallet_preview,
+                "note": "Token admin and LP reward recipient will be set to deployer address"
+            }
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
     }
 
     if chain_id != 8453 {

--- a/skills/clanker-plugin/src/commands/deploy_token.rs
+++ b/skills/clanker-plugin/src/commands/deploy_token.rs
@@ -153,8 +153,10 @@ pub async fn run(
         if wallet_preview.is_empty() {
             bail!("Cannot determine wallet address — pass --from or ensure onchainos is logged in");
         }
-        if !wallet_preview.starts_with("0x") || wallet_preview.len() != 42 {
-            bail!("Invalid wallet address: {}. Must be a 42-character hex address (0x...)", wallet_preview);
+        let hex_valid = wallet_preview.len() > 2
+            && wallet_preview[2..].chars().all(|c| c.is_ascii_hexdigit());
+        if !wallet_preview.starts_with("0x") || wallet_preview.len() != 42 || !hex_valid {
+            bail!("Invalid wallet address: {}. Must be a 42-character hex address (0x...).", wallet_preview);
         }
         let preview = serde_json::json!({
             "ok": true,

--- a/skills/clanker-plugin/src/commands/deploy_token.rs
+++ b/skills/clanker-plugin/src/commands/deploy_token.rs
@@ -131,6 +131,13 @@ pub async fn run(
     dry_run: bool,
     confirm: bool,
 ) -> Result<()> {
+    if name.trim().is_empty() {
+        bail!("--name cannot be empty");
+    }
+    if symbol.trim().is_empty() {
+        bail!("--symbol cannot be empty");
+    }
+
     // Preview gate: show intent without broadcasting when neither --dry-run nor --confirm
     if !dry_run && !confirm {
         let wallet_preview = from
@@ -138,6 +145,9 @@ pub async fn run(
             .unwrap_or_else(|| onchainos::resolve_wallet(chain_id).unwrap_or_default());
         if wallet_preview.is_empty() {
             bail!("Cannot determine wallet address — pass --from or ensure onchainos is logged in");
+        }
+        if !wallet_preview.starts_with("0x") || wallet_preview.len() != 42 {
+            bail!("Invalid wallet address: {}. Must be a 42-character hex address (0x...)", wallet_preview);
         }
         let preview = serde_json::json!({
             "ok": true,

--- a/skills/clanker-plugin/src/commands/deploy_token.rs
+++ b/skills/clanker-plugin/src/commands/deploy_token.rs
@@ -138,6 +138,13 @@ pub async fn run(
         bail!("--symbol cannot be empty");
     }
 
+    if chain_id != 8453 {
+        bail!(
+            "Direct on-chain deployment is only supported on Base (chain 8453). \
+             Arbitrum support is planned for a future release."
+        );
+    }
+
     // Preview gate: show intent without broadcasting when neither --dry-run nor --confirm
     if !dry_run && !confirm {
         let wallet_preview = from
@@ -163,13 +170,6 @@ pub async fn run(
         });
         println!("{}", serde_json::to_string_pretty(&preview)?);
         return Ok(());
-    }
-
-    if chain_id != 8453 {
-        bail!(
-            "Direct on-chain deployment is only supported on Base (chain 8453). \
-             Arbitrum support is planned for a future release."
-        );
     }
 
     // ── 1. Resolve wallet ─────────────────────────────────────────────────

--- a/skills/clanker-plugin/src/commands/list_tokens.rs
+++ b/skills/clanker-plugin/src/commands/list_tokens.rs
@@ -13,7 +13,16 @@ pub async fn run(
 
     // API returns { data: [...], total: ..., cursor: ... }
     // (Note: top-level "data" array, NOT "tokens")
-    let tokens = result["data"].as_array().cloned().unwrap_or_default();
+    let tokens = {
+        let raw = result["data"].as_array().cloned().unwrap_or_default();
+        if let Some(cid) = chain_id {
+            raw.into_iter()
+                .filter(|t| t["chain_id"].as_u64().map(|c| c == cid).unwrap_or(true))
+                .collect::<Vec<_>>()
+        } else {
+            raw
+        }
+    };
     let total = result["total"].as_u64().unwrap_or(0);
     // API uses cursor-based pagination; derive has_more from whether cursor is present
     let has_more = result["cursor"].is_string() && !result["cursor"].as_str().unwrap_or("").is_empty();

--- a/skills/clanker-plugin/src/commands/mod.rs
+++ b/skills/clanker-plugin/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod claim_rewards;
 pub mod deploy_token;
 pub mod list_tokens;
+pub mod quickstart;
 pub mod search_tokens;
 pub mod token_info;

--- a/skills/clanker-plugin/src/commands/quickstart.rs
+++ b/skills/clanker-plugin/src/commands/quickstart.rs
@@ -1,0 +1,131 @@
+// commands/quickstart.rs — Clanker wallet-state onboarding
+use crate::config;
+use crate::onchainos;
+use serde_json::{json, Value};
+
+const ABOUT: &str = "Clanker is a permissionless token launcher on Base — deploy your own \
+    ERC-20 token with a liquidity pool in seconds, then claim trading fees earned by your \
+    token's pool.";
+
+// Minimum ETH needed to deploy (covers factory gas on Base)
+const MIN_DEPLOY_GAS_WEI: u128 = 1_000_000_000_000_000; // 0.001 ETH
+
+async fn eth_balance_wei(wallet: &str, rpc_url: &str) -> u128 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [wallet, "latest"],
+        "id": 1
+    });
+    match client.post(rpc_url).json(&body).send().await {
+        Ok(resp) => {
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => val["result"].as_str()
+                    .and_then(|s| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                    .unwrap_or(0),
+                Err(_) => 0,
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+pub async fn run(chain_id: u64) -> anyhow::Result<Value> {
+    let rpc_url = config::rpc_url(chain_id);
+
+    let chain_display = match chain_id {
+        8453  => "Base",
+        42161 => "Arbitrum",
+        _     => "Base",
+    };
+
+    let wallet = onchainos::resolve_wallet(chain_id)
+        .map_err(|e| anyhow::anyhow!("Cannot resolve wallet: {e}"))?;
+
+    eprintln!(
+        "Checking assets for {}... on {}...",
+        &wallet[..10.min(wallet.len())],
+        chain_display
+    );
+
+    let eth_wei = eth_balance_wei(&wallet, rpc_url).await;
+    let eth_balance = eth_wei as f64 / 1e18;
+
+    let has_eth = eth_wei > 0;
+    let can_deploy = eth_wei >= MIN_DEPLOY_GAS_WEI;
+
+    let chain_flag = if chain_id != 8453 {
+        format!("--chain {} ", chain_id)
+    } else {
+        String::new()
+    };
+
+    let (status, suggestion, next_command, onboarding_steps): (&str, &str, String, Vec<String>) =
+        if can_deploy {
+            (
+                "ready",
+                "Your wallet has ETH to deploy a token on Base. Try listing recent launches or deploying your own token.",
+                format!("clanker {}list-tokens --limit 5", chain_flag),
+                vec![
+                    "1. Browse recently deployed tokens for inspiration:".to_string(),
+                    format!("   clanker {}list-tokens --limit 5", chain_flag),
+                    "2. Preview your token deployment (safe — no tx sent):".to_string(),
+                    format!("   clanker {}deploy-token --name \"MyToken\" --symbol \"MTK\" --from {}", chain_flag, wallet),
+                    "3. Deploy your token (add --confirm):".to_string(),
+                    format!("   clanker {}deploy-token --name \"MyToken\" --symbol \"MTK\" --from {} --confirm", chain_flag, wallet),
+                    "4. After deployment, claim LP fees:".to_string(),
+                    format!("   clanker {}claim-rewards --token-address <your-token> --from {} --confirm", chain_flag, wallet),
+                ],
+            )
+        } else if has_eth && !can_deploy {
+            (
+                "needs_funds",
+                "You have some ETH but may not have enough for deployment gas. Consider adding more ETH.",
+                format!("clanker {}list-tokens --limit 5", chain_flag),
+                vec![
+                    format!("1. Send at least {:.4} ETH to your wallet for deployment gas:", MIN_DEPLOY_GAS_WEI as f64 / 1e18),
+                    format!("   {}", wallet),
+                    "2. Browse recent Clanker launches while you wait:".to_string(),
+                    format!("   clanker {}list-tokens --limit 5", chain_flag),
+                    "3. Run quickstart again after topping up:".to_string(),
+                    format!("   clanker {}quickstart", chain_flag),
+                ],
+            )
+        } else {
+            (
+                "no_funds",
+                "No ETH found. Bridge ETH to Base to deploy a token.",
+                format!("clanker {}list-tokens --limit 5", chain_flag),
+                vec![
+                    format!("1. Bridge or send ETH to your wallet on {}:", chain_display),
+                    format!("   {}", wallet),
+                    format!("   Minimum recommended: {:.4} ETH", MIN_DEPLOY_GAS_WEI as f64 / 1e18),
+                    "2. Run quickstart again after funding:".to_string(),
+                    format!("   clanker {}quickstart", chain_flag),
+                    "3. While you wait, explore recent launches:".to_string(),
+                    format!("   clanker {}list-tokens --limit 5", chain_flag),
+                ],
+            )
+        };
+
+    let mut out = json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "chain": chain_display,
+        "chainId": chain_id,
+        "assets": {
+            "eth_balance": format!("{:.6}", eth_balance),
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = json!(onboarding_steps);
+    }
+
+    Ok(out)
+}

--- a/skills/clanker-plugin/src/commands/token_info.rs
+++ b/skills/clanker-plugin/src/commands/token_info.rs
@@ -3,6 +3,17 @@ use crate::onchainos;
 use anyhow::Result;
 
 pub fn run(chain_id: u64, token_address: &str) -> Result<()> {
+    // Validate address format before querying
+    let is_valid_addr = token_address.starts_with("0x")
+        && token_address.len() == 42
+        && token_address[2..].chars().all(|c| c.is_ascii_hexdigit());
+    if !is_valid_addr {
+        anyhow::bail!(
+            "Invalid token address: '{}'. Must be a 42-character hex address (0x...).",
+            token_address
+        );
+    }
+
     let info = onchainos::token_info(chain_id, token_address)?;
     let price = onchainos::token_price_info(chain_id, token_address)?;
 

--- a/skills/clanker-plugin/src/commands/token_info.rs
+++ b/skills/clanker-plugin/src/commands/token_info.rs
@@ -18,12 +18,21 @@ pub fn run(chain_id: u64, token_address: &str) -> Result<()> {
         serde_json::json!(null)
     };
 
+    let info_value = {
+        let d = &info["data"];
+        if let Some(arr) = d.as_array() {
+            arr.first().cloned().unwrap_or(serde_json::Value::Null)
+        } else {
+            d.clone()
+        }
+    };
+
     let output = serde_json::json!({
         "ok": true,
         "data": {
             "token_address": token_address,
             "chain_id": chain_id,
-            "info": info["data"],
+            "info": info_value,
             "price": price_field,
             "price_available": price_available,
             "price_note": if price_available {

--- a/skills/clanker-plugin/src/main.rs
+++ b/skills/clanker-plugin/src/main.rs
@@ -106,6 +106,9 @@ enum Commands {
         #[arg(long)]
         confirm: bool,
     },
+
+    /// Check wallet state and get personalised onboarding steps
+    Quickstart,
 }
 
 #[tokio::main]
@@ -162,6 +165,16 @@ async fn main() {
                 confirm,
             )
             .await
+        }
+
+        Commands::Quickstart => {
+            match commands::quickstart::run(cli.chain).await {
+                Ok(val) => {
+                    println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

1. **deploy-token preview gate** (Bug: running without `--confirm` and without `--dry-run` returned `ok: false` / exit code 1; indistinguishable from a real error by exit code alone)
   - Root cause: `deploy_token.rs` called `bail!()` when neither flag was present
   - Fix: Restructured to return `{"ok":true,"preview":true,"message":"Add --dry-run to see calldata, or --confirm to deploy"}` with exit 0

2. **`--dry-run` requires `--from`** (Bug: SKILL.md claimed `--dry-run` without `--from` "uses zero address as placeholder"; binary actually errors)
   - Root cause: Stale doc from a planned-but-never-implemented feature
   - Fix: Updated SKILL.md examples to remove false claim; added note that `--from` is required for all three modes (preview / dry-run / deploy)

3. **plugin.json version stale** (0.2.1 → 0.2.4)

4. **Proactive Onboarding + Quickstart sections** added to SKILL.md

## Files Changed

| File | Change |
|------|--------|
| `src/commands/deploy_token.rs` | Preview gate returns `ok:true` / exit 0 when no `--confirm` / no `--dry-run` |
| `SKILL.md` | Corrected deploy-token examples; Proactive Onboarding + Quickstart sections added |
| `.claude-plugin/plugin.json` | Version 0.2.1 → 0.2.4 |

## Live Verification

Live deployment intentionally skipped — `deploy-token --confirm` deploys a permanent ERC-20 token on Base mainnet and is not reversible. Preview and dry-run paths verified instead:

```bash
# Preview (ok:true, preview:true, exit 0 — verified):
clanker --chain 8453 deploy-token --name "TestCoin" --symbol "TST" --from 0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9
# Output: {"ok":true,"preview":true,"message":"Add --dry-run to see full calldata, or --confirm to deploy on-chain","data":{"chain":8453,"deployer":"0xee385...","name":"TestCoin","symbol":"TST",...}}

# Dry-run (with --from, verified):
clanker --dry-run --chain 8453 deploy-token --name "SkyDog" --symbol "SKYDOG" --from 0xee385ac7ac70b5e7f12aa49bf879a441bed0bae9
# Output: full calldata preview with factory, hook, tick range, reward_recipient = deployer
```

## Checklist

- [x] `deploy-token` without `--confirm` returns `ok:true, preview:true` (exit 0)
- [x] SKILL.md correctly documents `--from` required for dry-run
- [x] Version consistent in all locations
- [x] Proactive Onboarding and Quickstart sections added
- [x] Preview and dry-run paths verified live

---

## Proactive Onboarding

When a user signals they are **new or just installed** this plugin — e.g. "I just installed clanker",
"how do I get started", "what can I do with this", "how do I deploy a token" — **do not wait for them
to ask specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
waiting for confirmation before proceeding to the next:

1. **Check wallet** — run `onchainos wallet addresses --chain 8453`. If no address, direct them to
   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
2. **Check balance** — run `onchainos wallet balance --chain 8453`. Deploying a token requires ETH for
   gas (very cheap on Base, typically < $0.05). If insufficient, explain how to bridge ETH to Base.
3. **Explore read-only** — run `clanker --chain 8453 list-tokens --limit 10` to show recent launches.
   Ask if they want to search by creator or look up a specific token.
4. **Preview deployment** — run `clanker --chain 8453 --dry-run deploy-token --name X --symbol Y --from <wallet>`
   so they see deployment parameters (token admin, reward recipient, LP range) before any on-chain action.
5. **Execute** — once they confirm, re-run with `--confirm` instead of `--dry-run`.

Do not dump all steps at once. Guide conversationally — confirm each step before moving on.

**Key points for new users:**
- `deploy-token` without `--confirm` and without `--dry-run` returns a safe preview (`ok:true, preview:true`) — use `--dry-run` to see full calldata
- `--dry-run` is a **global flag** — it must come before the subcommand: `clanker --dry-run deploy-token ...`
- The deployed token contract address is found in the Basescan tx receipt, not the CLI output
- `claim-rewards` requires the user to have previously deployed a Clanker token and accrued LP fees

---

## Quickstart

New to clanker-plugin? Follow these steps to go from zero to your first token deployment on Base.

### Step 1 — Connect your wallet

```bash
onchainos wallet login your@email.com
onchainos wallet addresses --chain 8453
```

### Step 2 — Check your balance

```bash
onchainos wallet balance --chain 8453
```

Minimum recommended: ~0.0005 ETH (~$1) for gas on Base. Token deployments on Base cost well under $0.05
in gas at normal network conditions. If zero, bridge ETH to Base via a CEX withdrawal or bridge.

### Step 3 — Browse recently deployed tokens

```bash
clanker --chain 8453 list-tokens --limit 10 --sort desc
```

Returns the 10 most recently deployed Clanker tokens. Each entry includes `contract_address`, `name`,
`symbol`, `deployed_at`, and `pool_address`. Use `--sort asc` to see the oldest tokens first.
Note: `--page` pagination is not functional in this version — all calls return the same page of results.

### Step 4 — Search tokens by creator

```bash
# By Farcaster username:
clanker search-tokens --query dwr

# By wallet address:
clanker search-tokens --query 0xYourWalletAddress
```

Returns all tokens deployed by that creator, with `trust_status` fields indicating whether the token
is from a verified/trusted deployer. Use `--trusted-only` to filter to trusted creators only.

### Step 5 — Look up a specific token

```bash
clanker --chain 8453 token-info --address 0xTokenAddress
```

Returns token metadata (`tokenName`, `tokenSymbol`, `decimal`) and price data if available. When a
token has no oracle price yet, `price_available: false` and a `price_note` explain why — this is
normal for newly deployed tokens.

### Step 6 — Preview a token deployment (safe — no tx sent)

For `deploy-token`, running without any flags returns a safe preview (`ok: true, preview: true`) showing the deployer address and parameters — no transaction is sent. For `claim-rewards`, `--dry-run` is required to preview; running without `--dry-run` or `--confirm` returns an error asking for confirmation.

```bash
# Preview (safe — no tx sent):
clanker --chain 8453 --dry-run deploy-token \
  --name "MyToken" \
  --symbol "MTK" \
  --from 0xYourWalletAddress
```

Expected output: `"dry_run": true`, shows `token_admin`, `reward_recipient`, `factory`, LP range,
and hook config. Verify your wallet address appears as `token_admin` and `reward_recipient`.

### Step 7 — Deploy your token

```bash
# Execute (add --confirm; remove --dry-run):
clanker --chain 8453 deploy-token \
  --name "MyToken" \
  --symbol "MTK" \
  --from 0xYourWalletAddress \
  --confirm
```

Expected output: `"ok": true`, `"tx_hash": "0x..."`, `"explorer_url": "https://basescan.org/tx/0x..."`.
The deployed contract address is NOT in the CLI output — find it in the Basescan tx receipt under
"Internal Transactions" or the factory event logs. Wait ~30 seconds then run `token-info` to confirm.

### Step 8 — Claim LP rewards (if you have a deployed token)

```bash
# Preview:
clanker --chain 8453 --dry-run claim-rewards \
  --token-address 0xYourDeployedTokenAddress \
  --from 0xYourWalletAddress

# Execute:
clanker --chain 8453 claim-rewards \
  --token-address 0xYourDeployedTokenAddress \
  --from 0xYourWalletAddress \
  --confirm
```

If no rewards have accrued yet, returns `"status": "no_rewards"` — this is normal for new tokens.

---