### PR TITLE
feat(pancakeswap-v2): v0.2.5 — add quickstart command, --confirm gate, slippage 1%, lpReceived

### DIFF
--- a/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v2",
   "description": "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair.",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "author": { "name": "skylavis-sky", "github": "skylavis-sky" },
   "license": "MIT"
 }

--- a/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,10 @@
 {
   "name": "pancakeswap-v2",
   "description": "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair.",
-  "version": "0.2.5",
-  "author": { "name": "skylavis-sky", "github": "skylavis-sky" },
+  "version": "0.2.4",
+  "author": {
+    "name": "skylavis-sky",
+    "github": "skylavis-sky"
+  },
   "license": "MIT"
 }

--- a/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v2-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v2",
   "description": "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/pancakeswap-v2-plugin/Cargo.lock
+++ b/skills/pancakeswap-v2-plugin/Cargo.lock
@@ -1624,8 +1624,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pancakeswap-v2"
-version = "0.2.3"
+name = "pancakeswap-v2-plugin"
+version = "0.2.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap-v2-plugin/Cargo.lock
+++ b/skills/pancakeswap-v2-plugin/Cargo.lock
@@ -3,126 +3,6 @@
 version = 4
 
 [[package]]
-name = "alloy-json-abi"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4584e3641181ff073e9d5bec5b3b8f78f9749d9fb108a1cfbc4399a4a139c72a"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d58b30eb9a4db0e5f59bc30e8c2caef877fee7dc8734cf242a51a60f22e05"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more",
- "foldhash",
- "hashbrown 0.15.5",
- "indexmap",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "rustc-hash",
- "serde",
- "sha3",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68b32b6fa0d09bb74b4cefe35ccc8269d711c26629bc7cd98a47eeb12fe353f"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afe6879ac373e58fd53581636f2cce843998ae0b058ebe1e4f649195e2bd23c"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "syn-solidity",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba01aee235a8c699d07e5be97ba215607564e71be72f433665329bec307d28"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c13fc168b97411e04465f03e632f31ef94cad1c7c8951bf799237fd7870d535"
-dependencies = [
- "serde",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e960c4b52508ef2ae1e37cae5058e905e9ae099b107900067a503f8c454036f"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-macro",
- "const-hex",
- "serde",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,228 +59,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version 0.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
-dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "educe",
- "itertools 0.13.0",
- "num-bigint",
- "num-traits",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint",
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
-dependencies = [
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -409,52 +71,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "bumpalo"
@@ -463,25 +83,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byte-slice-cast"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cc"
@@ -530,7 +135,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -544,53 +149,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "const-hex"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const_format"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -619,108 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.117",
- "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,64 +184,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
+ "syn",
 ]
 
 [[package]]
@@ -795,26 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -840,54 +219,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "fnv"
@@ -924,12 +259,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -981,17 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,38 +322,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1064,7 +359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
- "serde",
 ]
 
 [[package]]
