### PR TITLE
fix(pancakeswap-v3): --version flag + add-liquidity confirm gate (v1.0.2)

### DIFF
--- a/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v3",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap-v3",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
@@ -1,10 +1,21 @@
 {
   "name": "pancakeswap-v3",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "1.0.2",
-  "author": {"name": "GeoGu360", "github": "GeoGu360"},
+  "version": "1.0.1",
+  "author": {
+    "name": "GeoGu360",
+    "github": "GeoGu360"
+  },
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap-v3",
   "repository": "https://github.com/okx/plugin-store",
   "license": "MIT",
-  "keywords": ["dex", "swap", "liquidity", "pancakeswap", "bsc", "base", "arbitrum"]
+  "keywords": [
+    "dex",
+    "swap",
+    "liquidity",
+    "pancakeswap",
+    "bsc",
+    "base",
+    "arbitrum"
+  ]
 }

--- a/skills/pancakeswap-v3-plugin/Cargo.lock
+++ b/skills/pancakeswap-v3-plugin/Cargo.lock
@@ -1614,8 +1614,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pancakeswap-v3"
-version = "1.0.0"
+name = "pancakeswap-v3-plugin"
+version = "1.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap-v3-plugin/Cargo.toml
+++ b/skills/pancakeswap-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v3-plugin"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v3-plugin/Cargo.toml
+++ b/skills/pancakeswap-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v3-plugin"
-version = "1.0.2"
+version = "1.0.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v3-plugin/SKILL.md
+++ b/skills/pancakeswap-v3-plugin/SKILL.md
@@ -146,6 +146,166 @@ Swap tokens and manage concentrated liquidity on PancakeSwap V3 — the leading 
 
 ---
 
