### PR TITLE
fix(pump-fun): v0.1.4 — confirm gate, sell-all balance, SOL units, wallet field

### DIFF
--- a/skills/pump-fun-plugin/.claude-plugin/plugin.json
+++ b/skills/pump-fun-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pump-fun",
   "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/pump-fun-plugin/.claude-plugin/plugin.json
+++ b/skills/pump-fun-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pump-fun",
   "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/pump-fun-plugin/.claude-plugin/plugin.json
+++ b/skills/pump-fun-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pump-fun",
   "description": "Buy and sell tokens on pump.fun bonding curves on Solana mainnet",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"
@@ -9,5 +9,11 @@
   "homepage": "https://github.com/skylavis-sky/onchainos-plugins/tree/main/pump-fun",
   "repository": "https://github.com/skylavis-sky/onchainos-plugins",
   "license": "MIT",
-  "keywords": ["solana", "memecoins", "bonding-curve", "launchpad", "pump-fun"]
+  "keywords": [
+    "solana",
+    "memecoins",
+    "bonding-curve",
+    "launchpad",
+    "pump-fun"
+  ]
 }

--- a/skills/pump-fun-plugin/Cargo.lock
+++ b/skills/pump-fun-plugin/Cargo.lock
@@ -2759,8 +2759,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pump-fun"
-version = "0.1.2"
+name = "pump-fun-plugin"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/pump-fun-plugin/Cargo.toml
+++ b/skills/pump-fun-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pump-fun-plugin"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [[bin]]

--- a/skills/pump-fun-plugin/Cargo.toml
+++ b/skills/pump-fun-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pump-fun-plugin"
-version = "0.1.4"
+version = "0.1.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pump-fun-plugin","version":"0.1.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"pump-fun-plugin","version":"0.1.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -204,6 +204,15 @@ pump-fun get-price --mint <MINT_ADDRESS> --direction sell --amount 5000000
 - `--fee-bps` (optional): Fee basis points for sell calculation (default: 100)
 - `--rpc-url` (optional): Solana RPC URL
 
+**Output fields:**
+- `amount_in` — input amount (lamports for buy; token units for sell)
+- `amount_out` — raw output amount (token atoms for buy; lamports for sell)
+- `amount_out_ui` — human-readable: tokens received (buy) or SOL received (sell)
+- `price_sol_per_token` — raw bonding curve price ratio (lamports / token atom)
+- `market_cap_sol` — current market cap in **SOL** (converted from lamports)
+- `bonding_complete` — `true` if graduated to PumpSwap/Raydium; check `graduated_warning`
+- `graduated_warning` — present when `bonding_complete: true`; directs to onchainos DEX swap
+
 ---
 
 ### buy — Buy tokens on bonding curve
@@ -246,9 +255,62 @@ pump-fun sell --mint <MINT> --confirm
 
 **Parameters:**
 - `--mint` (required): Token mint address (base58)
-- `--token-amount` (optional): Readable token amount to sell (e.g. `1000000`); omit to sell entire balance
+- `--token-amount` (optional): Token amount to sell in readable units, decimals accepted (e.g. `1000000` or `153450.77`); omit to sell entire balance
 - `--slippage-bps` (optional): Slippage tolerance in bps (default: 100)
 - `--confirm` (required to execute): Without this flag, returns preview with no on-chain action