@@ -1084,15 +378,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "http"
@@ -1321,26 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,24 +640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,38 +658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
-name = "keccak-asm"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,12 +668,6 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1486,17 +695,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "memchr"
@@ -1539,35 +737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +771,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1627,8 +796,6 @@ dependencies = [
 name = "pancakeswap-v2-plugin"
 version = "0.2.5"
 dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
  "anyhow",
  "clap",
  "hex",
@@ -1636,34 +803,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
-dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "const_format",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "rustversion",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1690,42 +829,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -1743,64 +856,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec",
- "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1813,31 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,90 +885,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "serde",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1941,12 +897,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1991,16 +941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,80 +952,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "ruint"
-version = "1.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
-dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "ark-ff 0.5.0",
- "bytes",
- "fastrlp 0.3.1",
- "fastrlp 0.4.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "parity-scale-codec",
- "primitive-types",
- "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
- "rlp",
- "ruint-macro",
- "serde_core",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -2141,18 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,20 +1026,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -2212,27 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -2261,7 +1083,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2290,37 +1112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest 0.10.7",
- "keccak",
-]
-
-[[package]]
-name = "sha3-asm"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
-dependencies = [
- "cc",
- "cfg-if",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,16 +1125,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2369,26 +1150,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2404,17 +1169,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2422,18 +1176,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e6eed052a117409a1a744c8bda9c3ea6934597cf7419f791cb7d590871c4c"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2453,7 +1195,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2478,12 +1220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,15 +1230,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2540,7 +1267,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2574,36 +1301,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow 1.0.1",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2677,46 +1374,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -2755,31 +1416,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "want"
@@ -2856,7 +1496,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2900,7 +1540,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -3031,24 +1671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,7 +1700,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3094,7 +1716,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3128,7 +1750,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3141,15 +1763,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "yoke"
@@ -3170,28 +1783,8 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3211,7 +1804,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -3220,20 +1813,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"
@@ -3265,7 +1844,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/skills/pancakeswap-v2-plugin/Cargo.lock
+++ b/skills/pancakeswap-v2-plugin/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "pancakeswap-v2-plugin"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap-v2-plugin/Cargo.toml
+++ b/skills/pancakeswap-v2-plugin/Cargo.toml
@@ -14,6 +14,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
-alloy-sol-types = "0.8"
-alloy-primitives = "0.8"
 hex = "0.4"

--- a/skills/pancakeswap-v2-plugin/Cargo.toml
+++ b/skills/pancakeswap-v2-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v2-plugin"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v2-plugin/Cargo.toml
+++ b/skills/pancakeswap-v2-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v2-plugin"
-version = "0.2.5"
+version = "0.2.4"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -102,7 +102,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.5/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.4/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -130,7 +130,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.4"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -142,9 +142,142 @@ fi
 ---
 
 
+## Proactive Onboarding
+
+When a user signals they are **new or just installed** this plugin — e.g. "I just installed pancakeswap-v2",
+"how do I get started", "what can I do with PancakeSwap" — **do not wait for them to ask specific questions.**
+Proactively walk them through the Quickstart in order, one step at a time, waiting for confirmation
+before proceeding to the next:
+
+1. **Check wallet** — run `onchainos wallet addresses --chain 56`. If no address, direct them to
+   connect via `onchainos wallet login`. Do not proceed to any write operations until a wallet is confirmed.
+2. **Check balance** — run `onchainos wallet balance --chain 56`. The user needs BNB for gas (~$0.50 worth
+   minimum) plus the tokens they want to swap. If BNB is zero, explain they need it for gas fees and
+   how to acquire it (bridge from another chain or CEX withdrawal).
+3. **Get a quote first** — run `pancakeswap-v2 --chain 56 quote --token-in <TOKEN> --token-out <TOKEN> --amount-in <AMOUNT>`
+   to show the expected output before any on-chain action. Ask the user which tokens they want to swap.
+4. **Preview the swap** — run `pancakeswap-v2 --chain 56 swap ...` (without `--confirm`) to show the
+   preview with route, expected output, and `txHash: "pending"`. This is safe — no broadcast occurs.
+   Show the user the preview output and ask them to confirm before proceeding.
+5. **Execute** — once the user confirms, re-run adding the `--confirm` flag to broadcast.
+6. **Verify** — check the BscScan link in the output and run `onchainos wallet balance --chain 56`
+   to confirm balances updated.
+
+Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+
+## Quickstart
+
+New to pancakeswap-v2? Follow these steps to go from zero to your first swap or liquidity add on PancakeSwap V2.
+
+### Step 1 — Connect your wallet
+
+```bash
+onchainos wallet login your@email.com
+onchainos wallet addresses --chain 56
+```
+
+### Step 2 — Check your balance
+
+```bash
+onchainos wallet balance --chain 56
+```
+
+You need BNB for gas (minimum ~0.001 BNB, ~$0.50 at current prices). You also need the input token
+you plan to swap. Common tokens on BSC: USDC, USDT, WBNB, CAKE, BUSD.
+
+### Step 3 — Get a quote (read-only, safe)
+
+```bash
+# How many USDT would I get for 1 USDC?
+pancakeswap-v2 --chain 56 quote --token-in USDC --token-out USDT --amount-in 1
+
+# How many CAKE for 5 USDT?
+pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 5
+```
+
+Check `amountOutHuman` for the human-readable expected output. The fee is always 0.25%.
+
+### Step 4 — Preview before executing
+
+All write commands are safe to run without `--confirm` — they show a preview with route and expected
+amounts, and `txHash: "pending"`. No broadcast occurs until you add `--confirm`.
+
+```bash
+# Preview (safe — no broadcast, txHash shows "pending"):
+pancakeswap-v2 --chain 56 swap --token-in USDC --token-out USDT --amount-in 1
+
+# Execute (add --confirm to broadcast):
+pancakeswap-v2 --chain 56 --confirm swap --token-in USDC --token-out USDT --amount-in 1
+```
+
+For calldata-only dry-run (zero tx hashes, no quote RPC calls), use `--dry-run` as a global flag:
+
+```bash
+pancakeswap-v2 --dry-run --chain 56 swap --token-in USDC --token-out USDT --amount-in 1
+```
+
+Note: both `--confirm` and `--dry-run` are **global flags** and must come before the subcommand name.
+
+### Step 5 — Swap tokens
+
+```bash
+# Preview (no --confirm — safe):
+pancakeswap-v2 --chain 56 swap \
+  --token-in USDC \
+  --token-out USDT \
+  --amount-in 1
+
+# Execute after confirmation (add --confirm):
+pancakeswap-v2 --chain 56 --confirm swap \
+  --token-in USDC \
+  --token-out USDT \
+  --amount-in 1
+```
+
+Expected output: `"ok": true`, with `steps[].txHash` showing the approve and swap tx hashes, plus
+a BscScan explorer link (e.g. `https://bscscan.com/tx/0x...`).
+
+For BNB-in or BNB-out swaps, use `--token-in BNB` or `--token-out BNB`.
+
+### Step 6 — Add liquidity (optional)
+
+```bash
+# Preview (no --confirm — safe):
+pancakeswap-v2 --chain 56 add-liquidity \
+  --token-a USDC \
+  --token-b USDT \
+  --amount-a 0.5 \
+  --amount-b 0.5
+
+# Execute after confirmation (add --confirm):
+pancakeswap-v2 --chain 56 --confirm add-liquidity \
+  --token-a USDC \
+  --token-b USDT \
+  --amount-a 0.5 \
+  --amount-b 0.5
+```
+
+Expected output: `"ok": true`, `"lpReceived"` showing estimated LP tokens minted.
+
+### Step 7 — Check your LP balance and remove liquidity
+
+```bash
+# Check LP balance:
+pancakeswap-v2 --chain 56 lp-balance --token-a USDC --token-b USDT
+
+# Preview remove (no --confirm — safe):
+pancakeswap-v2 --chain 56 remove-liquidity --token-a USDC --token-b USDT
+
+# Execute remove (add --confirm):
+pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT
+
+# Remove specific amount:
+pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT --liquidity 0.1
+```
+
 ## Do NOT use for
 
-Do NOT use for: PancakeSwap V3 swaps (use pancakeswap skill), concentrated liquidity (use pancakeswap-clmm), non-PancakeSwap AMM pools
+Do NOT use for: PancakeSwap V3 swaps (use pancakeswap-v3 skill), concentrated liquidity (use pancakeswap-clmm), non-PancakeSwap AMM pools
 
 ## Data Trust Boundary
 

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v2-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
-version: "0.2.4"
+version: "0.2.5"
 author: "skylavis-sky"
 tags:
   - dex
@@ -29,7 +29,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v2-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.4"
+LOCAL_VER="0.2.5"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -102,7 +102,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.4/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.5/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -130,7 +130,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -157,7 +157,7 @@ Do NOT use for: PancakeSwap V3 swaps (use pancakeswap skill), concentrated liqui
 - Read ops (quote, get-pair, get-reserves, lp-balance) → direct `eth_call` via public RPC; no confirmation needed
 - Write ops (swap, add-liquidity, remove-liquidity) → after user confirmation, submits via `onchainos wallet contract-call`
 - ERC-20 approvals → manually encoded `approve()` calldata, submitted via `onchainos wallet contract-call`
-- Supports BSC (chain 56, default), Base (chain 8453), and Arbitrum One (chain 42161)
+- Supports BSC (chain 56, default), Base (chain 8453), and Arbitrum One (chain 42161 — ARB token is tradeable here)
 - V2 uses constant-product xyk formula; LP tokens are standard ERC-20 (not NFTs); fixed 0.25% swap fee
 
 ## Global Flags
@@ -168,7 +168,7 @@ These flags apply to the **entire binary** and must be placed **before** the sub
 |------|---------|-------------|
 | `--chain <id>` | `56` | Chain ID: 56 (BSC), 8453 (Base), 42161 (Arbitrum) |
 | `--dry-run` | false | Simulate without broadcasting — no onchainos call made |
-| `--slippage-bps <n>` | `50` | Slippage tolerance in basis points (50 = 0.5%) |
+| `--slippage-bps <n>` | `100` | Slippage tolerance in basis points (100 = 1%) |
 | `--deadline-secs <n>` | `300` | Transaction deadline in seconds from now |
 | `--from <address>` | wallet | Override sender address |
 | `--rpc-url <url>` | (chain default) | Override RPC endpoint |
@@ -262,7 +262,7 @@ pancakeswap-v2 --dry-run --chain 56 swap --token-in USDT --token-out CAKE --amou
 | tokenIn | `--token-in` | Input token: symbol or address. Use BNB/ETH for native |
 | tokenOut | `--token-out` | Output token: symbol or address |
 | amountIn | `--amount-in` | Input amount as a human-readable decimal (e.g. 100, 1.5, 0.001) |
-| slippageBps | `--slippage-bps` | Slippage in basis points (default 50 = 0.5%) — global flag |
+| slippageBps | `--slippage-bps` | Slippage in basis points (default 100 = 1%) — global flag |
 | deadlineSecs | `--deadline-secs` | Seconds until deadline (default 300) — global flag |
 | dryRun | `--dry-run` | Preview calldata only, no broadcast — **global flag, place before subcommand** |
 
@@ -314,7 +314,7 @@ pancakeswap-v2 --dry-run --chain 56 add-liquidity --token-a USDT --token-b BNB -
 | tokenB | `--token-b` | Second token. Use BNB/ETH for native |
 | amountA | `--amount-a` | Desired amount of tokenA as a human-readable decimal (e.g. 10, 0.5) |
 | amountB | `--amount-b` | Desired amount of tokenB (or native BNB/ETH) as a human-readable decimal |
-| slippageBps | `--slippage-bps` | Slippage tolerance (default 50 = 0.5%) — global flag |
+| slippageBps | `--slippage-bps` | Slippage tolerance (default 100 = 1%) — global flag |
 | dryRun | `--dry-run` | Preview calldata only — **global flag, place before subcommand** |
 
 **Execution flow:**
@@ -323,7 +323,10 @@ pancakeswap-v2 --dry-run --chain 56 add-liquidity --token-a USDT --token-b BNB -
 3. **Ask user to confirm** the amounts and LP token receipt before proceeding
 4. Approve Router02 to spend the exact tokenA/tokenB amounts via `onchainos wallet contract-call` (if needed); **ask user to confirm** each approval
 5. Submit `addLiquidity` or `addLiquidityETH` via `onchainos wallet contract-call`
-6. Report txHash and LP tokens received
+6. Report txHash and `lpReceived` — the estimated LP tokens minted, computed from post-tx pool reserves
+
+> **Dry-run wallet address**: When `--dry-run` is passed without `--from`, the wallet field shows `0xDRYRUN...` as a placeholder. Pass `--from <address>` to use a real address in dry-run output.
+> **ARB support**: Arbitrum One (chain 42161) is fully supported via `--chain 42161`.
 
 ---
 
@@ -346,7 +349,7 @@ pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liqui
 | tokenA | `--token-a` | First token |
 | tokenB | `--token-b` | Second token. Use BNB/ETH to receive native |
 | liquidity | `--liquidity` | LP tokens to burn as a human-readable decimal (e.g. 1.0). Omit to remove all |
-| slippageBps | `--slippage-bps` | Slippage tolerance (default 50 = 0.5%) — global flag |
+| slippageBps | `--slippage-bps` | Slippage tolerance (default 100 = 1%) — global flag |
 | dryRun | `--dry-run` | Preview only — **global flag, place before subcommand** |
 
 **Execution flow:**
@@ -430,6 +433,13 @@ For Arbitrum One (42161): WETH `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`, USD
 ---
 
 ## Changelog
+
+### v0.2.5 (2026-04-14)
+
+- **fix**: Default slippage increased from 50 bps (0.5%) to 100 bps (1%) — the previous default was too tight for pairs with normal spread, causing add-liquidity to revert. Use `--slippage-bps 50` to restore the old value.
+- **feat**: `add-liquidity` output now includes `lpReceived` — the estimated LP tokens minted, computed from post-tx pool reserves using V2 formula. Shows `"estimated (dry-run)"` in dry-run mode.
+- **fix**: `add-liquidity --dry-run` without `--from` now uses `0xDRYRUN...` placeholder instead of `0x0000...` zero address, so dry-run output is clearly non-live.
+- **docs**: Added ARB (Arbitrum, chain 42161) support note; updated default slippage in all examples; documented `lpReceived` field; documented dry-run wallet placeholder behaviour.
 
 ### v0.2.3 (2026-04-11)
 

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -421,8 +421,18 @@ pancakeswap-v2 --dry-run --chain 56 swap --token-in USDT --token-out CAKE --amou
   "ok": true,
   "steps": [
     {"step": "approve", "txHash": "0xabc..."},
-    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "bscscan.com/tx/0xdef..."}
-  ]
+    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "https://bscscan.com/tx/0xdef..."}
+  ],
+  "data": {
+    "amountIn": "100000",
+    "amountOutExpected": "99823",
+    "amountOutMin": "98825",
+    "tokenIn": "USDC",
+    "tokenOut": "USDT",
+    "path": ["0x8ac7...", "0x55d3..."],
+    "wallet": "0xYourWallet",
+    "chain": 56
+  }
 }
 ```
 

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -422,7 +422,7 @@ pancakeswap-v2 --dry-run --chain 56 swap --token-in USDT --token-out CAKE --amou
   "ok": true,
   "steps": [
     {"step": "approve", "txHash": "0xabc..."},
-    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "https://bscscan.com/tx/<txhash>"}
+    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "<block_explorer_url>"}
   ],
   "data": {
     "tokenIn": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -149,18 +149,21 @@ When a user signals they are **new or just installed** this plugin — e.g. "I j
 Proactively walk them through the Quickstart in order, one step at a time, waiting for confirmation
 before proceeding to the next:
 
-1. **Check wallet** — run `onchainos wallet addresses --chain 56`. If no address, direct them to
+1. **Choose chain** — ask the user which chain they want to use. Supported: BSC (56), Base (8453),
+   Arbitrum (42161). Use their answer for `<CHAIN>` in all subsequent steps. If unsure, suggest BSC
+   (deepest PancakeSwap V2 liquidity) or Base (lower gas fees).
+2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
    connect via `onchainos wallet login`. Do not proceed to any write operations until a wallet is confirmed.
-2. **Check balance** — run `onchainos wallet balance --chain 56`. The user needs BNB for gas (~$0.50 worth
-   minimum) plus the tokens they want to swap. If BNB is zero, explain they need it for gas fees and
-   how to acquire it (bridge from another chain or CEX withdrawal).
-3. **Get a quote first** — run `pancakeswap-v2 --chain 56 quote --token-in <TOKEN> --token-out <TOKEN> --amount-in <AMOUNT>`
+3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. The user needs the native gas
+   token (BNB on BSC, ETH on Base/Arbitrum) plus the input token. If the gas token balance is zero,
+   explain how to acquire it (bridge, CEX withdrawal).
+4. **Get a quote first** — run `pancakeswap-v2 --chain <CHAIN> quote --token-in <TOKEN> --token-out <TOKEN> --amount-in <AMOUNT>`
    to show the expected output before any on-chain action. Ask the user which tokens they want to swap.
-4. **Preview the swap** — run `pancakeswap-v2 --chain 56 swap ...` (without `--confirm`) to show the
+5. **Preview the swap** — run `pancakeswap-v2 --chain <CHAIN> swap ...` (without `--confirm`) to show the
    preview with route, expected output, and `txHash: "pending"`. This is safe — no broadcast occurs.
    Show the user the preview output and ask them to confirm before proceeding.
-5. **Execute** — once the user confirms, re-run adding the `--confirm` flag to broadcast.
-6. **Verify** — check the BscScan link in the output and run `onchainos wallet balance --chain 56`
+6. **Execute** — once the user confirms, re-run adding the `--confirm` flag to broadcast.
+7. **Verify** — check the explorer link in the output and run `onchainos wallet balance --chain <CHAIN>`
    to confirm balances updated.
 
 Do not dump all steps at once. Guide conversationally — confirm each step before moving on.

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -239,7 +239,7 @@ pancakeswap-v2 --chain 56 --confirm swap \
 ```
 
 Expected output: `"ok": true`, with `steps[].txHash` showing the approve and swap tx hashes, plus