+## Proactive Onboarding
+
+When a user signals they are **new or just installed** this plugin — e.g. "I just installed pancakeswap-v3",
+"how do I get started with PancakeSwap V3", "what can I do with PancakeSwap V3" — **do not wait for them to ask
+specific questions.** Proactively walk them through the Quickstart in order, one step at a time,
+waiting for confirmation before proceeding to the next:
+
+1. **Choose chain** — ask the user which chain they want to use. Supported: BNB Chain (56), Base (8453),
+   Arbitrum (42161), Ethereum (1), Linea (59144). Use their answer for `<CHAIN>` in all subsequent steps.
+   If unsure, suggest BNB Chain (56) for the deepest PancakeSwap liquidity and lowest gas fees, or
+   Base (8453) for a low-cost EVM experience.
+2. **Check wallet** — run `onchainos wallet addresses --chain <CHAIN>`. If no address, direct them to
+   connect via `onchainos wallet login`. Do not proceed to write operations until a wallet is confirmed.
+3. **Check balance** — run `onchainos wallet balance --chain <CHAIN>`. You need at least a small amount
+   of the token you want to swap (e.g. 0.01 BNB, 1 USDT). If insufficient, explain what's needed and
+   how to fund (bridge, CEX withdrawal, or swap on another chain first).
+4. **Explore pools** — run `pancakeswap-v3 pools --token0 WBNB --token1 USDT --chain <CHAIN>` (or
+   the relevant pair) to show available fee tiers and liquidity. Use `quote` to preview expected
+   output before committing.
+5. **Preview first write** — run the write command (e.g. `swap`) **without `--confirm`** so the user
+   sees the preview (including expected output, min output, fee tier, and SmartRouter address) before
+   any on-chain action. Confirm no transaction was sent.
+6. **Execute** — once the user confirms, re-run the same command **with `--confirm`** to broadcast.
+   Note: ERC-20 tokens (USDT, USDC, CAKE, etc.) require an approval tx that fires first; the plugin
+   waits for approval to confirm on-chain before submitting the swap.
+
+**Important caveats:**
+- Write commands (`swap`, `add-liquidity`, `remove-liquidity`) require `--confirm` to broadcast.
+  Without `--confirm` the binary prints a preview and exits — no transaction is sent.
+- All five supported chains use the same PancakeV3Factory, NPM, and QuoterV2 addresses.
+- Unsupported chains return a clear error and exit 1.
+
+Do not dump all steps at once. Guide conversationally — confirm each step before moving on.
+
+---
+
+## Quickstart
+
+New to pancakeswap-v3-plugin? Follow these steps to go from zero to your first PancakeSwap V3 swap on BNB Chain.
+
+### Step 1 — Connect your wallet
+
+```bash
+onchainos wallet login your@email.com
+onchainos wallet addresses --chain 56
+```
+
+Confirm you see your BNB Chain address before continuing.
+
+### Step 2 — Check your balance
+
+```bash
+onchainos wallet balance --chain 56
+```
+
+Minimum recommended: at least 0.005 BNB for gas, plus the token you want to swap (e.g. 1 USDT or
+0.01 WBNB). If your balance is zero, transfer BNB to your BNB Chain address first (via CEX
+withdrawal or bridge).
+
+### Step 3 — Explore available pools
+
+```bash
+# List all fee-tier pools for a token pair
+pancakeswap-v3 pools --token0 WBNB --token1 USDT --chain 56
+```
+
+Returns pool addresses, current price, liquidity, and current tick for each fee tier (0.01%, 0.05%,
+0.25%, 1%). Note the fee tier with the highest liquidity — that's typically the best pool to use.
+
+To get a swap quote before committing:
+
+```bash
+# Quote 0.1 WBNB → USDT on BSC (best fee tier auto-selected)
+pancakeswap-v3 quote --from WBNB --to USDT --amount 0.1 --chain 56
+```
+
+### Step 4 — Preview before executing
+
+All write commands show a safe preview by default — no on-chain action until you add `--confirm`:
+
+```bash
+# Preview swap (safe — no tx sent):
+pancakeswap-v3 swap --from WBNB --to USDT --amount 0.1 --chain 56
+
+# Execute swap (add --confirm):
+pancakeswap-v3 swap --from WBNB --to USDT --amount 0.1 --chain 56 --confirm
+```
+
+Check that the preview shows expected output and minimum output (after slippage) before confirming.
+
+### Step 5 — Swap tokens
+
+```bash
+pancakeswap-v3 swap \
+  --from WBNB \
+  --to USDT \
+  --amount 0.1 \
+  --slippage 0.5 \
+  --chain 56 \
+  --confirm
+```
+
+Expected output: approval tx hash (if WBNB is ERC-20), then swap tx hash with explorer link.
+
+**Note:** ERC-20 swaps (USDT, USDC, CAKE, etc.) fire an approve tx first. You will see
+`Approving <token> for SmartRouter...` followed by the approve tx hash before the swap broadcasts.
+This is expected and safe — the plugin waits for approval to confirm before sending the swap.
+
+### Step 6 — (Optional) View your LP positions
+
+If you already have V3 LP positions on this chain, check them with:
+
+```bash
+pancakeswap-v3 positions --owner 0xYOUR_WALLET --chain 56
+```
+
+### Step 7 — (Optional) Add concentrated liquidity
+
+```bash
+# Preview — shows token pair, amounts, fee tier, tick range, estimated deposit (no tx)
+pancakeswap-v3 add-liquidity \
+  --token-a WBNB \
+  --token-b USDT \
+  --fee 500 \
+  --amount-a 0.1 \
+  --amount-b 30 \
+  --chain 56
+
+# Execute — broadcasts approve0, approve1, and mint transactions
+pancakeswap-v3 add-liquidity \
+  --token-a WBNB \
+  --token-b USDT \
+  --fee 500 \
+  --amount-a 0.1 \
+  --amount-b 30 \
+  --chain 56 \
+  --confirm
+```
+
+Omit `--tick-lower` / `--tick-upper` to let the plugin auto-select a ±10% price range. After
+minting, run `positions` to confirm your new tokenId.
+
+### Step 8 — (Optional) Remove liquidity
+
+```bash
+# Preview — shows expected out, min amounts (no tx)
+pancakeswap-v3 remove-liquidity --token-id 1234 --chain 56
+
+# Execute — broadcasts decreaseLiquidity then collect
+pancakeswap-v3 remove-liquidity --token-id 1234 --chain 56 --confirm
+```
+
+To remove only part of the position:
+
+```bash
+pancakeswap-v3 remove-liquidity --token-id 1234 --liquidity-pct 50 --slippage 1.0 --chain 56 --confirm
+```
+
+---
+
 ## Do NOT use for
 
 Do NOT use for: PancakeSwap V2 AMM swaps (use pancakeswap-v2 skill), concentrated liquidity farming (use pancakeswap-clmm skill), non-PancakeSwap DEXes