+
+---
+
+## Quickstart
+
+New to pump-fun-plugin? Follow these steps for your first buy and sell.
+
+### Step 1 — Connect your wallet
+
+```bash
+onchainos wallet login your@email.com
+onchainos wallet addresses --chain 501
+onchainos wallet balance --chain 501
+```
+
+You need a Solana wallet with at least 0.01 SOL (covers a small buy plus fees).
+
+### Step 2 — Research a token
+
+```bash
+# Check bonding curve state (reserves, graduation progress, price)
+pump-fun get-token-info --mint <MINT_ADDRESS>
+
+# Estimate tokens you'd receive for 0.005 SOL (5000000 lamports)
+pump-fun get-price --mint <MINT_ADDRESS> --direction buy --amount 5000000
+```
+
+Key fields: `graduation_progress_pct` (0–100%), `amount_out_ui` (tokens you'd receive), `market_cap_sol` (in SOL).
+
+### Step 3 — Preview, then buy
+
+```bash
+# Preview (no --confirm — safe, no tx):
+pump-fun buy --mint <MINT_ADDRESS> --sol-amount 0.005
+
+# Execute after confirming the preview:
+pump-fun buy --mint <MINT_ADDRESS> --sol-amount 0.005 --confirm
+```
+
+Success output includes `wallet` (address that executed), `tx_hash`, and `explorer_url` (Solscan link).
+
+### Step 4 — Sell tokens
+
+```bash
+# Check balance first:
+onchainos wallet balance --chain 501
+
+# Preview sell:
+pump-fun sell --mint <MINT_ADDRESS> --token-amount 153450.77
+
+# Execute sell:
+pump-fun sell --mint <MINT_ADDRESS> --token-amount 153450.77 --confirm
+```
 
 ---
 

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -151,10 +151,18 @@ Solana mainnet (chain 501). Program: `6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6
 
 ## Execution Flow for Write Operations
 
-1. Run with `--dry-run` first to preview the operation
-2. **Ask user to confirm** before executing on-chain
-3. Execute only after explicit user approval
-4. Report transaction hash (Solana signature) and outcome
+**Three execution modes:**
+
+| Mode | How to invoke | What happens |
+|------|--------------|--------------|
+| Preview | No `--confirm`, no `--dry-run` (default) | Returns `"preview":true`, no on-chain action |
+| Dry-run | `--dry-run` (global flag before subcommand) | Returns stub output, no SDK call or transaction |
+| Live | `--confirm` | Executes swap on-chain via onchainos |
+
+1. Run **without any flags** to preview — returns `"preview":true`, no transaction submitted
+2. **Show preview to user and ask for confirmation**
+3. Re-run with `--confirm` to execute on-chain
+4. Report transaction signature (`tx_hash`)
 
 ---
 
@@ -200,44 +208,47 @@ pump-fun get-price --mint <MINT_ADDRESS> --direction sell --amount 5000000
 
 ### buy — Buy tokens on bonding curve
 
-Purchases tokens on a pump.fun bonding curve via `onchainos swap execute`. Works for both bonding curve tokens and graduated tokens. Run `--dry-run` to preview, then **ask user to confirm** before proceeding.
+Purchases tokens on a pump.fun bonding curve via `onchainos swap execute`. Works for both bonding curve tokens and graduated tokens. Run without flags to preview, then **ask user to confirm** before proceeding.
 
 ```bash
-# Preview
-pump-fun buy --mint <MINT> --sol-amount 0.01 --dry-run
+# Preview (no --confirm — safe, returns "preview":true)
+pump-fun buy --mint <MINT> --sol-amount 0.01
 
 # Execute after user confirms
-pump-fun buy --mint <MINT> --sol-amount 0.01 --slippage-bps 200
+pump-fun buy --mint <MINT> --sol-amount 0.01 --confirm
+
+# Dry-run (stub only, fastest preview)
+pump-fun --dry-run buy --mint <MINT> --sol-amount 0.01
 ```
 
 **Parameters:**
 - `--mint` (required): Token mint address (base58)
 - `--sol-amount` (required): SOL amount in readable units (e.g. `0.01` = 0.01 SOL)
 - `--slippage-bps` (optional): Slippage tolerance in bps (default: 100)
-- `--dry-run` (optional): Preview without broadcasting
+- `--confirm` (required to execute): Without this flag, returns preview with no on-chain action
 
 ---
 
 ### sell — Sell tokens back to bonding curve
 
-Sells tokens back to a pump.fun bonding curve (or DEX if graduated) for SOL via `onchainos swap execute`. Run `--dry-run` to preview, then **ask user to confirm** before proceeding.
+Sells tokens back to a pump.fun bonding curve (or DEX if graduated) for SOL via `onchainos swap execute`. Run without flags to preview, then **ask user to confirm** before proceeding.
 
 ```bash
-# Preview
-pump-fun sell --mint <MINT> --token-amount 1000000 --dry-run
-
-# Sell a specific amount after user confirms
+# Preview (no --confirm — safe, returns "preview":true)
 pump-fun sell --mint <MINT> --token-amount 1000000
 
-# Sell ALL tokens after user confirms
-pump-fun sell --mint <MINT>
+# Sell a specific amount after user confirms
+pump-fun sell --mint <MINT> --token-amount 1000000 --confirm
+
+# Sell ALL tokens after user confirms (fetches balance at execution time)
+pump-fun sell --mint <MINT> --confirm
 ```
 
 **Parameters:**
 - `--mint` (required): Token mint address (base58)
 - `--token-amount` (optional): Readable token amount to sell (e.g. `1000000`); omit to sell entire balance
 - `--slippage-bps` (optional): Slippage tolerance in bps (default: 100)
-- `--dry-run` (optional): Preview without broadcasting
+- `--confirm` (required to execute): Without this flag, returns preview with no on-chain action
 
 ---
 

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Interact with pump.fun bonding curves on Solana: buy tokens, sell 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.3"
+  version: "0.1.4"
 ---
 
 
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pump-fun-plugin","version":"0.1.3"}' >/dev/null 2>&1 || true
+    -d '{"name":"pump-fun-plugin","version":"0.1.4"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -200,12 +200,14 @@ pump-fun get-price --mint <MINT_ADDRESS> --direction sell --amount 5000000
 **Parameters:**
 - `--mint` (required): Token mint address (base58)
 - `--direction` (required): `buy` or `sell`
-- `--amount` (required): SOL lamports for buy; token units for sell
+- `--amount` (required): SOL lamports for buy; token atoms (6 decimals) for sell
 - `--fee-bps` (optional): Fee basis points for sell calculation (default: 100)
 - `--rpc-url` (optional): Solana RPC URL
 
+> **Unit note**: `get-price` uses raw units — unlike `buy` (`--sol-amount` in readable SOL) and `sell` (`--token-amount` in readable tokens). For buy: `100000000` = 0.1 SOL. For sell: `1000000` = 1 token (6 decimals). Passing a small sell `--amount` (e.g. `1000000` = 1 token) on a low-price token will produce a near-zero `amount_out_ui` — use at least 1000 tokens (`1000000000`) for a meaningful sell quote.
+
 **Output fields:**
-- `amount_in` — input amount (lamports for buy; token units for sell)
+- `amount_in` — input amount (lamports for buy; token atoms for sell)
 - `amount_out` — raw output amount (token atoms for buy; lamports for sell)
 - `amount_out_ui` — human-readable: tokens received (buy) or SOL received (sell)
 - `price_sol_per_token` — raw bonding curve price ratio (lamports / token atom)

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Interact with pump.fun bonding curves on Solana: buy tokens, sell 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.4"
+  version: "0.1.3"
 ---
 
 

--- a/skills/pump-fun-plugin/SKILL.md
+++ b/skills/pump-fun-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Interact with pump.fun bonding curves on Solana: buy tokens, sell 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.3"
+  version: "0.1.4"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pump-fun-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.3"
+LOCAL_VER="0.1.4"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pump-fun-plugin@0.1.3/pump-fun-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pump-fun-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pump-fun-plugin@0.1.4/pump-fun-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pump-fun-plugin-core${EXT}
 chmod +x ~/.local/bin/.pump-fun-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/pump-fun-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.3" > "$HOME/.plugin-store/managed/pump-fun-plugin"
+echo "0.1.4" > "$HOME/.plugin-store/managed/pump-fun-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pump-fun-plugin","version":"0.1.3"}' >/dev/null 2>&1 || true
+    -d '{"name":"pump-fun-plugin","version":"0.1.4"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pump-fun-plugin/plugin.yaml
+++ b/skills/pump-fun-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pump-fun-plugin
-version: "0.1.3"
+version: "0.1.4"
 description: "Buy and sell tokens on pump.fun bonding curves on Solana mainnet"
 author:
   name: skylavis-sky

--- a/skills/pump-fun-plugin/plugin.yaml
+++ b/skills/pump-fun-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pump-fun-plugin
-version: "0.1.4"
+version: "0.1.3"
 description: "Buy and sell tokens on pump.fun bonding curves on Solana mainnet"
 author:
   name: skylavis-sky

--- a/skills/pump-fun-plugin/src/commands/buy.rs
+++ b/skills/pump-fun-plugin/src/commands/buy.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::config::DEFAULT_SLIPPAGE_BPS;
 use crate::onchainos::{self, SOL_MINT};
+use crate::onchainos::resolve_wallet_solana;
 
 #[derive(Args, Debug)]
 pub struct BuyArgs {
@@ -30,7 +31,11 @@ struct BuyOutput {
     mint: String,
     sol_amount: String,
     slippage_bps: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wallet: Option<String>,
     tx_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explorer_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dry_run: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,6 +46,7 @@ struct BuyOutput {
 
 pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
     if dry_run || !args.confirm {
+        let wallet = resolve_wallet_solana().ok();
         let (is_dry_run, is_preview, note) = if dry_run {
             (Some(true), None, "dry_run=true — no transaction submitted. Pass --confirm to execute.".to_string())
         } else {
@@ -53,7 +59,9 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
                 mint: args.mint.clone(),
                 sol_amount: args.sol_amount.clone(),
                 slippage_bps: args.slippage_bps,
+                wallet,
                 tx_hash: String::new(),
+                explorer_url: None,
                 dry_run: is_dry_run,
                 preview: is_preview,
                 note: Some(note),
@@ -67,6 +75,8 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
             .await?;
 
     let tx_hash = onchainos::extract_tx_hash(&result)?;
+    let wallet = resolve_wallet_solana().ok();
+    let explorer_url = Some(format!("https://solscan.io/tx/{}", tx_hash));
 
     println!(
         "{}",
@@ -75,7 +85,9 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
             mint: args.mint.clone(),
             sol_amount: args.sol_amount.clone(),
             slippage_bps: args.slippage_bps,
+            wallet,
             tx_hash,
+            explorer_url,
             dry_run: None,
             preview: None,
             note: None,

--- a/skills/pump-fun-plugin/src/commands/buy.rs
+++ b/skills/pump-fun-plugin/src/commands/buy.rs
@@ -33,7 +33,8 @@ struct BuyOutput {
     slippage_bps: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     wallet: Option<String>,
-    tx_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     explorer_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,7 +61,7 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
                 sol_amount: args.sol_amount.clone(),
                 slippage_bps: args.slippage_bps,
                 wallet,
-                tx_hash: String::new(),
+                tx_hash: None,
                 explorer_url: None,
                 dry_run: is_dry_run,
                 preview: is_preview,
@@ -86,7 +87,7 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
             sol_amount: args.sol_amount.clone(),
             slippage_bps: args.slippage_bps,
             wallet,
-            tx_hash,
+            tx_hash: Some(tx_hash),
             explorer_url,
             dry_run: None,
             preview: None,

--- a/skills/pump-fun-plugin/src/commands/buy.rs
+++ b/skills/pump-fun-plugin/src/commands/buy.rs
@@ -18,6 +18,10 @@ pub struct BuyArgs {
     /// Slippage tolerance in basis points (default: 100 = 1%)
     #[arg(long, default_value_t = DEFAULT_SLIPPAGE_BPS)]
     pub slippage_bps: u64,
+
+    /// Confirm execution — required to execute on-chain. Without this flag, shows a preview.
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 #[derive(Serialize, Debug)]
@@ -29,10 +33,19 @@ struct BuyOutput {
     tx_hash: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     dry_run: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preview: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
 }
 
 pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
-    if dry_run {
+    if dry_run || !args.confirm {
+        let (is_dry_run, is_preview, note) = if dry_run {
+            (Some(true), None, "dry_run=true — no transaction submitted. Pass --confirm to execute.".to_string())
+        } else {
+            (None, Some(true), "Preview: re-run with --confirm to execute on-chain.".to_string())
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&BuyOutput {
@@ -41,7 +54,9 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
                 sol_amount: args.sol_amount.clone(),
                 slippage_bps: args.slippage_bps,
                 tx_hash: String::new(),
-                dry_run: Some(true),
+                dry_run: is_dry_run,
+                preview: is_preview,
+                note: Some(note),
             })?
         );
         return Ok(());
@@ -62,6 +77,8 @@ pub async fn execute(args: &BuyArgs, dry_run: bool) -> Result<()> {
             slippage_bps: args.slippage_bps,
             tx_hash,
             dry_run: None,
+            preview: None,
+            note: None,
         })?
     );
     Ok(())

--- a/skills/pump-fun-plugin/src/commands/get_price.rs
+++ b/skills/pump-fun-plugin/src/commands/get_price.rs
@@ -43,7 +43,8 @@ struct GetPriceOutput {
     amount_out: u64,
     amount_out_ui: f64,
     price_sol_per_token: f64,
-    market_cap_sol: u64,
+    /// SOL (not lamports). Divide the raw on-chain lamport value by 1e9.
+    market_cap_sol: f64,
     bonding_complete: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     graduated_warning: Option<String>,
@@ -131,7 +132,7 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
         amount_out,
         amount_out_ui,
         price_sol_per_token,
-        market_cap_sol: curve.get_market_cap_sol(),
+        market_cap_sol: curve.get_market_cap_sol() as f64 / 1_000_000_000.0,
         bonding_complete: curve.complete,
         graduated_warning,
     };

--- a/skills/pump-fun-plugin/src/commands/get_price.rs
+++ b/skills/pump-fun-plugin/src/commands/get_price.rs
@@ -98,7 +98,11 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
         0.0
     };
 
-    let (amount_out, amount_out_ui) = if direction == "buy" {
+    let (amount_out, amount_out_ui) = if direction == "buy" && curve.complete {
+        // Graduated token — bonding curve is closed, get_buy_price would error.
+        // Return ok:true with amount_out=0 and a graduated_warning instead.
+        (0u64, 0.0f64)
+    } else if direction == "buy" {
         let tokens = curve
             .get_buy_price(args.amount)
             .map_err(|e| anyhow::anyhow!("get_buy_price failed: {e}"))?;

--- a/skills/pump-fun-plugin/src/commands/get_token_info.rs
+++ b/skills/pump-fun-plugin/src/commands/get_token_info.rs
@@ -29,13 +29,16 @@ struct TokenInfoOutput {
     virtual_token_reserves: u64,
     virtual_sol_reserves: u64,
     real_token_reserves: u64,
-    real_sol_reserves: u64,
+    /// SOL (not lamports). Divide the raw on-chain lamport value by 1e9.
+    real_sol_reserves: f64,
     token_total_supply: u64,
     complete: bool,
     creator: String,
     price_sol_per_token: f64,
-    market_cap_sol: u64,
-    final_market_cap_sol: u64,
+    /// SOL (not lamports). Divide the raw on-chain lamport value by 1e9.
+    market_cap_sol: f64,
+    /// SOL (not lamports). Divide the raw on-chain lamport value by 1e9.
+    final_market_cap_sol: f64,
     graduation_progress_pct: f64,
     status: String,
 }
@@ -129,13 +132,13 @@ pub async fn execute(args: &GetTokenInfoArgs) -> Result<()> {
         virtual_token_reserves: curve.virtual_token_reserves,
         virtual_sol_reserves: curve.virtual_sol_reserves,
         real_token_reserves: curve.real_token_reserves,
-        real_sol_reserves: curve.real_sol_reserves,
+        real_sol_reserves: curve.real_sol_reserves as f64 / 1_000_000_000.0,
         token_total_supply: curve.token_total_supply,
         complete: curve.complete,
         creator: curve.creator.to_string(),
         price_sol_per_token,
-        market_cap_sol: curve.get_market_cap_sol(),
-        final_market_cap_sol,
+        market_cap_sol: curve.get_market_cap_sol() as f64 / 1_000_000_000.0,
+        final_market_cap_sol: final_market_cap_sol as f64 / 1_000_000_000.0,
         graduation_progress_pct: graduation_progress_pct.min(100.0),
         status,
     };

--- a/skills/pump-fun-plugin/src/commands/sell.rs
+++ b/skills/pump-fun-plugin/src/commands/sell.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::config::DEFAULT_SLIPPAGE_BPS;
 use crate::onchainos::{self, SOL_MINT};
+use crate::onchainos::resolve_wallet_solana;
 
 #[derive(Args, Debug)]
 pub struct SellArgs {
@@ -30,7 +31,11 @@ struct SellOutput {
     mint: String,
     token_amount: String,
     slippage_bps: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wallet: Option<String>,
     tx_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explorer_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dry_run: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,6 +64,7 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
     };
 
     if dry_run || !args.confirm {
+        let wallet = resolve_wallet_solana().ok();
         let (is_dry_run, is_preview, note) = if dry_run {
             (Some(true), None, "dry_run=true — no transaction submitted. Pass --confirm to execute.".to_string())
         } else {
@@ -71,7 +77,9 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
                 mint: args.mint.clone(),
                 token_amount: amount,
                 slippage_bps: args.slippage_bps,
+                wallet,
                 tx_hash: String::new(),
+                explorer_url: None,
                 dry_run: is_dry_run,
                 preview: is_preview,
                 note: Some(note),
@@ -84,6 +92,8 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
         onchainos::swap_execute_solana(&args.mint, SOL_MINT, &amount, args.slippage_bps).await?;
 
     let tx_hash = onchainos::extract_tx_hash(&result)?;
+    let wallet = resolve_wallet_solana().ok();
+    let explorer_url = Some(format!("https://solscan.io/tx/{}", tx_hash));
 
     println!(
         "{}",
@@ -92,7 +102,9 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
             mint: args.mint.clone(),
             token_amount: amount,
             slippage_bps: args.slippage_bps,
+            wallet,
             tx_hash,
+            explorer_url,
             dry_run: None,
             preview: None,
             note: None,

--- a/skills/pump-fun-plugin/src/commands/sell.rs
+++ b/skills/pump-fun-plugin/src/commands/sell.rs
@@ -33,7 +33,8 @@ struct SellOutput {
     slippage_bps: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     wallet: Option<String>,
-    tx_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     explorer_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +79,7 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
                 token_amount: amount,
                 slippage_bps: args.slippage_bps,
                 wallet,
-                tx_hash: String::new(),
+                tx_hash: None,
                 explorer_url: None,
                 dry_run: is_dry_run,
                 preview: is_preview,
@@ -103,7 +104,7 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
             token_amount: amount,
             slippage_bps: args.slippage_bps,
             wallet,
-            tx_hash,
+            tx_hash: Some(tx_hash),
             explorer_url,
             dry_run: None,
             preview: None,

--- a/skills/pump-fun-plugin/src/commands/sell.rs
+++ b/skills/pump-fun-plugin/src/commands/sell.rs
@@ -18,6 +18,10 @@ pub struct SellArgs {
     /// Slippage tolerance in basis points (default: 100 = 1%)
     #[arg(long, default_value_t = DEFAULT_SLIPPAGE_BPS)]
     pub slippage_bps: u64,
+
+    /// Confirm execution — required to execute on-chain. Without this flag, shows a preview.
+    #[arg(long)]
+    pub confirm: bool,
 }
 
 #[derive(Serialize, Debug)]
@@ -29,14 +33,18 @@ struct SellOutput {
     tx_hash: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     dry_run: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preview: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
 }
 
 pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
-    // Resolve amount: explicit or full balance
+    // Resolve amount: explicit or placeholder/balance
     let amount = match &args.token_amount {
         Some(a) => a.clone(),
         None => {
-            if dry_run {
+            if dry_run || !args.confirm {
                 "<full balance>".to_string()
             } else {
                 onchainos::get_token_balance(&args.mint)?
@@ -45,7 +53,12 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
         }
     };
 
-    if dry_run {
+    if dry_run || !args.confirm {
+        let (is_dry_run, is_preview, note) = if dry_run {
+            (Some(true), None, "dry_run=true — no transaction submitted. Pass --confirm to execute.".to_string())
+        } else {
+            (None, Some(true), "Preview: re-run with --confirm to execute on-chain.".to_string())
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&SellOutput {
@@ -54,7 +67,9 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
                 token_amount: amount,
                 slippage_bps: args.slippage_bps,
                 tx_hash: String::new(),
-                dry_run: Some(true),
+                dry_run: is_dry_run,
+                preview: is_preview,
+                note: Some(note),
             })?
         );
         return Ok(());
@@ -74,6 +89,8 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
             slippage_bps: args.slippage_bps,
             tx_hash,
             dry_run: None,
+            preview: None,
+            note: None,
         })?
     );
     Ok(())

--- a/skills/pump-fun-plugin/src/commands/sell.rs
+++ b/skills/pump-fun-plugin/src/commands/sell.rs
@@ -48,7 +48,12 @@ pub async fn execute(args: &SellArgs, dry_run: bool) -> Result<()> {
                 "<full balance>".to_string()
             } else {
                 onchainos::get_token_balance(&args.mint)?
-                    .ok_or_else(|| anyhow::anyhow!("No balance found for mint {}", args.mint))?
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "No balance found for mint {} in your Solana wallet. \
+                         Ensure the token is held in the active wallet, or specify \
+                         the amount explicitly with --token-amount <amount>.",
+                        args.mint
+                    ))?
             }
         }
     };

--- a/skills/pump-fun-plugin/src/onchainos.rs
+++ b/skills/pump-fun-plugin/src/onchainos.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 pub const SOL_MINT: &str = "11111111111111111111111111111111";
 
 /// Resolve the current Solana wallet address (base58) via onchainos.
-fn resolve_wallet_solana() -> anyhow::Result<String> {
+pub fn resolve_wallet_solana() -> anyhow::Result<String> {
     let output = Command::new("onchainos")
         .args(["wallet", "addresses", "--chain", "501"])
         .output()?;
@@ -87,9 +87,11 @@ pub fn get_token_balance(mint: &str) -> anyhow::Result<Option<String>> {
     for detail in details {
         if let Some(assets) = detail["tokenAssets"].as_array() {
             for asset in assets {
-                // onchainos returns "address" for the token mint on Solana (not "tokenAddress")
-                let addr = asset["address"].as_str()
-                    .or_else(|| asset["tokenAddress"].as_str())
+                // onchainos wallet balance --chain 501 structure:
+                //   asset["address"]      = wallet address (always present — do NOT use for mint matching)
+                //   asset["tokenAddress"] = token mint address (correct field to match against)
+                //   asset["mint"]         = fallback for alternative response shapes
+                let addr = asset["tokenAddress"].as_str()
                     .or_else(|| asset["mint"].as_str())
                     .unwrap_or("");
                 if addr.eq_ignore_ascii_case(mint) {

--- a/skills/pump-fun-plugin/src/onchainos.rs
+++ b/skills/pump-fun-plugin/src/onchainos.rs
@@ -87,7 +87,7 @@ pub fn get_token_balance(mint: &str) -> anyhow::Result<Option<String>> {
     for detail in details {
         if let Some(assets) = detail["tokenAssets"].as_array() {
             for asset in assets {
-                let addr = asset["tokenContractAddress"].as_str().unwrap_or("");
+                let addr = asset["tokenAddress"].as_str().unwrap_or("");
                 if addr.eq_ignore_ascii_case(mint) {
                     if let Some(bal) = asset["balance"].as_str()
                         .or_else(|| asset["readableBalance"].as_str())

--- a/skills/pump-fun-plugin/src/onchainos.rs
+++ b/skills/pump-fun-plugin/src/onchainos.rs
@@ -87,12 +87,22 @@ pub fn get_token_balance(mint: &str) -> anyhow::Result<Option<String>> {
     for detail in details {
         if let Some(assets) = detail["tokenAssets"].as_array() {
             for asset in assets {
-                let addr = asset["tokenAddress"].as_str().unwrap_or("");
+                // onchainos returns "address" for the token mint on Solana (not "tokenAddress")
+                let addr = asset["address"].as_str()
+                    .or_else(|| asset["tokenAddress"].as_str())
+                    .or_else(|| asset["mint"].as_str())
+                    .unwrap_or("");
                 if addr.eq_ignore_ascii_case(mint) {
                     if let Some(bal) = asset["balance"].as_str()
                         .or_else(|| asset["readableBalance"].as_str())
+                        .or_else(|| asset["uiAmount"].as_str())
                     {
                         return Ok(Some(bal.to_string()));
+                    }
+                    if let Some(n) = asset["balance"].as_f64()
+                        .or_else(|| asset["uiAmount"].as_f64())
+                    {
+                        return Ok(Some(n.to_string()));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Six fixes across read and write commands, discovered during post-release testing:

### 1. Critical: sell-all balance lookup broken on Solana

**Bug**: `pump-fun sell --mint <MINT>` (omitting `--token-amount`) returned `{"error":"No balance found for mint ..."}` for every token.

**Root cause**: `get_token_balance()` matched on `asset["tokenContractAddress"]` — an EVM field absent from Solana responses. `onchainos wallet balance --chain 501` returns the mint under `asset["tokenAddress"]`.

**Fix**: Changed lookup to `asset["tokenAddress"]` first, `asset["mint"]` as fallback. `address` (wallet address field, always present) is no longer used for mint matching.

### 2. Major: `--confirm` gate on buy/sell (3 execution modes)

**Bug**: All write commands executed immediately with no confirmation step.

**Fix**: Added `--confirm` flag. Without it, commands return `"preview":true` with no on-chain action. `--dry-run` (global flag) provides a stub-only fast path.

| Mode | How to invoke | What happens |
|------|--------------|--------------|
| Preview | No flags (default) | Returns `"preview":true`, no transaction |
| Dry-run | `--dry-run` global flag | Returns stub output, no SDK call |
| Live | `--confirm` | Executes swap on-chain via onchainos |

### 3. Major: `market_cap_sol`, `real_sol_reserves`, `final_market_cap_sol` output raw lamports

**Bug**: `get-token-info` and `get-price` returned SOL-denominated fields as raw lamports (e.g. `51475043617` instead of `51.47`). Values were ~1e9× too large.

**Fix**: Changed struct fields from `u64` to `f64`, divided by `1_000_000_000.0` on assignment.

### 4. Major: `wallet` field absent from buy/sell output

**Bug**: Preview, dry-run, and confirmed buy/sell output omitted the `wallet` field despite SKILL.md Quickstart documenting it.

**Fix**: Added `resolve_wallet_solana()` call in all three output paths. Field uses `skip_serializing_if = "Option::is_none"` so it's omitted only when the wallet can't be resolved.

### 5. Minor: get-price `--direction buy` crashes on graduated tokens

**Bug**: `pump-fun get-price --mint <GRADUATED> --direction buy --amount 100000000` returned `{"error":"get_buy_price failed: Curve is complete"}`. The sell direction already handled `curve.complete` gracefully.

**Fix**: Added `curve.complete` guard before `get_buy_price` call. Buy direction on graduated tokens now returns `ok: true`, `amount_out: 0`, and `graduated_warning` — consistent with the sell path.

### 6. Minor: `tx_hash` serialized as `""` in preview/dry-run output

**Bug**: Preview and dry-run output included `"tx_hash": ""` — an empty string that consumers could mistake for a valid transaction signature.

**Fix**: Changed `tx_hash` field to `Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`. Field is now entirely absent from preview/dry-run output and populated only on confirmed execution.

---

## SKILL.md Changes

- Execution flow table (Preview / Dry-run / Live modes)
- buy/sell execute examples updated with `--confirm` flag
- `get-price` output fields documented (`amount_out_ui`, `market_cap_sol`, `bonding_complete`, `graduated_warning`)
- `--token-amount` description: clarified decimals are accepted (`1000000` or `153450.77`)
- Quickstart section: 4-step guide from wallet connect through buy and sell
- Version strings consistent: `0.1.4` in frontmatter, download URL, LOCAL_VER, and telemetry curl body

## Files Changed

| File | Change |
|------|--------|
| `src/onchainos.rs` | `get_token_balance`: `tokenAddress` lookup (fixes sell-all C1) |
| `src/commands/buy.rs` | `--confirm` gate; `wallet` + `explorer_url` fields; `tx_hash: Option<String>` |
| `src/commands/sell.rs` | Same |
| `src/commands/get_token_info.rs` | `market_cap_sol`, `real_sol_reserves`, `final_market_cap_sol` ÷ 1e9 |
| `src/commands/get_price.rs` | `market_cap_sol` ÷ 1e9; buy direction `curve.complete` guard (N1) |
| `Cargo.toml` | Version `0.1.4` |
| `Cargo.lock` | Version `0.1.4` |
| `plugin.yaml` | Version `0.1.4` |
| `.claude-plugin/plugin.json` | Version `0.1.4` |
| `SKILL.md` | Execution flow; buy/sell examples; get-price docs; Quickstart |

## Live Verification

The critical sell-all fix (C1) was verified end-to-end with a live `--confirm` transaction on Solana mainnet:

```bash
pump-fun sell --mint Gm1LznJrxfKpAJ6Mt6DxuwSNZdkaXJxtL1dAVRUZpump --confirm
```

```json
{
  "ok": true,
  "mint": "Gm1LznJrxfKpAJ6Mt6DxuwSNZdkaXJxtL1dAVRUZpump",
  "token_amount": "342529.60037",
  "slippage_bps": 100,
  "wallet": "6hY15MNMZtjF15sPtuSozxjrrZPyrDmqBaC48496T8UY",
  "tx_hash": "3RaCfVWt1iVA2YBjRGNvPmGT5NFVomELnrGPJcNzy7jKbZ31BMi3cMyaev7Evuyu658A569Udv8JFLxymRJeUkpm",
  "explorer_url": "https://solscan.io/tx/3RaCfVWt1iVA2YBjRGNvPmGT5NFVomELnrGPJcNzy7jKbZ31BMi3cMyaev7Evuyu658A569Udv8JFLxymRJeUkpm"
}
```

Verifies simultaneously: C1 (balance resolved to `342529.60037`, not "No balance found"), fix 4 (`wallet` field present in execution output), fix 6 (`tx_hash` only present on confirmed execution), and `explorer_url` populated.

## Checklist

- [x] Source code included (local build)
- [x] Version consistent: `0.1.4` across Cargo.toml, plugin.yaml, .claude-plugin/plugin.json, SKILL.md
- [x] SKILL.md prose accurate — matches current implementation
- [x] Only `skills/pump-fun-plugin/` files in diff
- [x] All on-chain writes via onchainos swap execute
- [x] plugin.yaml api_calls match source code
- [x] .claude-plugin/plugin.json present
- [x] Live end-to-end verification on Solana mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)