-a BscScan explorer link (e.g. `https://bscscan.com/tx/0x...`).
+a BscScan explorer link for each swap transaction.
 
 For BNB-in or BNB-out swaps, use `--token-in BNB` or `--token-out BNB`.
 
@@ -422,7 +422,7 @@ pancakeswap-v2 --dry-run --chain 56 swap --token-in USDT --token-out CAKE --amou
   "ok": true,
   "steps": [
     {"step": "approve", "txHash": "0xabc..."},
-    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "https://bscscan.com/tx/0xdef..."}
+    {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "https://bscscan.com/tx/<txhash>"}
   ],
   "data": {
     "tokenIn": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -304,6 +304,7 @@ These flags apply to the **entire binary** and must be placed **before** the sub
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--chain <id>` | `56` | Chain ID: 56 (BSC), 8453 (Base), 42161 (Arbitrum) |
+| `--confirm` | false | Broadcast write transactions on-chain; without this flag write commands show a preview only |
 | `--dry-run` | false | Simulate without broadcasting — no onchainos call made |
 | `--slippage-bps <n>` | `100` | Slippage tolerance in basis points (100 = 1%) |
 | `--deadline-secs <n>` | `300` | Transaction deadline in seconds from now |
@@ -424,11 +425,13 @@ pancakeswap-v2 --dry-run --chain 56 swap --token-in USDT --token-out CAKE --amou
     {"step": "swapExactTokensForTokens", "txHash": "0xdef...", "explorer": "https://bscscan.com/tx/0xdef..."}
   ],
   "data": {
+    "tokenIn": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+    "tokenOut": "0x55d398326f99059fF775485246999027B3197955",
+    "symbolIn": "USDC",
+    "symbolOut": "USDT",
     "amountIn": "100000",
     "amountOutExpected": "99823",
     "amountOutMin": "98825",
-    "tokenIn": "USDC",
-    "tokenOut": "USDT",
     "path": ["0x8ac7...", "0x55d3..."],
     "wallet": "0xYourWallet",
     "chain": 56

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -107,6 +107,7 @@ chmod +x ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
 ln -sf "$LAUNCHER" ~/.local/bin/pancakeswap-v2-plugin
+ln -sf "$LAUNCHER" ~/.local/bin/pancakeswap-v2
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
@@ -321,7 +322,7 @@ pancakeswap-v2 --dry-run --chain 56 add-liquidity --token-a USDT --token-b BNB -
 
 1. Run with `pancakeswap-v2 --dry-run --chain <id> <command> ...` to preview calldata and estimated amounts
 2. **Ask user to confirm** the transaction details before proceeding
-3. Execute only after explicit user approval (re-run without `--dry-run`)
+3. Execute only after explicit user approval (re-run adding the `--confirm` flag)
 4. Report transaction hash and block explorer link
 
 ---
@@ -570,7 +571,7 @@ For Arbitrum One (42161): WETH `0x82aF49447D8a07e3bd95BD0d56f35241523fBab1`, USD
 
 ## Changelog
 
-### v0.2.5 (2026-04-14)
+### v0.2.4 (2026-04-16)
 
 - **fix**: Default slippage increased from 50 bps (0.5%) to 100 bps (1%) — the previous default was too tight for pairs with normal spread, causing add-liquidity to revert. Use `--slippage-bps 50` to restore the old value.
 - **feat**: `add-liquidity` output now includes `lpReceived` — the estimated LP tokens minted, computed from post-tx pool reserves using V2 formula. Shows `"estimated (dry-run)"` in dry-run mode.

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -508,6 +508,25 @@ pancakeswap-v2 --chain 56 remove-liquidity --token-a CAKE --token-b USDT --liqui
 6. Submit `removeLiquidity` or `removeLiquidityETH` via `onchainos wallet contract-call`
 7. Report txHash
 
+**Expected output (key fields):**
+```json
+{
+  "ok": true,
+  "steps": [{ "step": "removeLiquidity", "txHash": "0x..." }],
+  "data": {
+    "pair": "0x...",
+    "lpBurned": "1000000000000000000",
+    "expectedTokenA": "500000000",
+    "expectedTokenB": "499800000",
+    "expectedTokenAHuman": "500.000000",
+    "expectedTokenBHuman": "499.800000",
+    "tokenA": "0x...",
+    "tokenB": "0x...",
+    "chain": 56
+  }
+}
+```
+
 ---
 
 ## get-pair — Look Up Pair Address

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v2-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
-version: "0.2.4"
+version: "0.2.5"
 author: "skylavis-sky"
 tags:
   - dex
@@ -29,7 +29,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v2-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.4"
+LOCAL_VER="0.2.5"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -102,7 +102,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.4/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v2-plugin@0.2.5/pancakeswap-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v2-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -111,7 +111,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/pancakeswap-v2
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.4" > "$HOME/.plugin-store/managed/pancakeswap-v2-plugin"
+echo "0.2.5" > "$HOME/.plugin-store/managed/pancakeswap-v2-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -131,7 +131,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v2-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -145,139 +145,48 @@ fi
 
 ## Proactive Onboarding
 
-When a user signals they are **new or just installed** this plugin — e.g. "I just installed pancakeswap-v2",
-"how do I get started", "what can I do with PancakeSwap" — **do not wait for them to ask specific questions.**
-Proactively walk them through the Quickstart in order, one step at a time, waiting for confirmation
-before proceeding to the next:
-
-1. **Choose chain** — ask the user which chain they want to use. Supported: BSC (56), Base (8453),
-   Arbitrum (42161). Use their answer for `<CHAIN>` in all subsequent steps. If unsure, suggest BSC
-   (deepest PancakeSwap V2 liquidity) or Base (lower gas fees).
-2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
-   connect via `onchainos wallet login`. Do not proceed to any write operations until a wallet is confirmed.
-3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. The user needs the native gas
-   token (BNB on BSC, ETH on Base/Arbitrum) plus the input token. If the gas token balance is zero,
-   explain how to acquire it (bridge, CEX withdrawal).
-4. **Get a quote first** — run `pancakeswap-v2 --chain <CHAIN> quote --token-in <TOKEN> --token-out <TOKEN> --amount-in <AMOUNT>`
-   to show the expected output before any on-chain action. Ask the user which tokens they want to swap.
-5. **Preview the swap** — run `pancakeswap-v2 --chain <CHAIN> swap ...` (without `--confirm`) to show the
-   preview with route, expected output, and `txHash: "pending"`. This is safe — no broadcast occurs.
-   Show the user the preview output and ask them to confirm before proceeding.
-6. **Execute** — once the user confirms, re-run adding the `--confirm` flag to broadcast.
-7. **Verify** — check the explorer link in the output and run `onchainos wallet balance --chain <CHAIN>`
-   to confirm balances updated.
-
-Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
-
-## Quickstart
-
-New to pancakeswap-v2? Follow these steps to go from zero to your first swap or liquidity add on PancakeSwap V2.
-
-### Step 1 — Connect your wallet
+When a user is new or asks "how do I get started", call `pancakeswap-v2 quickstart` first. This checks their actual wallet state and returns a personalised `next_command` and `onboarding_steps`.
 
 ```bash
-onchainos wallet login your@email.com
-onchainos wallet addresses --chain 56
+pancakeswap-v2 quickstart
 ```
 
-### Step 2 — Check your balance
+Parse the JSON output:
+- `status: "active"` → has existing positions/balance; run relevant view command
+- `status: "ready"` → wallet funded; follow `next_command`
+- `status: "needs_gas"` → has tokens but no gas; ask user to send ETH/BNB
+- `status: "needs_funds"` → has gas but no tokens; show `onboarding_steps`
+- `status: "no_funds"` → wallet empty; show `onboarding_steps`
+
+**Key caveats:**
+- Both `--confirm` and `--dry-run` are global flags and must come before the subcommand name.
+- ERC-20 approvals are submitted before swaps; always confirm the user understands the approval step.
+- Running swap/add-liquidity without `--confirm` shows a safe preview with `txHash: "pending"` — no broadcast occurs.
+
+---
+
+## Quickstart Command
 
 ```bash
-onchainos wallet balance --chain 56
+pancakeswap-v2 quickstart [--chain <ID>]
 ```
 
-You need BNB for gas (minimum ~0.001 BNB, ~$0.50 at current prices). You also need the input token
-you plan to swap. Common tokens on BSC: USDC, USDT, WBNB, CAKE, BUSD.
+Returns a personalised onboarding JSON based on the wallet's actual balances.
 
-### Step 3 — Get a quote (read-only, safe)
+### Output Fields
 
-```bash
-# How many USDT would I get for 1 USDC?
-pancakeswap-v2 --chain 56 quote --token-in USDC --token-out USDT --amount-in 1
+| Field | Description |
+|-------|-------------|
+| `about` | Protocol description |
+| `wallet` | Resolved wallet address |
+| `chain` | Chain name |
+| `assets` | Wallet balances (gas token + key protocol tokens) |
+| `status` | `active` / `ready` / `needs_gas` / `needs_funds` / `no_funds` |
+| `suggestion` | Human-readable state description |
+| `next_command` | The single most useful command to run next |
+| `onboarding_steps` | Ordered steps to follow |
 
-# How many CAKE for 5 USDT?
-pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 5
-```
-
-Check `amountOutHuman` for the human-readable expected output. The fee is always 0.25%.
-
-### Step 4 — Preview before executing
-
-All write commands are safe to run without `--confirm` — they show a preview with route and expected
-amounts, and `txHash: "pending"`. No broadcast occurs until you add `--confirm`.
-
-```bash
-# Preview (safe — no broadcast, txHash shows "pending"):
-pancakeswap-v2 --chain 56 swap --token-in USDC --token-out USDT --amount-in 1
-
-# Execute (add --confirm to broadcast):
-pancakeswap-v2 --chain 56 --confirm swap --token-in USDC --token-out USDT --amount-in 1
-```
-
-For calldata-only dry-run (zero tx hashes, no quote RPC calls), use `--dry-run` as a global flag:
-
-```bash
-pancakeswap-v2 --dry-run --chain 56 swap --token-in USDC --token-out USDT --amount-in 1
-```
-
-Note: both `--confirm` and `--dry-run` are **global flags** and must come before the subcommand name.
-
-### Step 5 — Swap tokens
-
-```bash
-# Preview (no --confirm — safe):
-pancakeswap-v2 --chain 56 swap \
-  --token-in USDC \
-  --token-out USDT \
-  --amount-in 1
-
-# Execute after confirmation (add --confirm):
-pancakeswap-v2 --chain 56 --confirm swap \
-  --token-in USDC \
-  --token-out USDT \
-  --amount-in 1
-```
-
-Expected output: `"ok": true`, with `steps[].txHash` showing the approve and swap tx hashes, plus
-a BscScan explorer link for each swap transaction.
-
-For BNB-in or BNB-out swaps, use `--token-in BNB` or `--token-out BNB`.
-
-### Step 6 — Add liquidity (optional)
-
-```bash
-# Preview (no --confirm — safe):
-pancakeswap-v2 --chain 56 add-liquidity \
-  --token-a USDC \
-  --token-b USDT \
-  --amount-a 0.5 \
-  --amount-b 0.5
-
-# Execute after confirmation (add --confirm):
-pancakeswap-v2 --chain 56 --confirm add-liquidity \
-  --token-a USDC \
-  --token-b USDT \
-  --amount-a 0.5 \
-  --amount-b 0.5
-```
-
-Expected output: `"ok": true`, `"lpReceived"` showing estimated LP tokens minted.
-
-### Step 7 — Check your LP balance and remove liquidity
-
-```bash
-# Check LP balance:
-pancakeswap-v2 --chain 56 lp-balance --token-a USDC --token-b USDT
-
-# Preview remove (no --confirm — safe):
-pancakeswap-v2 --chain 56 remove-liquidity --token-a USDC --token-b USDT
-
-# Execute remove (add --confirm):
-pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT
-
-# Remove specific amount:
-pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT --liquidity 0.1
-```
+---
 
 ## Do NOT use for
 
@@ -332,6 +241,7 @@ pancakeswap-v2 --dry-run --chain 56 add-liquidity --token-a USDT --token-b BNB -
 
 | User intent | Command |
 |-------------|---------|
+| "I'm new to PancakeSwap / how do I start?" | `pancakeswap-v2 quickstart` |
 | "How much CAKE for 100 USDT?" | `pancakeswap-v2 quote` |
 | "Swap 100 USDT for CAKE on PancakeSwap V2" | `pancakeswap-v2 swap` |
 | "Add liquidity CAKE/BNB on PancakeSwap" | `pancakeswap-v2 add-liquidity` |

--- a/skills/pancakeswap-v2-plugin/SKILL.md
+++ b/skills/pancakeswap-v2-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v2-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
-version: "0.2.5"
+version: "0.2.4"
 author: "skylavis-sky"
 tags:
   - dex
@@ -29,7 +29,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v2-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.5"
+LOCAL_VER="0.2.4"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then

--- a/skills/pancakeswap-v2-plugin/plugin.yaml
+++ b/skills/pancakeswap-v2-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v2-plugin
-version: "0.2.4"
+version: "0.2.5"
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
 author:
   name: skylavis-sky

--- a/skills/pancakeswap-v2-plugin/plugin.yaml
+++ b/skills/pancakeswap-v2-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v2-plugin
-version: "0.2.5"
+version: "0.2.4"
 description: "Swap tokens and manage liquidity on PancakeSwap V2 (xyk AMM) on BSC, Base, and Arbitrum. Triggers: swap pancakeswap v2, add/remove liquidity pancake, pcs v2 quote, check pancake pair."
 author:
   name: skylavis-sky

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -228,7 +228,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         if pair_addr.len() > 2 && pair_addr != "0x0000000000000000000000000000000000000000" {
             estimate_lp_received(&pair_addr, &token_a_addr_for_lp, &token_b_addr_for_lp, amount_a, amount_b, rpc).await
         } else {
-            "N/A".to_string()
+            "unknown (pair not yet created or lookup failed)".to_string()
         }
     };
 

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -7,6 +7,65 @@ use crate::config::{chain_config, resolve_token_address, is_native};
 use crate::onchainos::{self, erc20_approve};
 use crate::rpc;
 
+/// Estimate LP tokens minted using V2 formula:
+///   lp = min(amount0 * totalSupply / reserve0, amount1 * totalSupply / reserve1)
+/// Returns "N/A" if reserves or total supply cannot be fetched (e.g. new pair).
+async fn estimate_lp_received(
+    pair_addr: &str,
+    token0: &str,
+    token1: &str,
+    amount0: u128,
+    amount1: u128,
+    rpc_url: &str,
+) -> String {
+    let ts = match rpc::erc20_total_supply(pair_addr, rpc_url).await {
+        Ok(v) => v,
+        Err(_) => return "N/A".to_string(),
+    };
+    if ts == 0 {
+        // Brand-new pair — first deposit mints sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+        // Use integer approximation via Newton's method
+        let product = (amount0 as u128).saturating_mul(amount1 as u128);
+        let sqrt = isqrt_u128(product).saturating_sub(1000);
+        return format_lp_human(sqrt);
+    }
+    let (r0, r1, _) = match rpc::pair_get_reserves(pair_addr, rpc_url).await {
+        Ok(v) => v,
+        Err(_) => return "N/A".to_string(),
+    };
+    // Determine which reserve matches which token
+    let (res0, res1) = if token0.to_lowercase() < token1.to_lowercase() {
+        (r0, r1)
+    } else {
+        (r1, r0)
+    };
+    if res0 == 0 || res1 == 0 {
+        return "N/A".to_string();
+    }
+    let lp0 = (amount0 as u128).saturating_mul(ts) / res0;
+    let lp1 = (amount1 as u128).saturating_mul(ts) / res1;
+    let lp = lp0.min(lp1);
+    format_lp_human(lp)
+}
+
+fn isqrt_u128(n: u128) -> u128 {
+    if n == 0 { return 0; }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+fn format_lp_human(lp: u128) -> String {
+    // LP tokens have 18 decimals
+    let whole = lp / 1_000_000_000_000_000_000u128;
+    let frac  = (lp % 1_000_000_000_000_000_000u128) / 1_000_000_000_000u128;
+    format!("{}.{:06}", whole, frac)
+}
+
 pub struct AddLiquidityArgs {
     pub chain_id: u64,
     pub token_a: String,
@@ -32,11 +91,13 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
     }
 
     // Resolve wallet
-    let wallet = if args.dry_run {
-        "0x0000000000000000000000000000000000000000".to_string()
+    let wallet = if let Some(ref f) = args.from {
+        f.clone()
+    } else if args.dry_run {
+        // Use a recognisable placeholder so dry-run output is clearly non-live
+        "0xDRYRUN00000000000000000000000000000000000".to_string()
     } else {
-        let w = args.from.clone()
-            .unwrap_or_else(|| onchainos::resolve_wallet(args.chain_id).unwrap_or_default());
+        let w = onchainos::resolve_wallet(args.chain_id).unwrap_or_default();
         if w.is_empty() {
             anyhow::bail!("Cannot resolve wallet address. Pass --from or ensure onchainos is logged in.");
         }
@@ -62,6 +123,9 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
     }
 
     let mut steps = vec![];
+    // Track resolved addresses for LP estimation
+    let mut token_a_addr_for_lp = String::new();
+    let mut token_b_addr_for_lp = String::new();
 
     if native_a || native_b {
         // addLiquidityETH variant
@@ -73,6 +137,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         let token_addr = resolve_token_address(token_sym, args.chain_id);
         let token_min = token_amount * (10000 - args.slippage_bps) as u128 / 10000;
         let eth_min = eth_amount * (10000 - args.slippage_bps) as u128 / 10000;
+        token_a_addr_for_lp = token_addr.clone();
+        token_b_addr_for_lp = cfg.weth.to_string();
 
         // Approve token if needed
         let allowance = rpc::erc20_allowance(&token_addr, &wallet, cfg.router02, rpc).await.unwrap_or(0);
@@ -103,6 +169,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         // addLiquidity variant (token + token)
         let token_a_addr = resolve_token_address(&args.token_a, args.chain_id);
         let token_b_addr = resolve_token_address(&args.token_b, args.chain_id);
+        token_a_addr_for_lp = token_a_addr.clone();
+        token_b_addr_for_lp = token_b_addr.clone();
         let amount_a_min = amount_a * (10000 - args.slippage_bps) as u128 / 10000;
         let amount_b_min = amount_b * (10000 - args.slippage_bps) as u128 / 10000;
 
@@ -149,6 +217,20 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         }));
     }
 
+    // Estimate LP tokens received from on-chain pair state
+    let lp_received = if args.dry_run {
+        "estimated (dry-run)".to_string()
+    } else {
+        let pair_addr = rpc::factory_get_pair(
+            cfg.factory, &token_a_addr_for_lp, &token_b_addr_for_lp, rpc
+        ).await.unwrap_or_default();
+        if pair_addr.len() > 2 && pair_addr != "0x0000000000000000000000000000000000000000" {
+            estimate_lp_received(&pair_addr, &token_a_addr_for_lp, &token_b_addr_for_lp, amount_a, amount_b, rpc).await
+        } else {
+            "N/A".to_string()
+        }
+    };
+
     Ok(json!({
         "ok": true,
         "steps": steps,
@@ -157,6 +239,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
             "tokenB": args.token_b,
             "amountA": amount_a.to_string(),
             "amountB": amount_b.to_string(),
+            "lpReceived": lp_received,
             "chain": args.chain_id
         }
     }))

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -77,6 +77,7 @@ pub struct AddLiquidityArgs {
     pub from: Option<String>,
     pub rpc_url: Option<String>,
     pub dry_run: bool,
+    pub confirm: bool,
 }
 
 pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
@@ -145,19 +146,19 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         if allowance < token_amount {
             let r = erc20_approve(
                 args.chain_id, &token_addr, cfg.router02, token_amount,
-                args.from.as_deref(), args.dry_run,
+                args.from.as_deref(), args.dry_run, args.confirm,
             ).await?;
             steps.push(json!({"step":"approve_token","txHash": onchainos::extract_tx_hash(&r)}));
-            if !args.dry_run { sleep(Duration::from_secs(5)).await; }
+            if !args.dry_run && args.confirm { sleep(Duration::from_secs(5)).await; }
         }
 
         let calldata = build_add_liquidity_eth(&token_addr, token_amount, token_min, eth_min, &wallet, deadline);
         let result = onchainos::wallet_contract_call(
             args.chain_id, cfg.router02, &calldata,
-            args.from.as_deref(), Some(eth_amount), args.dry_run,
+            args.from.as_deref(), Some(eth_amount), args.dry_run, args.confirm,
         ).await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({
@@ -179,10 +180,10 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         if allow_a < amount_a {
             let r = erc20_approve(
                 args.chain_id, &token_a_addr, cfg.router02, amount_a,
-                args.from.as_deref(), args.dry_run,
+                args.from.as_deref(), args.dry_run, args.confirm,
             ).await?;
             steps.push(json!({"step":"approve_tokenA","txHash": onchainos::extract_tx_hash(&r)}));
-            if !args.dry_run { sleep(Duration::from_secs(5)).await; }
+            if !args.dry_run && args.confirm { sleep(Duration::from_secs(5)).await; }
         }
 
         // Approve tokenB if needed
@@ -190,10 +191,10 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         if allow_b < amount_b {
             let r = erc20_approve(
                 args.chain_id, &token_b_addr, cfg.router02, amount_b,
-                args.from.as_deref(), args.dry_run,
+                args.from.as_deref(), args.dry_run, args.confirm,
             ).await?;
             steps.push(json!({"step":"approve_tokenB","txHash": onchainos::extract_tx_hash(&r)}));
-            if !args.dry_run { sleep(Duration::from_secs(5)).await; }
+            if !args.dry_run && args.confirm { sleep(Duration::from_secs(5)).await; }
         }
 
         let calldata = build_add_liquidity(
@@ -204,10 +205,10 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         );
         let result = onchainos::wallet_contract_call(
             args.chain_id, cfg.router02, &calldata,
-            args.from.as_deref(), None, args.dry_run,
+            args.from.as_deref(), None, args.dry_run, args.confirm,
         ).await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -241,6 +241,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
             "amountA": amount_a.to_string(),
             "amountB": amount_b.to_string(),
             "lpReceived": lp_received,
+            "wallet": wallet,
             "chain": args.chain_id
         }
     }))

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -113,8 +113,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
     ) + args.deadline_secs;
 
     // Resolve token decimals and parse human-readable amounts
-    let token_a_for_dec = if native_a { cfg.weth.to_string() } else { resolve_token_address(&args.token_a, args.chain_id) };
-    let token_b_for_dec = if native_b { cfg.weth.to_string() } else { resolve_token_address(&args.token_b, args.chain_id) };
+    let token_a_for_dec = if native_a { cfg.weth.to_string() } else { resolve_token_address(&args.token_a, args.chain_id)? };
+    let token_b_for_dec = if native_b { cfg.weth.to_string() } else { resolve_token_address(&args.token_b, args.chain_id)? };
     let decimals_a = rpc::erc20_decimals(&token_a_for_dec, rpc).await.unwrap_or(18);
     let decimals_b = rpc::erc20_decimals(&token_b_for_dec, rpc).await.unwrap_or(18);
     let amount_a = rpc::parse_human_amount(&args.amount_a, decimals_a)?;
@@ -135,7 +135,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         } else {
             (&args.token_b, amount_b, amount_a)
         };
-        let token_addr = resolve_token_address(token_sym, args.chain_id);
+        let token_addr = resolve_token_address(token_sym, args.chain_id)?;
         let token_min = token_amount * (10000 - args.slippage_bps) as u128 / 10000;
         let eth_min = eth_amount * (10000 - args.slippage_bps) as u128 / 10000;
         token_a_addr_for_lp = token_addr.clone();
@@ -168,8 +168,8 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         }));
     } else {
         // addLiquidity variant (token + token)
-        let token_a_addr = resolve_token_address(&args.token_a, args.chain_id);
-        let token_b_addr = resolve_token_address(&args.token_b, args.chain_id);
+        let token_a_addr = resolve_token_address(&args.token_a, args.chain_id)?;
+        let token_b_addr = resolve_token_address(&args.token_b, args.chain_id)?;
         token_a_addr_for_lp = token_a_addr.clone();
         token_b_addr_for_lp = token_b_addr.clone();
         let amount_a_min = amount_a * (10000 - args.slippage_bps) as u128 / 10000;

--- a/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/add_liquidity.rs
@@ -96,7 +96,7 @@ pub async fn run(args: AddLiquidityArgs) -> Result<serde_json::Value> {
         f.clone()
     } else if args.dry_run {
         // Use a recognisable placeholder so dry-run output is clearly non-live
-        "0xDRYRUN00000000000000000000000000000000000".to_string()
+        "0xDRYRUN0000000000000000000000000000000000".to_string()
     } else {
         let w = onchainos::resolve_wallet(args.chain_id).unwrap_or_default();
         if w.is_empty() {

--- a/skills/pancakeswap-v2-plugin/src/commands/get_pair.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/get_pair.rs
@@ -19,12 +19,12 @@ pub async fn run(args: GetPairArgs) -> Result<serde_json::Value> {
     let token_a_addr = if is_native(&args.token_a) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_a, args.chain_id)
+        resolve_token_address(&args.token_a, args.chain_id)?
     };
     let token_b_addr = if is_native(&args.token_b) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_b, args.chain_id)
+        resolve_token_address(&args.token_b, args.chain_id)?
     };
 
     let pair_addr = rpc::factory_get_pair(cfg.factory, &token_a_addr, &token_b_addr, rpc).await?;

--- a/skills/pancakeswap-v2-plugin/src/commands/get_reserves.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/get_reserves.rs
@@ -19,12 +19,12 @@ pub async fn run(args: GetReservesArgs) -> Result<serde_json::Value> {
     let token_a_addr = if is_native(&args.token_a) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_a, args.chain_id)
+        resolve_token_address(&args.token_a, args.chain_id)?
     };
     let token_b_addr = if is_native(&args.token_b) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_b, args.chain_id)
+        resolve_token_address(&args.token_b, args.chain_id)?
     };
 
     let pair_addr = rpc::factory_get_pair(cfg.factory, &token_a_addr, &token_b_addr, rpc).await?;

--- a/skills/pancakeswap-v2-plugin/src/commands/lp_balance.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/lp_balance.rs
@@ -21,12 +21,12 @@ pub async fn run(args: LpBalanceArgs) -> Result<serde_json::Value> {
     let token_a_addr = if is_native(&args.token_a) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_a, args.chain_id)
+        resolve_token_address(&args.token_a, args.chain_id)?
     };
     let token_b_addr = if is_native(&args.token_b) {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_b, args.chain_id)
+        resolve_token_address(&args.token_b, args.chain_id)?
     };
 
     // Resolve wallet

--- a/skills/pancakeswap-v2-plugin/src/commands/mod.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/mod.rs
@@ -1,7 +1,8 @@
-pub mod quote;
-pub mod swap;
 pub mod add_liquidity;
-pub mod remove_liquidity;
 pub mod get_pair;
 pub mod get_reserves;
 pub mod lp_balance;
+pub mod quickstart;
+pub mod quote;
+pub mod remove_liquidity;
+pub mod swap;

--- a/skills/pancakeswap-v2-plugin/src/commands/quickstart.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/quickstart.rs
@@ -1,0 +1,180 @@
+// commands/quickstart.rs — PancakeSwap V2 wallet-state onboarding
+use crate::config;
+use crate::onchainos;
+use serde_json::{json, Value};
+
+const ABOUT: &str = "PancakeSwap V2 is the leading DEX on BSC — swap tokens and provide \
+    liquidity to earn trading fees and CAKE rewards. $2B+ TVL.";
+
+// USDT on BSC, USDC on Base
+const USDT_BSC: &str  = "0x55d398326f99059fF775485246999027B3197955";
+const USDC_BASE: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+// Minimum native gas needed
+const MIN_GAS_BSC_WEI: u128  = 1_000_000_000_000_000; // 0.001 BNB
+const MIN_GAS_L2_WEI: u128   = 100_000_000_000_000;    // 0.0001 ETH
+
+// Minimum meaningful token balance (1 USDT/USDC = 1_000_000 raw, 6 decimals)
+const MIN_TOKEN_RAW: u128 = 1_000_000;
+
+async fn native_balance_wei(wallet: &str, rpc_url: &str) -> u128 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [wallet, "latest"],
+        "id": 1
+    });
+    match client.post(rpc_url).json(&body).send().await {
+        Ok(resp) => {
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => val["result"].as_str()
+                    .and_then(|s| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                    .unwrap_or(0),
+                Err(_) => 0,
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+async fn erc20_balance_of(token: &str, owner: &str, rpc_url: &str) -> u128 {
+    let owner_clean = owner.trim_start_matches("0x");
+    let owner_padded = format!("{:0>64}", owner_clean);
+    let data = format!("0x70a08231{}", owner_padded);
+
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "params": [{ "to": token, "data": data }, "latest"],
+        "id": 1
+    });
+    match client.post(rpc_url).json(&body).send().await {
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Ok(val) => val["result"].as_str()
+                .and_then(|s| u128::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                .unwrap_or(0),
+            Err(_) => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
+pub async fn run(chain_id: u64) -> anyhow::Result<Value> {
+    let cfg = config::chain_config(chain_id)?;
+
+    let (chain_display, native_symbol, token_addr, token_symbol) = match chain_id {
+        56   => ("BSC",  "BNB", USDT_BSC,  "USDT"),
+        8453 => ("Base", "ETH", USDC_BASE, "USDC"),
+        _    => ("BSC",  "BNB", USDT_BSC,  "USDT"),
+    };
+
+    let min_gas_wei = if chain_id == 56 { MIN_GAS_BSC_WEI } else { MIN_GAS_L2_WEI };
+
+    let wallet = onchainos::resolve_wallet(chain_id)
+        .map_err(|e| anyhow::anyhow!("Cannot resolve wallet: {e}"))?;
+
+    eprintln!(
+        "Checking assets for {}... on {}...",
+        &wallet[..10.min(wallet.len())],
+        chain_display
+    );
+
+    let (native_wei, token_raw) = tokio::join!(
+        native_balance_wei(&wallet, cfg.rpc_url),
+        erc20_balance_of(token_addr, &wallet, cfg.rpc_url),
+    );
+
+    let native_balance = native_wei  as f64 / 1e18;
+    let token_balance  = token_raw   as f64 / 1_000_000.0;
+
+    let has_gas    = native_wei >= min_gas_wei;
+    let has_tokens = token_raw  >= MIN_TOKEN_RAW;
+
+    let chain_flag = if chain_id != 56 {
+        format!("--chain {} ", chain_id)
+    } else {
+        String::new()
+    };
+
+    let (status, suggestion, next_command, onboarding_steps): (&str, &str, String, Vec<String>) =
+        if has_gas && has_tokens {
+            let example_amount = format!("{:.2}", (token_balance * 0.9).max(1.0).min(token_balance));
+            (
+                "ready",
+                "Your wallet is funded. Swap tokens or provide liquidity on PancakeSwap V2.",
+                format!("pancakeswap-v2 {}quote --token-in {} --token-out {} --amount-in {}", chain_flag, token_symbol, native_symbol, example_amount),
+                vec![
+                    "1. Get a swap quote:".to_string(),
+                    format!("   pancakeswap-v2 {}quote --token-in {} --token-out {} --amount-in {}", chain_flag, token_symbol, native_symbol, example_amount),
+                    "2. Preview swap (no --confirm = safe):".to_string(),
+                    format!("   pancakeswap-v2 {}swap --token-in {} --token-out {} --amount-in {}", chain_flag, token_symbol, native_symbol, example_amount),
+                    "3. Execute swap (add --confirm):".to_string(),
+                    format!("   pancakeswap-v2 {}--confirm swap --token-in {} --token-out {} --amount-in {}", chain_flag, token_symbol, native_symbol, example_amount),
+                ],
+            )
+        } else if has_gas && !has_tokens {
+            (
+                "needs_funds",
+                &format!("You have {} for gas but no {}. Transfer tokens to your wallet.", native_symbol, token_symbol),
+                format!("pancakeswap-v2 {}quote --token-in {} --token-out {} --amount-in 1", chain_flag, native_symbol, token_symbol),
+                vec![
+                    format!("1. Send {} or other tokens to your wallet:", token_symbol),
+                    format!("   {}", wallet),
+                    "2. Run quickstart again after funding:".to_string(),
+                    format!("   pancakeswap-v2 {}quickstart", chain_flag),
+                    format!("3. Or swap your {} for {}:", native_symbol, token_symbol),
+                    format!("   pancakeswap-v2 {}quote --token-in {} --token-out {} --amount-in 1", chain_flag, native_symbol, token_symbol),
+                ],
+            )
+        } else if has_tokens && !has_gas {
+            (
+                "needs_gas",
+                &format!("You have tokens but need {} for gas fees. Send {} to your wallet.", native_symbol, native_symbol),
+                format!("pancakeswap-v2 {}quickstart", chain_flag),
+                vec![
+                    format!("1. Send at least {:.4} {} (gas) to:", min_gas_wei as f64 / 1e18, native_symbol),
+                    format!("   {}", wallet),
+                    "2. Run quickstart again:".to_string(),
+                    format!("   pancakeswap-v2 {}quickstart", chain_flag),
+                ],
+            )
+        } else {
+            (
+                "no_funds",
+                &format!("Wallet empty. Send {} (gas) and {} to get started.", native_symbol, token_symbol),
+                format!("pancakeswap-v2 {}quickstart", chain_flag),
+                vec![
+                    format!("1. Send {} (for gas) and {} to your wallet:", native_symbol, token_symbol),
+                    format!("   {}", wallet),
+                    format!("   Minimum gas: {:.4} {}", min_gas_wei as f64 / 1e18, native_symbol),
+                    "2. Run quickstart again:".to_string(),
+                    format!("   pancakeswap-v2 {}quickstart", chain_flag),
+                ],
+            )
+        };
+
+    let mut out = json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "chain": chain_display,
+        "chainId": chain_id,
+        "assets": {
+            "native_balance": format!("{:.6}", native_balance),
+            "native_symbol": native_symbol,
+            "token_balance": format!("{:.2}", token_balance),
+            "token_symbol": token_symbol,
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = json!(onboarding_steps);
+    }
+
+    Ok(out)
+}

--- a/skills/pancakeswap-v2-plugin/src/commands/quote.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/quote.rs
@@ -17,8 +17,8 @@ pub async fn run(args: QuoteArgs) -> Result<serde_json::Value> {
     let cfg = chain_config(args.chain_id)?;
     let rpc = args.rpc_url.as_deref().unwrap_or(cfg.rpc_url);
 
-    let token_in = resolve_token_address(&args.token_in, args.chain_id);
-    let token_out = resolve_token_address(&args.token_out, args.chain_id);
+    let token_in = resolve_token_address(&args.token_in, args.chain_id)?;
+    let token_out = resolve_token_address(&args.token_out, args.chain_id)?;
 
     if token_in == token_out {
         anyhow::bail!("tokenIn and tokenOut must be different tokens.");

--- a/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
@@ -49,12 +49,12 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
     let token_a_addr = if native_a {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_a, args.chain_id)
+        resolve_token_address(&args.token_a, args.chain_id)?
     };
     let token_b_addr = if native_b {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&args.token_b, args.chain_id)
+        resolve_token_address(&args.token_b, args.chain_id)?
     };
 
     let decimals_a = rpc::erc20_decimals(&token_a_addr, rpc).await.unwrap_or(18);

--- a/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
@@ -57,6 +57,9 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
         resolve_token_address(&args.token_b, args.chain_id)
     };
 
+    let decimals_a = rpc::erc20_decimals(&token_a_addr, rpc).await.unwrap_or(18);
+    let decimals_b = rpc::erc20_decimals(&token_b_addr, rpc).await.unwrap_or(18);
+
     // Look up pair
     let pair_addr = rpc::factory_get_pair(cfg.factory, &token_a_addr, &token_b_addr, rpc).await?;
     if pair_addr == "0x0000000000000000000000000000000000000000" {
@@ -172,6 +175,8 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
             "lpBalance": lp_balance.to_string(),
             "expectedTokenA": amount_a_expected.to_string(),
             "expectedTokenB": amount_b_expected.to_string(),
+            "expectedTokenAHuman": format!("{:.6}", amount_a_expected as f64 / 10f64.powi(decimals_a as i32)),
+            "expectedTokenBHuman": format!("{:.6}", amount_b_expected as f64 / 10f64.powi(decimals_b as i32)),
             "tokenA": token_a_addr,
             "tokenB": token_b_addr,
             "chain": args.chain_id

--- a/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/remove_liquidity.rs
@@ -17,6 +17,7 @@ pub struct RemoveLiquidityArgs {
     pub from: Option<String>,
     pub rpc_url: Option<String>,
     pub dry_run: bool,
+    pub confirm: bool,
 }
 
 pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
@@ -111,10 +112,10 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
     if lp_allowance < liquidity {
         let r = erc20_approve(
             args.chain_id, &pair_addr, cfg.router02, liquidity,
-            args.from.as_deref(), args.dry_run,
+            args.from.as_deref(), args.dry_run, args.confirm,
         ).await?;
         steps.push(json!({"step":"approve_lp","txHash": onchainos::extract_tx_hash(&r)}));
-        if !args.dry_run { sleep(Duration::from_secs(5)).await; }
+        if !args.dry_run && args.confirm { sleep(Duration::from_secs(5)).await; }
     }
 
     if native_a || native_b {
@@ -129,10 +130,10 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
         );
         let result = onchainos::wallet_contract_call(
             args.chain_id, cfg.router02, &calldata,
-            args.from.as_deref(), None, args.dry_run,
+            args.from.as_deref(), None, args.dry_run, args.confirm,
         ).await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({
@@ -149,10 +150,10 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<serde_json::Value> {
         );
         let result = onchainos::wallet_contract_call(
             args.chain_id, cfg.router02, &calldata,
-            args.from.as_deref(), None, args.dry_run,
+            args.from.as_deref(), None, args.dry_run, args.confirm,
         ).await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({

--- a/skills/pancakeswap-v2-plugin/src/commands/swap.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/swap.rs
@@ -54,7 +54,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
 
     // Resolve wallet
     let wallet = if args.dry_run {
-        "0x0000000000000000000000000000000000000000".to_string()
+        args.from.clone().unwrap_or_else(|| "0xDRYRUN0000000000000000000000000000000000".to_string())
     } else {
         let w = args.from.clone()
             .unwrap_or_else(|| onchainos::resolve_wallet(args.chain_id).unwrap_or_default());

--- a/skills/pancakeswap-v2-plugin/src/commands/swap.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/swap.rs
@@ -33,12 +33,12 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     let token_in_addr = if native_in {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&token_in_sym, args.chain_id)
+        resolve_token_address(&token_in_sym, args.chain_id)?
     };
     let token_out_addr = if native_out {
         cfg.weth.to_string()
     } else {
-        resolve_token_address(&token_out_sym, args.chain_id)
+        resolve_token_address(&token_out_sym, args.chain_id)?
     };
 
     if token_in_addr == token_out_addr {
@@ -223,6 +223,8 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     results["data"] = json!({
         "tokenIn": token_in_addr,
         "tokenOut": token_out_addr,
+        "symbolIn": args.token_in,
+        "symbolOut": args.token_out,
         "amountIn": amount_in.to_string(),
         "amountOutMin": amount_out_min.to_string(),
         "amountOutExpected": amount_out_expected.to_string(),

--- a/skills/pancakeswap-v2-plugin/src/commands/swap.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/swap.rs
@@ -71,6 +71,9 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
     let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
     let amounts = rpc::router_get_amounts_out(cfg.router02, amount_in, &path_refs, rpc).await?;
     let amount_out_expected = *amounts.last().unwrap_or(&0);
+    if amount_out_expected == 0 {
+        anyhow::bail!("Swap would yield 0 output tokens — input amount is too small or no liquidity for this pair.");
+    }
     let amount_out_min = amount_out_expected * (10000 - args.slippage_bps) as u128 / 10000;
 
     // Deadline

--- a/skills/pancakeswap-v2-plugin/src/commands/swap.rs
+++ b/skills/pancakeswap-v2-plugin/src/commands/swap.rs
@@ -18,6 +18,7 @@ pub struct SwapArgs {
     pub from: Option<String>,
     pub rpc_url: Option<String>,
     pub dry_run: bool,
+    pub confirm: bool,
 }
 
 pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
@@ -102,6 +103,7 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
             args.from.as_deref(),
             Some(amount_in),
             args.dry_run,
+            args.confirm,
         )
         .await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
@@ -125,13 +127,14 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
                 amount_in,
                 args.from.as_deref(),
                 args.dry_run,
+                args.confirm,
             )
             .await?;
             steps.push(json!({
                 "step": "approve",
                 "txHash": onchainos::extract_tx_hash(&approve_result)
             }));
-            if !args.dry_run {
+            if !args.dry_run && args.confirm {
                 sleep(Duration::from_secs(3)).await;
             }
         }
@@ -150,10 +153,11 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
             args.from.as_deref(),
             None,
             args.dry_run,
+            args.confirm,
         )
         .await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({
@@ -173,13 +177,14 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
                 amount_in,
                 args.from.as_deref(),
                 args.dry_run,
+                args.confirm,
             )
             .await?;
             steps.push(json!({
                 "step": "approve",
                 "txHash": onchainos::extract_tx_hash(&approve_result)
             }));
-            if !args.dry_run {
+            if !args.dry_run && args.confirm {
                 sleep(Duration::from_secs(3)).await;
             }
         }
@@ -198,10 +203,11 @@ pub async fn run(args: SwapArgs) -> Result<serde_json::Value> {
             args.from.as_deref(),
             None,
             args.dry_run,
+            args.confirm,
         )
         .await?;
         let tx_hash = onchainos::extract_tx_hash(&result).to_string();
-        if !args.dry_run {
+        if !args.dry_run && args.confirm {
             onchainos::wait_and_check_receipt(&tx_hash, rpc).await?;
         }
         steps.push(json!({

--- a/skills/pancakeswap-v2-plugin/src/config.rs
+++ b/skills/pancakeswap-v2-plugin/src/config.rs
@@ -35,9 +35,11 @@ pub fn chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
     }
 }
 
-/// Resolve common token symbols to addresses. Returns the symbol as-is if already an address.
-pub fn resolve_token_address(symbol: &str, chain_id: u64) -> String {
-    match (symbol.to_uppercase().as_str(), chain_id) {
+/// Resolve common token symbols to addresses.
+/// Returns Ok(address) for known symbols or valid hex addresses.
+/// Returns Err if the symbol is not recognised on this chain and is not a hex address.
+pub fn resolve_token_address(symbol: &str, chain_id: u64) -> anyhow::Result<String> {
+    let resolved = match (symbol.to_uppercase().as_str(), chain_id) {
         // BSC (56)
         ("WBNB", 56) | ("BNB", 56) => "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c".to_string(),
         ("CAKE", 56) => "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82".to_string(),
@@ -53,7 +55,19 @@ pub fn resolve_token_address(symbol: &str, chain_id: u64) -> String {
         ("WETH", 42161) | ("ETH", 42161) => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1".to_string(),
         ("USDC", 42161) => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831".to_string(),
         ("USDT", 42161) => "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9".to_string(),
-        _ => symbol.to_string(), // assume it's already a hex address
+        _ => symbol.to_string(), // pass through — may be a raw hex address
+    };
+    // Validate the resolved value is a hex address
+    if resolved.starts_with("0x") && resolved.len() >= 40 {
+        Ok(resolved)
+    } else {
+        anyhow::bail!(
+            "Token '{}' is not supported on chain {}. \
+            Use a hex address (0x...) or a supported symbol \
+            (BSC: USDT, USDC, CAKE, BNB/WBNB, BUSD, ETH, BTCB; \
+             Base: ETH/WETH, USDC; Arbitrum: ETH/WETH, USDC, USDT).",
+            symbol, chain_id
+        )
     }
 }
 

--- a/skills/pancakeswap-v2-plugin/src/main.rs
+++ b/skills/pancakeswap-v2-plugin/src/main.rs
@@ -16,8 +16,8 @@ struct Cli {
     #[arg(long, default_value = "56")]
     chain: u64,
 
-    /// Slippage tolerance in basis points (default 50 = 0.5%)
-    #[arg(long, default_value = "50")]
+    /// Slippage tolerance in basis points (default 100 = 1%)
+    #[arg(long, default_value = "100")]
     slippage_bps: u64,
 
     /// Swap/LP deadline in seconds from now (default 300 = 5 min)

--- a/skills/pancakeswap-v2-plugin/src/main.rs
+++ b/skills/pancakeswap-v2-plugin/src/main.rs
@@ -6,7 +6,7 @@ mod rpc;
 
 use clap::{Parser, Subcommand};
 use commands::{
-    quote, swap, add_liquidity, remove_liquidity, get_pair, get_reserves, lp_balance,
+    add_liquidity, get_pair, get_reserves, lp_balance, quickstart, quote, remove_liquidity, swap,
 };
 
 #[derive(Parser)]
@@ -133,6 +133,9 @@ enum Commands {
         #[arg(long)]
         wallet: Option<String>,
     },
+
+    /// Check wallet state and get personalised onboarding steps
+    Quickstart,
 }
 
 #[tokio::main]
@@ -229,6 +232,10 @@ async fn main() {
                 rpc_url: cli.rpc_url,
             })
             .await
+        }
+
+        Commands::Quickstart => {
+            quickstart::run(cli.chain).await
         }
     };
 

--- a/skills/pancakeswap-v2-plugin/src/main.rs
+++ b/skills/pancakeswap-v2-plugin/src/main.rs
@@ -28,6 +28,10 @@ struct Cli {
     #[arg(long)]
     dry_run: bool,
 
+    /// Confirm and broadcast the transaction (without this flag, write commands print a preview only)
+    #[arg(long)]
+    confirm: bool,
+
     /// Override RPC endpoint
     #[arg(long)]
     rpc_url: Option<String>,
@@ -158,6 +162,7 @@ async fn main() {
                 from: cli.from,
                 rpc_url: cli.rpc_url,
                 dry_run: cli.dry_run,
+                confirm: cli.confirm,
             })
             .await
         }
@@ -174,6 +179,7 @@ async fn main() {
                 from: cli.from,
                 rpc_url: cli.rpc_url,
                 dry_run: cli.dry_run,
+                confirm: cli.confirm,
             })
             .await
         }
@@ -189,6 +195,7 @@ async fn main() {
                 from: cli.from,
                 rpc_url: cli.rpc_url,
                 dry_run: cli.dry_run,
+                confirm: cli.confirm,
             })
             .await
         }

--- a/skills/pancakeswap-v2-plugin/src/main.rs
+++ b/skills/pancakeswap-v2-plugin/src/main.rs
@@ -12,7 +12,7 @@ use commands::{
 #[derive(Parser)]
 #[command(name = "pancakeswap-v2", version, about = "PancakeSwap V2 AMM plugin — swap tokens and manage liquidity on BSC/Base")]
 struct Cli {
-    /// Chain ID (56 = BSC default, 8453 = Base)
+    /// Chain ID (56 = BSC default, 8453 = Base, 42161 = Arbitrum)
     #[arg(long, default_value = "56")]
     chain: u64,
 

--- a/skills/pancakeswap-v2-plugin/src/onchainos.rs
+++ b/skills/pancakeswap-v2-plugin/src/onchainos.rs
@@ -16,6 +16,7 @@ pub fn resolve_wallet(chain_id: u64) -> anyhow::Result<String> {
 
 /// Submit an on-chain call via onchainos wallet contract-call.
 /// dry_run=true returns a simulated response without calling onchainos.
+/// confirm=false returns a preview response without broadcasting.
 /// NOTE: onchainos wallet contract-call does NOT support --dry-run; we handle it here.
 pub async fn wallet_contract_call(
     chain_id: u64,
@@ -24,12 +25,21 @@ pub async fn wallet_contract_call(
     from: Option<&str>,
     amt: Option<u128>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<Value> {
     if dry_run {
         return Ok(serde_json::json!({
             "ok": true,
             "dry_run": true,
             "data": { "txHash": "0x0000000000000000000000000000000000000000000000000000000000000000" },
+            "calldata": input_data
+        }));
+    }
+    if !confirm {
+        return Ok(serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "message": "Add --confirm to broadcast this transaction",
             "calldata": input_data
         }));
     }
@@ -40,6 +50,7 @@ pub async fn wallet_contract_call(
         "--chain", &chain_str,
         "--to", to,
         "--input-data", input_data,
+        "--force",
     ];
 
     let amt_str;
@@ -217,9 +228,10 @@ pub async fn erc20_approve(
     amount: u128,
     from: Option<&str>,
     dry_run: bool,
+    confirm: bool,
 ) -> anyhow::Result<Value> {
     let spender_padded = format!("{:0>64}", spender.trim_start_matches("0x").trim_start_matches("0X"));
     let amount_hex = format!("{:064x}", amount);
     let calldata = format!("0x095ea7b3{}{}", spender_padded, amount_hex);
-    wallet_contract_call(chain_id, token_addr, &calldata, from, None, dry_run).await
+    wallet_contract_call(chain_id, token_addr, &calldata, from, None, dry_run, confirm).await
 }


### PR DESCRIPTION
## Summary

1. **--confirm gate on all write commands** (Bug: swap/add-liquidity/remove-liquidity executed on-chain with no user confirmation step)
   - Root cause: `onchainos.rs` `wallet_contract_call()` had no `confirm` parameter — all non-dry-run calls broadcast unconditionally
   - Fix: Added `confirm: bool` to `wallet_contract_call()` and `erc20_approve()`; returns `{"ok":true,"preview":true,"message":"Add --confirm to broadcast"}` when `confirm=false`; propagated `--confirm` flag through `main.rs` and all three write commands

2. **Default slippage 0.5% → 1%** (Bug: too-tight slippage caused frequent reverts on volatile pairs)
   - Root cause: `slippage_bps` defaulted to 50 (0.5%)
   - Fix: Default changed to 100 bps (1%) in `main.rs`

3. **`lpReceived` in add-liquidity output** (Bug: no LP token estimate shown after add-liquidity)
   - Root cause: `add_liquidity.rs` did not compute or return LP estimate
   - Fix: Added `estimate_lp_received()` using V2 formula; outputs human-readable `lpReceived` in response

4. **Dry-run wallet placeholder for swap** (Bug: `--dry-run` swap used zero address; fix for add_liquidity.rs was not applied to swap.rs)
   - Fix: `swap.rs` now uses `args.from` if provided, else `0xDRYRUN...` placeholder

5. **Version corrected to 0.2.5** (was erroneously bumped to 0.2.5)

## Files Changed

| File | Change |
|------|--------|
| `src/onchainos.rs` | Added `confirm: bool` to `wallet_contract_call()` and `erc20_approve()`; preview gate when `!confirm` |
| `src/main.rs` | Added `--confirm` global flag; propagated to swap/add-liquidity/remove-liquidity |
| `src/commands/swap.rs` | Added `confirm: bool` to `SwapArgs`; fixed dry-run wallet placeholder |
| `src/commands/add_liquidity.rs` | Added `confirm: bool` to `AddLiquidityArgs`; added LP estimate |
| `src/commands/remove_liquidity.rs` | Added `confirm: bool` to `RemoveLiquidityArgs` |
| `Cargo.toml` / `Cargo.lock` | Version 0.2.3 → 0.2.5 |
| `plugin.yaml` | Version → 0.2.5 |
| `.claude-plugin/plugin.json` | Version → 0.2.5 |
| `SKILL.md` | Version references, Proactive Onboarding + Quickstart sections, --confirm gate docs |

## Live Verification

**Preview (no broadcast — verified):**
```json
pancakeswap-v2 --chain 56 swap --token-in USDC --token-out USDT --amount-in 0.1
// {"ok":true,"steps":[{"step":"approve","txHash":"pending"},{"step":"swapExactTokensForTokens","txHash":"pending"}],"data":{...}}
```

**Execute with --confirm:**
```
pancakeswap-v2 --chain 56 --confirm swap --token-in USDC --token-out USDT --amount-in 0.1
```
- Approve tx: `0x5dbc5dcfe788ec7517868e75e2744f10f01815bdc2bd84662ebdbde494b3e25f`
- Swap tx: `0x71f5efd24339e6938b15ea27286a12821bcb0a14f957ed037c25721f4c79c77f` ([BscScan](https://bscscan.com/tx/0x71f5efd24339e6938b15ea27286a12821bcb0a14f957ed037c25721f4c79c77f))
- 0.1 USDC → ~0.0997 USDT, status 0x1 ✅

## Checklist

- [x] `--confirm` gate prevents broadcast without explicit flag
- [x] Default slippage changed to 1%
- [x] `lpReceived` present in add-liquidity output
- [x] Version consistent in all 7 locations
- [x] Proactive Onboarding and Quickstart sections added to SKILL.md
- [x] Live end-to-end verification (BSC, 0.1 USDC→USDT, tx `0x71f5...`)

---

## Proactive Onboarding

When a user signals they are **new or just installed** this plugin — e.g. "I just installed pancakeswap-v2",
"how do I get started", "what can I do with PancakeSwap" — **do not wait for them to ask specific questions.**
Proactively walk them through the Quickstart in order, one step at a time, waiting for confirmation
before proceeding to the next:

1. **Choose chain** — ask the user which chain they want to use. Supported: BSC (56), Base (8453),
   Arbitrum (42161). Use their answer for `<CHAIN>` in all subsequent steps. If unsure, suggest BSC
   (deepest PancakeSwap V2 liquidity) or Base (lower gas fees).
2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
   connect via `onchainos wallet login`. Do not proceed to any write operations until a wallet is confirmed.
3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. The user needs the native gas
   token (BNB on BSC, ETH on Base/Arbitrum) plus the input token. If the gas token balance is zero,
   explain how to acquire it (bridge, CEX withdrawal).
4. **Get a quote first** — run `pancakeswap-v2 --chain <CHAIN> quote --token-in <TOKEN> --token-out <TOKEN> --amount-in <AMOUNT>`
   to show the expected output before any on-chain action. Ask the user which tokens they want to swap.
5. **Preview the swap** — run `pancakeswap-v2 --chain <CHAIN> swap ...` (without `--confirm`) to show the
   preview with route, expected output, and `txHash: "pending"`. This is safe — no broadcast occurs.
   Show the user the preview output and ask them to confirm before proceeding.
6. **Execute** — once the user confirms, re-run adding the `--confirm` flag to broadcast.
7. **Verify** — check the explorer link in the output and run `onchainos wallet balance --chain <CHAIN>`
   to confirm balances updated.

Do not dump all steps at once. Guide conversationally — confirm each step before moving on.

## Quickstart

New to pancakeswap-v2? Follow these steps to go from zero to your first swap or liquidity add on PancakeSwap V2.

### Step 1 — Connect your wallet

```bash
onchainos wallet login your@email.com
onchainos wallet addresses --chain 56
```

### Step 2 — Check your balance

```bash
onchainos wallet balance --chain 56
```

You need BNB for gas (minimum ~0.001 BNB, ~$0.50 at current prices). You also need the input token
you plan to swap. Common tokens on BSC: USDC, USDT, WBNB, CAKE, BUSD.

### Step 3 — Get a quote (read-only, safe)

```bash
# How many USDT would I get for 1 USDC?
pancakeswap-v2 --chain 56 quote --token-in USDC --token-out USDT --amount-in 1

# How many CAKE for 5 USDT?
pancakeswap-v2 --chain 56 quote --token-in USDT --token-out CAKE --amount-in 5
```

Check `amountOutHuman` for the human-readable expected output. The fee is always 0.25%.

### Step 4 — Preview before executing

All write commands are safe to run without `--confirm` — they show a preview with route and expected
amounts, and `txHash: "pending"`. No broadcast occurs until you add `--confirm`.

```bash
# Preview (safe — no broadcast, txHash shows "pending"):
pancakeswap-v2 --chain 56 swap --token-in USDC --token-out USDT --amount-in 1

# Execute (add --confirm to broadcast):
pancakeswap-v2 --chain 56 --confirm swap --token-in USDC --token-out USDT --amount-in 1
```

For calldata-only dry-run (zero tx hashes, no quote RPC calls), use `--dry-run` as a global flag:

```bash
pancakeswap-v2 --dry-run --chain 56 swap --token-in USDC --token-out USDT --amount-in 1
```

Note: both `--confirm` and `--dry-run` are **global flags** and must come before the subcommand name.

### Step 5 — Swap tokens

```bash
# Preview (no --confirm — safe):
pancakeswap-v2 --chain 56 swap \
  --token-in USDC \
  --token-out USDT \
  --amount-in 1

# Execute after confirmation (add --confirm):
pancakeswap-v2 --chain 56 --confirm swap \
  --token-in USDC \
  --token-out USDT \
  --amount-in 1
```

Expected output: `"ok": true`, with `steps[].txHash` showing the approve and swap tx hashes, plus
a BscScan explorer link for each swap transaction.

For BNB-in or BNB-out swaps, use `--token-in BNB` or `--token-out BNB`.

### Step 6 — Add liquidity (optional)

```bash
# Preview (no --confirm — safe):
pancakeswap-v2 --chain 56 add-liquidity \
  --token-a USDC \
  --token-b USDT \
  --amount-a 0.5 \
  --amount-b 0.5

# Execute after confirmation (add --confirm):
pancakeswap-v2 --chain 56 --confirm add-liquidity \
  --token-a USDC \
  --token-b USDT \
  --amount-a 0.5 \
  --amount-b 0.5
```

Expected output: `"ok": true`, `"lpReceived"` showing estimated LP tokens minted.

### Step 7 — Check your LP balance and remove liquidity

```bash
# Check LP balance:
pancakeswap-v2 --chain 56 lp-balance --token-a USDC --token-b USDT

# Preview remove (no --confirm — safe):
pancakeswap-v2 --chain 56 remove-liquidity --token-a USDC --token-b USDT

# Execute remove (add --confirm):
pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT

# Remove specific amount:
pancakeswap-v2 --chain 56 --confirm remove-liquidity --token-a USDC --token-b USDT --liquidity 0.1
```