--- a/skills/pancakeswap-v3-plugin/SKILL.md
+++ b/skills/pancakeswap-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v3-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on Ethereum, BNB Chain, Base, Arbitrum, and Linea"
-version: "1.0.1"
+version: "1.0.2"
 author: "GeoGu360"
 tags:
   - dex
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v3-plugin"
 CACHE_MAX=3600
-LOCAL_VER="1.0.1"
+LOCAL_VER="1.0.2"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.1/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.2/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -161,7 +161,7 @@ Do NOT use for: PancakeSwap V2 AMM swaps (use pancakeswap-v2 skill), concentrate
 
 Before executing any write command, verify:
 
-1. **Binary installed**: `pancakeswap --version` — if not found, run the install script above
+1. **Binary installed**: `pancakeswap-v3 --version` — if not found, run the install script above
 2. **Wallet connected**: `onchainos wallet addresses` — confirm wallet is logged in and active address is set
 3. **Chain supported**: target chain must be BNB Chain (56), Base (8453), or Arbitrum (42161)
 
@@ -310,7 +310,20 @@ pancakeswap-v3 add-liquidity \
   [--tick-upper <int>] \
   [--slippage 1.0] \
   [--chain 1|56|8453|42161|59144] \
-  [--dry-run]
+  [--dry-run] \
+  [--confirm]
+```
+
+**Examples:**
+```
+# Preview — shows token pair, amounts, fee tier, tick range, estimated deposit (no tx)
+pancakeswap-v3 add-liquidity --token-a WBNB --token-b USDT --fee 500 --amount-a 0.1 --amount-b 30 --chain 56
+
+# Execute — broadcasts all 3 transactions (approve0, approve1, mint)
+pancakeswap-v3 add-liquidity --token-a WBNB --token-b USDT --fee 500 --amount-a 0.1 --amount-b 30 --chain 56 --confirm
+
+# Dry-run — shows calldata for all 3 steps without broadcasting
+pancakeswap-v3 add-liquidity --token-a WBNB --token-b USDT --fee 500 --amount-a 0.1 --amount-b 30 --chain 56 --dry-run
 ```
 
 **Execution flow:**
@@ -320,8 +333,8 @@ pancakeswap-v3 add-liquidity \
 3. **Tick range**: if `--tick-lower`/`--tick-upper` are omitted, auto-compute ±10% price range (~±1000 ticks) from the current pool tick, aligned to tickSpacing. If provided, validate they are multiples of tickSpacing.
 4. **Balance check**: verify wallet holds sufficient token0 and token1 before submitting any transaction. Fails early with a clear message if balance is insufficient.
 5. **Slippage minimums**: compute the actual deposit amounts using V3 liquidity math (based on current sqrtPrice and tick range), then apply slippage tolerance to those amounts. This prevents "Price slippage check" reverts caused by applying slippage to `desired` amounts instead of actual amounts.
-6. Present the full plan (amounts, tick range, expected deposit, min amounts, NPM address).
-7. Submit Step 1 — approve token0 for NonfungiblePositionManager.
+6. Without `--confirm`: print a JSON preview (token pair, amounts, fee tier, tick range, estimated LP, NPM address) and exit. **No transactions are submitted.**
+7. With `--confirm`: submit Step 1 — approve token0 for NonfungiblePositionManager.
 8. Submit Step 2 — approve token1 for NonfungiblePositionManager.
 9. Submit Step 3 — `mint(MintParams)` to NonfungiblePositionManager.
 10. Report tokenId and transaction hash.
@@ -354,7 +367,8 @@ pancakeswap-v3 remove-liquidity \
   [--liquidity-pct 100] \
   [--slippage 0.5] \
   [--chain 1|56|8453|42161|59144] \
-  [--dry-run]
+  [--dry-run] \
+  [--confirm]
 ```
 
 **Example:**
@@ -439,6 +453,12 @@ pancakeswap-v3 remove-liquidity --token-id 345455 --liquidity-pct 50 --slippage 
 | WBTC | `0x3aAB2285ddcDdaD8edf438C1bAB47e1a9D05a9b4` |
 
 ## Changelog
+
+### v1.0.2 (2026-04-14)
+
+- **fix (CRITICAL)**: Added `version` to `#[command(...)]` in `main.rs` — `pancakeswap-v3 --version` now works correctly. Previously the flag was not registered and returned an error.
+- **fix (MAJOR)**: `add-liquidity` confirm gate — without `--confirm`, the command now prints a JSON preview (token pair, amounts, fee tier, tick range, estimated deposit) and exits. Previously it printed misleading "Step 1: Approving..." messages suggesting execution was in progress.
+- **docs**: Added `--version` to pre-flight check example; added `--confirm` to all `add-liquidity` usage examples; clarified dry-run vs confirm flow in execution flow section.
 
 ### v1.0.0 (2026-04-12)
 

--- a/skills/pancakeswap-v3-plugin/SKILL.md
+++ b/skills/pancakeswap-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v3-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on Ethereum, BNB Chain, Base, Arbitrum, and Linea"
-version: "1.0.2"
+version: "1.0.1"
 author: "GeoGu360"
 tags:
   - dex
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v3-plugin"
 CACHE_MAX=3600
-LOCAL_VER="1.0.2"
+LOCAL_VER="1.0.1"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then

--- a/skills/pancakeswap-v3-plugin/plugin.yaml
+++ b/skills/pancakeswap-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v3-plugin
-version: "1.0.1"
+version: "1.0.2"
 description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360

--- a/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
@@ -1,6 +1,7 @@
 /// `pancakeswap add-liquidity` — mint a new V3 LP position via NonfungiblePositionManager.
 
 use anyhow::Result;
+use serde_json;
 
 pub struct AddLiquidityArgs {
     pub token_a: String,
@@ -118,6 +119,37 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
             );
         }
         println!("Balance check OK: {} {} available, {} {} available", bal0, sym0, bal1, sym1);
+    }
+
+    // Confirm gate: if not dry-run and not confirmed, print preview and exit
+    if !args.dry_run && !args.confirm {
+        let preview = serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "operation": "add-liquidity",
+            "chain": args.chain,
+            "token0": { "address": token0, "symbol": sym0, "amount": amount_a_str },
+            "token1": { "address": token1, "symbol": sym1, "amount": amount_b_str },
+            "feeTier": format!("{}%", args.fee as f64 / 10000.0),
+            "tickRange": { "lower": tick_lower, "upper": tick_upper },
+            "expectedDeposit": {
+                "amount0": actual0.to_string(),
+                "amount1": actual1.to_string(),
+                "amount0Min": amount0_min.to_string(),
+                "amount1Min": amount1_min.to_string(),
+                "slippagePct": args.slippage
+            },
+            "npm": cfg.npm,
+            "pendingTransactions": 3,
+            "transactions": [
+                {"step": 1, "description": format!("Approve {} {} for NonfungiblePositionManager", amount_a_str, sym0), "to": token0},
+                {"step": 2, "description": format!("Approve {} {} for NonfungiblePositionManager", amount_b_str, sym1), "to": token1},
+                {"step": 3, "description": "Mint V3 LP position via NonfungiblePositionManager.mint", "to": cfg.npm},
+            ],
+            "note": "Re-run with --confirm to execute these transactions on-chain."
+        });
+        println!("{}", serde_json::to_string_pretty(&preview)?);
+        return Ok(());
     }
 
     println!("Add Liquidity (chain {}):", args.chain);

--- a/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
@@ -71,6 +71,12 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
     println!("  Owed fees:    {} {} / {} {}", pos.tokens_owed0, sym0, pos.tokens_owed1, sym1);
     println!("  NPM:          {}", cfg.npm);
 
+    // Preview gate: if --confirm not passed and not dry-run, show details and exit without broadcasting
+    if !args.confirm && !args.dry_run {
+        println!("\nPreview only — no transactions submitted. Add --confirm to execute.");
+        return Ok(());
+    }
+
     // Deadline: 20 minutes from now
     let deadline = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/skills/pancakeswap-v3-plugin/src/main.rs
+++ b/skills/pancakeswap-v3-plugin/src/main.rs
@@ -7,7 +7,7 @@ mod commands;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "pancakeswap-v3", about = "Swap tokens and manage liquidity on PancakeSwap V3")]
+#[command(name = "pancakeswap-v3", version, about = "Swap tokens and manage liquidity on PancakeSwap V3")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
## Summary
- Add `--version` flag via `#[command(version)]`
- Add `--confirm` gate to `add-liquidity` with JSON preview output
- Version bump 1.0.1 → 1.0.2

## Test plan
- [ ] `pancakeswap-v3-plugin --version` prints version string
- [ ] `add-liquidity` without `--confirm` returns `"preview": true` JSON
- [ ] `add-liquidity --confirm` executes on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)