### PR TITLE
fix(raydium): v0.2.1 — confirm gate, decimal fix, native SOL, API error exits

### DIFF
--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.7"
+  "version": "0.1.8"
 }

--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.9"
+  "version": "0.2.0"
 }

--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.8"
+  "version": "0.1.9"
 }

--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.7"
+  version: "0.1.8"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.7"
+LOCAL_VER="0.1.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.7/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.8/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/raydium-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.7" > "$HOME/.plugin-store/managed/raydium-plugin"
+echo "0.1.8" > "$HOME/.plugin-store/managed/raydium-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.1.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.1.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -170,7 +170,7 @@ Returns expected output amount, price impact, and route plan. No on-chain action
 Pass `--amount` in human-readable token units (e.g. `0.1` for 0.1 SOL, `1.5` for 1.5 USDC).
 
 ```bash
-raydium get-swap-quote \
+raydium-plugin get-swap-quote \
   --input-mint So11111111111111111111111111111111111111112 \
   --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --amount 0.1 \
@@ -182,7 +182,7 @@ raydium get-swap-quote \
 Computes the price ratio between two tokens using the swap quote endpoint.
 
 ```bash
-raydium get-price \
+raydium-plugin get-price \
   --input-mint So11111111111111111111111111111111111111112 \
   --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --amount 1
@@ -193,7 +193,7 @@ raydium get-price \
 Returns the USD price for one or more token mint addresses.
 
 ```bash
-raydium get-token-price \
+raydium-plugin get-token-price \
   --mints So11111111111111111111111111111111111111112,EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
 ```
 
@@ -203,14 +203,14 @@ Query pool info by pool IDs or by token mint addresses.
 
 ```bash
 # By mint addresses
-raydium get-pools \
+raydium-plugin get-pools \
   --mint1 So11111111111111111111111111111111111111112 \
   --mint2 EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --pool-type all \
   --sort-field liquidity
 
 # By pool ID
-raydium get-pools --ids 58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2
+raydium-plugin get-pools --ids 58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2
 ```
 
 ### get-pool-list — List pools with pagination
@@ -218,7 +218,7 @@ raydium get-pools --ids 58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2
 Paginated list of all Raydium pools.
 
 ```bash
-raydium get-pool-list \
+raydium-plugin get-pool-list \
   --pool-type all \
   --sort-field liquidity \
   --sort-type desc \
@@ -231,25 +231,26 @@ raydium get-pool-list \
 **Ask user to confirm** before executing. This is an on-chain write operation.
 
 Execution flow:
-1. Run with `--dry-run` first to preview (no on-chain action)
+1. Run without `--confirm` first to preview quote (no on-chain action)
 2. **Ask user to confirm** the swap details, price impact, and fees
-3. Execute only after explicit user approval — pre-flight balance check runs automatically before swap
+3. Execute with `--confirm` only after explicit user approval — pre-flight balance check runs automatically before swap
 4. Reports transaction hash(es) on completion
 
 ```bash
-# Preview (dry run) -- swap 0.1 SOL for USDC
-raydium --dry-run swap \
+# Preview -- swap 0.1 SOL for USDC (no --confirm = preview only)
+raydium-plugin swap \
   --input-mint So11111111111111111111111111111111111111112 \
   --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --amount 0.1 \
   --slippage-bps 50
 
 # Execute (after user confirmation)
-raydium swap \
+raydium-plugin swap \
   --input-mint So11111111111111111111111111111111111111112 \
   --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --amount 0.1 \
-  --slippage-bps 50
+  --slippage-bps 50 \
+  --confirm
 ```
 
 **Output fields:** `ok`, `inputMint`, `outputMint`, `amount`, `amountDisplay` (2 decimal places), `rawAmount`, `outputAmount`, `priceImpactPct`, `transactions` (array of `txHash`)
@@ -271,7 +272,8 @@ raydium swap \
 ## Notes
 
 - Solana blockhash expires in ~60 seconds. The swap command builds and broadcasts the transaction immediately — do NOT add delays between getting the quote and submitting.
-- The `--dry-run` flag skips all on-chain operations and returns a simulated response.
+- The global `--dry-run` flag skips all on-chain operations and returns a simulated response. For `swap`, omitting `--confirm` shows a preview with the quote but does not broadcast.
+- The `swap` command requires `--confirm` to execute on-chain. Without it, a quote preview is shown and the command exits safely.
 - Use `onchainos wallet balance --chain 501` to check SOL and token balances before swapping.
 - `--amount` accepts human-readable decimal values: `0.1` for 0.1 SOL, `1.5` for 1.5 USDC. The plugin resolves token decimals automatically (SOL=9, USDC=6; other SPL tokens fetched from Raydium mint API).
 

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.9"
+  version: "0.2.0"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.9"
+LOCAL_VER="0.2.0"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.9/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.2.0/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/raydium-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.9" > "$HOME/.plugin-store/managed/raydium-plugin"
+echo "0.2.0" > "$HOME/.plugin-store/managed/raydium-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.1.9"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.2.0"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.8"
+  version: "0.1.9"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.8"
+LOCAL_VER="0.1.9"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.8/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.9/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/raydium-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.8" > "$HOME/.plugin-store/managed/raydium-plugin"
+echo "0.1.9" > "$HOME/.plugin-store/managed/raydium-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.1.8"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.1.9"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -158,10 +158,12 @@ Resolves your Solana wallet, checks SOL balance, and emits JSON with onboarding 
 raydium-plugin quickstart
 ```
 
-Output fields: `ok`, `about`, `wallet`, `chain`, `assets.sol_balance`, `status` (`ready` | `no_funds`), `suggestion`, `next_command`, `onboarding_steps`.
+Output fields: `ok`, `about`, `wallet`, `chain`, `assets.sol_balance`, `assets.usdc_balance`, `status` (`ready` | `ready_sol_only` | `needs_gas` | `no_funds`), `suggestion`, `next_command`, `onboarding_steps`.
 
-- `status: "ready"` — wallet has ≥ 0.01 SOL; steps guide you to get a quote and swap
-- `status: "no_funds"` — wallet has < 0.01 SOL; steps guide you to fund the wallet
+- `status: "ready"` — wallet has ≥ 1 USDC and ≥ 0.01 SOL; steps guide you to swap USDC → SOL or other tokens
+- `status: "ready_sol_only"` — wallet has SOL but < 1 USDC; steps guide you to swap SOL → USDC
+- `status: "needs_gas"` — wallet has ≥ 1 USDC but < 0.01 SOL; steps guide you to fund SOL for gas
+- `status: "no_funds"` — wallet has neither SOL nor USDC; steps guide you to fund the wallet
 
 ### get-swap-quote — Get swap quote
 

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -140,6 +140,103 @@ fi
 
 > ⚠️ **--force note**: The `swap` command uses `onchainos wallet contract-call --force` for Solana `--unsigned-tx` submissions. This is required because Solana blockhashes expire in ~60 seconds — a two-step confirm/retry flow would risk expiry between steps. The agent MUST always confirm with the user before calling `swap` (not after). Do not call `swap` without explicit user confirmation.
 
+---
+
+## Proactive Onboarding
+
+When a user signals they are **new or just installed** this plugin — e.g. "I just installed raydium", "how do I get started with raydium", "what can I do with this", "help me swap on Solana", "I'm new to raydium" — **do not wait for them to ask specific questions.** Proactively run the quickstart check and walk them through setup in order, one step at a time, waiting for confirmation before proceeding to the next:
+
+1. **Check wallet** — run `raydium-plugin quickstart`. This resolves your Solana wallet, checks SOL and USDC balances, and returns a `status` field indicating your readiness:
+   - `no_funds` → guide user to fund wallet with SOL (minimum ~0.01 SOL for gas)
+   - `needs_gas` → guide user to top up SOL; they have USDC but need SOL for gas
+   - `ready_sol_only` → wallet has SOL; suggest swapping SOL → USDC or another token
+   - `ready` → wallet is funded; proceed to swap
+2. **Find a token to swap** — ask what tokens the user wants to trade. Help them find mint addresses using `raydium-plugin get-token-price --symbol <TOKEN>` or `raydium-plugin get-price --input-mint <MINT> --output-mint <MINT>`.
+3. **Get a quote first** — always run `raydium-plugin get-swap-quote` (or `swap` without `--confirm`) before executing. Show the user the `outputAmount`, `priceImpactPct`, and fees. Ask for explicit confirmation before proceeding.
+4. **Execute the swap** — only after the user confirms the quote details, re-run the `swap` command with `--confirm`.
+
+Do not dump all steps at once. Guide conversationally — confirm each step before moving on. Never call `swap --confirm` without the user explicitly approving the quoted output amount and price impact.
+
+---
+
+## Quickstart
+
+New to Raydium on Solana? Follow these steps to go from zero to placing your first swap.
+
+### Step 1 — Connect your Solana wallet
+
+Raydium swaps are signed by an onchainos agentic wallet on Solana (chain 501). Log in with your email (OTP) or API key:
+
+```bash
+# Email-based login (sends OTP to your inbox)
+onchainos wallet login your@email.com
+```
+
+Once connected, verify a Solana address is active:
+
+```bash
+onchainos wallet addresses --chain 501
+```
+
+Your wallet address is your Raydium identity — all swaps are built and signed from it.
+
+### Step 2 — Check your readiness
+
+Run the built-in quickstart check to see your wallet status and get guided next steps:
+
+```bash
+raydium-plugin quickstart
+```
+
+This returns your SOL and USDC balances plus a `status` field:
+- `ready` — you have both SOL gas and USDC; you can swap immediately
+- `ready_sol_only` — you have SOL but no USDC; swap SOL → USDC first
+- `needs_gas` — you have USDC but need SOL for gas; top up ~0.01 SOL
+- `no_funds` — wallet is empty; fund it via OKX Web3 or a CEX withdrawal to Solana
+
+**Minimum required**: ~0.01 SOL for gas fees per swap transaction.
+
+### Step 3 — Get a swap quote
+
+Before executing any swap, preview the quote:
+
+```bash
+# Quote: swap 0.1 SOL → USDC (no --confirm = preview only, no on-chain action)
+raydium-plugin swap \
+  --input-mint So11111111111111111111111111111111111111112 \
+  --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+  --amount 0.1 \
+  --slippage-bps 50
+```
+
+Review the output:
+- `outputAmount` — how many tokens you'll receive
+- `priceImpactPct` — market impact (warn at ≥ 5%, abort at ≥ 20%)
+- No on-chain transaction is submitted without `--confirm`
+
+### Step 4 — Execute the swap
+
+After reviewing the quote and confirming with the user, add `--confirm` to execute:
+
+```bash
+raydium-plugin swap \
+  --input-mint So11111111111111111111111111111111111111112 \
+  --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
+  --amount 0.1 \
+  --slippage-bps 50 \
+  --confirm
+```
+
+The command will check your balance, build the transaction, and broadcast it. You'll receive `transactions[].txHash` on success.
+
+**Common mint addresses for Solana mainnet:**
+- SOL (native/wrapped): `So11111111111111111111111111111111111111112`
+- USDC: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- USDT: `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`
+- RAY: `4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R`
+
+---
+
 ## Architecture
 
 - Read ops (`get-swap-quote`, `get-price`, `get-token-price`, `get-pools`, `get-pool-list`) → direct REST API calls to Raydium endpoints; no wallet or confirmation needed

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.2.0"
+  version: "0.2.1"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.0"
+LOCAL_VER="0.2.1"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.2.0/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.2.1/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.2.0"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.2.1"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.6"
+  version: "0.1.7"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.5"
+LOCAL_VER="0.1.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.5/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.7/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/raydium-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.5" > "$HOME/.plugin-store/managed/raydium-plugin"
+echo "0.1.7" > "$HOME/.plugin-store/managed/raydium-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.1.5"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.1.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -149,6 +149,19 @@ fi
 - APIs: `https://api-v3.raydium.io` (data) and `https://transaction-v1.raydium.io` (tx building)
 
 ## Commands
+
+### quickstart — Check wallet and get guided next steps
+
+Resolves your Solana wallet, checks SOL balance, and emits JSON with onboarding steps tailored to your current state. No on-chain action.
+
+```bash
+raydium-plugin quickstart
+```
+
+Output fields: `ok`, `about`, `wallet`, `chain`, `assets.sol_balance`, `status` (`ready` | `no_funds`), `suggestion`, `next_command`, `onboarding_steps`.
+
+- `status: "ready"` — wallet has ≥ 0.01 SOL; steps guide you to get a quote and swap
+- `status: "no_funds"` — wallet has < 0.01 SOL; steps guide you to fund the wallet
 
 ### get-swap-quote — Get swap quote
 

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.9"
+version: "0.2.0"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.8"
+version: "0.1.9"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.7"
+version: "0.1.8"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.2.0"
+version: "0.2.1"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.6"
+version: "0.1.7"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/src/commands/get_price.rs
+++ b/skills/raydium-plugin/src/commands/get_price.rs
@@ -5,8 +5,8 @@ use clap::Args;
 use serde_json::Value;
 
 use crate::config::{
-    parse_human_amount, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION, SOL_NATIVE_MINT, USDC_SOLANA,
-    TX_API_BASE,
+    parse_human_amount, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION, SOL_NATIVE_MINT,
+    SOL_SYSTEM_PROGRAM, USDC_SOLANA, TX_API_BASE,
 };
 
 #[derive(Args, Debug)]
@@ -34,7 +34,7 @@ pub struct GetPriceArgs {
 
 /// Resolve decimals for well-known Solana mints, falling back to Raydium mint API.
 async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Result<u8> {
-    if mint == SOL_NATIVE_MINT {
+    if mint == SOL_NATIVE_MINT || mint == SOL_SYSTEM_PROGRAM {
         return Ok(9);
     }
     if mint == USDC_SOLANA {
@@ -57,15 +57,28 @@ async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Resul
 pub async fn execute(args: &GetPriceArgs) -> Result<()> {
     let client = reqwest::Client::new();
 
-    let input_decimals = resolve_decimals(&args.input_mint, &client).await?;
+    // Rewrite native SOL system program address to WSOL — Raydium routes use WSOL
+    let input_mint = if args.input_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.input_mint.clone()
+    };
+    let output_mint = if args.output_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.output_mint.clone()
+    };
+
+    let input_decimals = resolve_decimals(&input_mint, &client).await?;
+    let output_decimals = resolve_decimals(&output_mint, &client).await?;
     let raw_amount = parse_human_amount(&args.amount, input_decimals)?;
 
     let url = format!("{}/compute/swap-base-in", TX_API_BASE);
     let resp: Value = client
         .get(&url)
         .query(&[
-            ("inputMint", args.input_mint.as_str()),
-            ("outputMint", args.output_mint.as_str()),
+            ("inputMint", input_mint.as_str()),
+            ("outputMint", output_mint.as_str()),
             ("amount", &raw_amount.to_string()),
             ("slippageBps", &args.slippage_bps.to_string()),
             ("txVersion", args.tx_version.as_str()),
@@ -75,29 +88,34 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
         .json()
         .await?;
 
-    // Compute price ratio from quote data
+    // Compute price ratio from quote data, normalizing raw amounts by token decimals
     let price_info = if let Some(data) = resp.get("data") {
-        let input_amount: f64 = data["inputAmount"]
+        let raw_input: f64 = data["inputAmount"]
             .as_str()
             .and_then(|s| s.parse().ok())
             .unwrap_or(raw_amount as f64);
-        let output_amount: f64 = data["outputAmount"]
+        let raw_output: f64 = data["outputAmount"]
             .as_str()
             .and_then(|s| s.parse().ok())
             .unwrap_or(0.0);
         let price_impact_pct = data["priceImpactPct"].as_f64().unwrap_or(0.0);
-        let price = if input_amount > 0.0 {
-            output_amount / input_amount
+
+        // Convert raw amounts to human-readable by dividing by 10^decimals
+        let input_human = raw_input / 10f64.powi(input_decimals as i32);
+        let output_human = raw_output / 10f64.powi(output_decimals as i32);
+
+        let price = if input_human > 0.0 {
+            output_human / input_human
         } else {
             0.0
         };
         serde_json::json!({
-            "inputMint": args.input_mint,
-            "outputMint": args.output_mint,
+            "inputMint": input_mint,
+            "outputMint": output_mint,
             "price": price,
             "priceImpactPct": price_impact_pct,
-            "inputAmount": input_amount,
-            "outputAmount": output_amount,
+            "inputAmount": input_human,
+            "outputAmount": output_human,
             "quote": data,
         })
     } else {

--- a/skills/raydium-plugin/src/commands/get_price.rs
+++ b/skills/raydium-plugin/src/commands/get_price.rs
@@ -88,6 +88,20 @@ pub async fn execute(args: &GetPriceArgs) -> Result<()> {
         .json()
         .await?;
 
+    // Surface API errors as structured JSON with exit 1
+    if resp.get("success").and_then(|v| v.as_bool()) == Some(false) {
+        let msg = resp["msg"].as_str().unwrap_or("Raydium API error");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": msg,
+                "raw": resp
+            }))?
+        );
+        std::process::exit(1);
+    }
+
     // Compute price ratio from quote data, normalizing raw amounts by token decimals
     let price_info = if let Some(data) = resp.get("data") {
         let raw_input: f64 = data["inputAmount"]

--- a/skills/raydium-plugin/src/commands/get_swap_quote.rs
+++ b/skills/raydium-plugin/src/commands/get_swap_quote.rs
@@ -3,8 +3,8 @@ use clap::Args;
 use serde_json::Value;
 
 use crate::config::{
-    parse_human_amount, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION, SOL_NATIVE_MINT, USDC_SOLANA,
-    TX_API_BASE,
+    parse_human_amount, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION, SOL_NATIVE_MINT,
+    SOL_SYSTEM_PROGRAM, USDC_SOLANA, TX_API_BASE,
 };
 
 #[derive(Args, Debug)]
@@ -32,7 +32,7 @@ pub struct GetSwapQuoteArgs {
 
 /// Resolve decimals for well-known Solana mints, falling back to Raydium mint API.
 async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Result<u8> {
-    if mint == SOL_NATIVE_MINT {
+    if mint == SOL_NATIVE_MINT || mint == SOL_SYSTEM_PROGRAM {
         return Ok(9);
     }
     if mint == USDC_SOLANA {
@@ -53,20 +53,32 @@ async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Resul
 }
 
 pub async fn execute(args: &GetSwapQuoteArgs) -> Result<()> {
-    crate::config::validate_solana_address(&args.input_mint)?;
-    crate::config::validate_solana_address(&args.output_mint)?;
+    // Rewrite native SOL system program address to WSOL — Raydium routes use WSOL
+    let input_mint = if args.input_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.input_mint.clone()
+    };
+    let output_mint = if args.output_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.output_mint.clone()
+    };
+
+    crate::config::validate_solana_address(&input_mint)?;
+    crate::config::validate_solana_address(&output_mint)?;
 
     let client = reqwest::Client::new();
 
-    let input_decimals = resolve_decimals(&args.input_mint, &client).await?;
+    let input_decimals = resolve_decimals(&input_mint, &client).await?;
     let raw_amount = parse_human_amount(&args.amount, input_decimals)?;
 
     let url = format!("{}/compute/swap-base-in", TX_API_BASE);
     let resp: Value = client
         .get(&url)
         .query(&[
-            ("inputMint", args.input_mint.as_str()),
-            ("outputMint", args.output_mint.as_str()),
+            ("inputMint", input_mint.as_str()),
+            ("outputMint", output_mint.as_str()),
             ("amount", &raw_amount.to_string()),
             ("slippageBps", &args.slippage_bps.to_string()),
             ("txVersion", args.tx_version.as_str()),

--- a/skills/raydium-plugin/src/commands/get_swap_quote.rs
+++ b/skills/raydium-plugin/src/commands/get_swap_quote.rs
@@ -88,6 +88,20 @@ pub async fn execute(args: &GetSwapQuoteArgs) -> Result<()> {
         .json()
         .await?;
 
+    // Surface API errors as structured JSON with exit 1
+    if resp.get("success").and_then(|v| v.as_bool()) == Some(false) {
+        let msg = resp["msg"].as_str().unwrap_or("Raydium API error");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": msg,
+                "raw": resp
+            }))?
+        );
+        std::process::exit(1);
+    }
+
     println!("{}", serde_json::to_string_pretty(&resp)?);
     Ok(())
 }

--- a/skills/raydium-plugin/src/commands/get_token_price.rs
+++ b/skills/raydium-plugin/src/commands/get_token_price.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Args;
 use serde_json::Value;
 
-use crate::config::DATA_API_BASE;
+use crate::config::{DATA_API_BASE, SOL_NATIVE_MINT, SOL_SYSTEM_PROGRAM};
 
 #[derive(Args, Debug)]
 pub struct GetTokenPriceArgs {
@@ -14,9 +14,21 @@ pub struct GetTokenPriceArgs {
 pub async fn execute(args: &GetTokenPriceArgs) -> Result<()> {
     let client = reqwest::Client::new();
     let url = format!("{}/mint/price", DATA_API_BASE);
+
+    // Rewrite native SOL system program address to WSOL in the mints list
+    let mints: String = args
+        .mints
+        .split(',')
+        .map(|m| {
+            let m = m.trim();
+            if m == SOL_SYSTEM_PROGRAM { SOL_NATIVE_MINT } else { m }
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+
     let resp: Value = client
         .get(&url)
-        .query(&[("mints", &args.mints)])
+        .query(&[("mints", &mints)])
         .send()
         .await?
         .json()

--- a/skills/raydium-plugin/src/commands/mod.rs
+++ b/skills/raydium-plugin/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod get_pools;
 pub mod get_price;
 pub mod get_swap_quote;
 pub mod get_token_price;
+pub mod quickstart;
 pub mod swap;

--- a/skills/raydium-plugin/src/commands/quickstart.rs
+++ b/skills/raydium-plugin/src/commands/quickstart.rs
@@ -2,59 +2,106 @@
 ///
 /// Flow:
 ///   1. Resolve Solana wallet address (sync, via onchainos)
-///   2. Fetch SOL balance via Solana RPC getBalance
+///   2. Fetch SOL and USDC balances in parallel via Solana RPC
 ///   3. Emit JSON with status + next steps
 use anyhow::Result;
+use crate::onchainos;
 
-const SOLANA_RPC: &str = "https://api.mainnet-beta.solana.com";
+const SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const LAMPORTS_PER_SOL: f64 = 1_000_000_000.0;
-const MIN_SOL_READY: f64 = 0.01;
-
-/// Fetch SOL balance in lamports via Solana JSON-RPC getBalance.
-async fn sol_balance_lamports(wallet: &str) -> u64 {
-    let client = reqwest::Client::new();
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "getBalance",
-        "params": [wallet, {"commitment": "confirmed"}]
-    });
-    match client
-        .post(SOLANA_RPC)
-        .json(&body)
-        .send()
-        .await
-    {
-        Ok(resp) => {
-            match resp.json::<serde_json::Value>().await {
-                Ok(json) => json["result"]["value"].as_u64().unwrap_or(0),
-                Err(_) => 0,
-            }
-        }
-        Err(_) => 0,
-    }
-}
+const USDC_DECIMALS: f64 = 1_000_000.0;
+const MIN_SOL_GAS: f64 = 0.01;
+const MIN_USDC_RAW: u64 = 1_000_000; // 1 USDC
 
 pub async fn run() -> Result<()> {
     // Resolve wallet (sync)
-    let wallet = crate::onchainos::resolve_wallet_solana()?;
+    let wallet = onchainos::resolve_wallet_solana()?;
 
     // Progress to stderr
     let short = &wallet[..wallet.len().min(8)];
     eprintln!("Checking assets for {}... on Solana...", short);
 
-    // Fetch SOL balance
-    let lamports = sol_balance_lamports(&wallet).await;
-    let sol = lamports as f64 / LAMPORTS_PER_SOL;
-    let sol_str = format!("{:.6}", sol);
+    // Fetch SOL and USDC balances in parallel
+    let (sol_res, usdc_res) = tokio::join!(
+        onchainos::get_sol_balance(&wallet, SOLANA_RPC_URL),
+        onchainos::get_spl_token_balance(&wallet, USDC_MINT, SOLANA_RPC_URL),
+    );
 
-    let (status, suggestion, next_command, onboarding_steps) = if sol >= MIN_SOL_READY {
+    let lamports = sol_res.unwrap_or(0);
+    let usdc_raw = usdc_res.unwrap_or(0);
+
+    let sol = lamports as f64 / LAMPORTS_PER_SOL;
+    let usdc_balance = usdc_raw as f64 / USDC_DECIMALS;
+    let sol_str = format!("{:.6}", sol);
+    let usdc_str = format!("{:.6}", usdc_balance);
+
+    let has_gas = sol >= MIN_SOL_GAS;
+    let has_usdc = usdc_raw >= MIN_USDC_RAW;
+    let has_sol = sol > 0.0;
+
+    let (status, suggestion, next_command, onboarding_steps) = if has_usdc && !has_gas {
+        // Has USDC but not enough SOL for gas
         let steps = serde_json::json!([
             {
                 "step": 1,
-                "description": "Get a swap quote (no gas):",
+                "description": "Send at least 0.01 SOL to your wallet for gas fees:",
+                "wallet": wallet,
+                "note": "Minimum recommended: 0.01 SOL (covers transaction fees)"
+            },
+            {
+                "step": 2,
+                "description": "Run quickstart again:",
+                "command": "raydium-plugin quickstart"
+            }
+        ]);
+        (
+            "needs_gas",
+            "You have USDC but need SOL for gas. Send at least 0.01 SOL.",
+            "raydium-plugin quickstart".to_string(),
+            steps,
+        )
+    } else if has_usdc && has_gas {
+        // Has both USDC and SOL — ready to swap USDC → SOL or other tokens
+        let steps = serde_json::json!([
+            {
+                "step": 1,
+                "description": "Get a swap quote (USDC → SOL, no gas):",
+                "command": format!(
+                    "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 1",
+                    USDC_MINT, SOL_MINT
+                )
+            },
+            {
+                "step": 2,
+                "description": "Execute swap (USDC → SOL):",
+                "command": format!(
+                    "raydium-plugin swap --input-mint {} --output-mint {} --amount 1 --confirm",
+                    USDC_MINT, SOL_MINT
+                )
+            },
+            {
+                "step": 3,
+                "description": "Get token price:",
+                "command": format!("raydium-plugin get-token-price --mints {}", USDC_MINT)
+            }
+        ]);
+        (
+            "ready",
+            "Your wallet has USDC and SOL. Get a quote or swap tokens on Raydium.",
+            format!(
+                "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 1",
+                USDC_MINT, SOL_MINT
+            ),
+            steps,
+        )
+    } else if has_sol {
+        // Has SOL only — ready to swap SOL → USDC or other tokens
+        let steps = serde_json::json!([
+            {
+                "step": 1,
+                "description": "Get a swap quote (SOL → USDC, no gas):",
                 "command": format!(
                     "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 0.1",
                     SOL_MINT, USDC_MINT
@@ -62,7 +109,7 @@ pub async fn run() -> Result<()> {
             },
             {
                 "step": 2,
-                "description": "Execute swap:",
+                "description": "Execute swap (SOL → USDC):",
                 "command": format!(
                     "raydium-plugin swap --input-mint {} --output-mint {} --amount 0.1 --confirm",
                     SOL_MINT, USDC_MINT
@@ -75,8 +122,8 @@ pub async fn run() -> Result<()> {
             }
         ]);
         (
-            "ready",
-            "Your wallet has SOL. Get a quote or swap tokens on Raydium.",
+            "ready_sol_only",
+            "Your wallet has SOL. Swap SOL for USDC or other tokens on Raydium.",
             format!(
                 "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 0.1",
                 SOL_MINT, USDC_MINT
@@ -84,12 +131,13 @@ pub async fn run() -> Result<()> {
             steps,
         )
     } else {
+        // No funds
         let steps = serde_json::json!([
             {
                 "step": 1,
-                "description": "Send SOL to your wallet on Solana mainnet:",
+                "description": "Send SOL or USDC to your wallet on Solana mainnet:",
                 "wallet": wallet,
-                "note": "Minimum recommended: 0.1 SOL (covers fees + swap amount)"
+                "note": "Minimum recommended: 0.1 SOL (covers fees + swap amount) or 1+ USDC with 0.01 SOL for gas"
             },
             {
                 "step": 2,
@@ -99,7 +147,7 @@ pub async fn run() -> Result<()> {
         ]);
         (
             "no_funds",
-            "Send SOL to your wallet before swapping.",
+            "Send SOL or USDC to your wallet before swapping.",
             "raydium-plugin quickstart".to_string(),
             steps,
         )
@@ -111,7 +159,8 @@ pub async fn run() -> Result<()> {
         "wallet": wallet,
         "chain": "Solana",
         "assets": {
-            "sol_balance": sol_str
+            "sol_balance": sol_str,
+            "usdc_balance": usdc_str
         },
         "status": status,
         "suggestion": suggestion,

--- a/skills/raydium-plugin/src/commands/quickstart.rs
+++ b/skills/raydium-plugin/src/commands/quickstart.rs
@@ -1,0 +1,124 @@
+/// quickstart: Check wallet state and emit guided onboarding steps for new users.
+///
+/// Flow:
+///   1. Resolve Solana wallet address (sync, via onchainos)
+///   2. Fetch SOL balance via Solana RPC getBalance
+///   3. Emit JSON with status + next steps
+use anyhow::Result;
+
+const SOLANA_RPC: &str = "https://api.mainnet-beta.solana.com";
+const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const LAMPORTS_PER_SOL: f64 = 1_000_000_000.0;
+const MIN_SOL_READY: f64 = 0.01;
+
+/// Fetch SOL balance in lamports via Solana JSON-RPC getBalance.
+async fn sol_balance_lamports(wallet: &str) -> u64 {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getBalance",
+        "params": [wallet, {"commitment": "confirmed"}]
+    });
+    match client
+        .post(SOLANA_RPC)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            match resp.json::<serde_json::Value>().await {
+                Ok(json) => json["result"]["value"].as_u64().unwrap_or(0),
+                Err(_) => 0,
+            }
+        }
+        Err(_) => 0,
+    }
+}
+
+pub async fn run() -> Result<()> {
+    // Resolve wallet (sync)
+    let wallet = crate::onchainos::resolve_wallet_solana()?;
+
+    // Progress to stderr
+    let short = &wallet[..wallet.len().min(8)];
+    eprintln!("Checking assets for {}... on Solana...", short);
+
+    // Fetch SOL balance
+    let lamports = sol_balance_lamports(&wallet).await;
+    let sol = lamports as f64 / LAMPORTS_PER_SOL;
+    let sol_str = format!("{:.6}", sol);
+
+    let (status, suggestion, next_command, onboarding_steps) = if sol >= MIN_SOL_READY {
+        let steps = serde_json::json!([
+            {
+                "step": 1,
+                "description": "Get a swap quote (no gas):",
+                "command": format!(
+                    "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 0.1",
+                    SOL_MINT, USDC_MINT
+                )
+            },
+            {
+                "step": 2,
+                "description": "Execute swap:",
+                "command": format!(
+                    "raydium-plugin swap --input-mint {} --output-mint {} --amount 0.1 --confirm",
+                    SOL_MINT, USDC_MINT
+                )
+            },
+            {
+                "step": 3,
+                "description": "Get token price:",
+                "command": format!("raydium-plugin get-token-price --mints {}", SOL_MINT)
+            }
+        ]);
+        (
+            "ready",
+            "Your wallet has SOL. Get a quote or swap tokens on Raydium.",
+            format!(
+                "raydium-plugin get-swap-quote --input-mint {} --output-mint {} --amount 0.1",
+                SOL_MINT, USDC_MINT
+            ),
+            steps,
+        )
+    } else {
+        let steps = serde_json::json!([
+            {
+                "step": 1,
+                "description": "Send SOL to your wallet on Solana mainnet:",
+                "wallet": wallet,
+                "note": "Minimum recommended: 0.1 SOL (covers fees + swap amount)"
+            },
+            {
+                "step": 2,
+                "description": "Run quickstart again:",
+                "command": "raydium-plugin quickstart"
+            }
+        ]);
+        (
+            "no_funds",
+            "Send SOL to your wallet before swapping.",
+            "raydium-plugin quickstart".to_string(),
+            steps,
+        )
+    };
+
+    let output = serde_json::json!({
+        "ok": true,
+        "about": "Raydium is Solana's leading AMM — swap tokens at competitive rates with deep liquidity across hundreds of pairs.",
+        "wallet": wallet,
+        "chain": "Solana",
+        "assets": {
+            "sol_balance": sol_str
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+        "onboarding_steps": onboarding_steps
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}

--- a/skills/raydium-plugin/src/commands/swap.rs
+++ b/skills/raydium-plugin/src/commands/swap.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use crate::config::{
     parse_human_amount, DEFAULT_COMPUTE_UNIT_PRICE, DEFAULT_SLIPPAGE_BPS, DEFAULT_TX_VERSION,
     PRICE_IMPACT_BLOCK_PCT, PRICE_IMPACT_WARN_PCT, RAYDIUM_AMM_PROGRAM, SOL_NATIVE_MINT,
-    SOLANA_RPC_URL, USDC_SOLANA, TX_API_BASE,
+    SOL_SYSTEM_PROGRAM, SOLANA_RPC_URL, USDC_SOLANA, TX_API_BASE,
 };
 use crate::onchainos;
 
@@ -56,12 +56,16 @@ pub struct SwapArgs {
     /// Wallet public key (base58); if omitted, resolved from onchainos
     #[arg(long)]
     pub from: Option<String>,
+
+    /// Execute the swap on-chain. Without this flag, a preview is shown only.
+    #[arg(long, default_value = "false")]
+    pub confirm: bool,
 }
 
 /// Resolve token decimals for well-known mints; fall back to Raydium mint API for others.
 /// SOL: 9 decimals, USDC on Solana: 6 decimals.
 async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Result<u8> {
-    if mint == SOL_NATIVE_MINT {
+    if mint == SOL_NATIVE_MINT || mint == SOL_SYSTEM_PROGRAM {
         return Ok(9);
     }
     if mint == USDC_SOLANA {
@@ -85,14 +89,26 @@ async fn resolve_decimals(mint: &str, client: &reqwest::Client) -> anyhow::Resul
 }
 
 pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
+    // Rewrite native SOL system program address to WSOL — Raydium routes use WSOL
+    let input_mint = if args.input_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.input_mint.clone()
+    };
+    let output_mint = if args.output_mint == SOL_SYSTEM_PROGRAM {
+        SOL_NATIVE_MINT.to_string()
+    } else {
+        args.output_mint.clone()
+    };
+
     // Validate mint addresses before any API calls
-    crate::config::validate_solana_address(&args.input_mint)?;
-    crate::config::validate_solana_address(&args.output_mint)?;
+    crate::config::validate_solana_address(&input_mint)?;
+    crate::config::validate_solana_address(&output_mint)?;
 
     let client = reqwest::Client::new();
 
     // Resolve input token decimals and parse human-readable amount to raw u64
-    let input_decimals = resolve_decimals(&args.input_mint, &client).await?;
+    let input_decimals = resolve_decimals(&input_mint, &client).await?;
     let raw_amount = parse_human_amount(&args.amount, input_decimals)?;
 
     // dry_run guard - must come before resolve_wallet_solana()
@@ -105,8 +121,8 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
             serde_json::to_string_pretty(&serde_json::json!({
                 "ok": true,
                 "dry_run": true,
-                "inputMint": args.input_mint,
-                "outputMint": args.output_mint,
+                "inputMint": input_mint,
+                "outputMint": output_mint,
                 "amount": args.amount,
                 "amountDisplay": amount_display,
                 "rawAmount": raw_amount,
@@ -131,7 +147,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
     };
 
     // Pre-flight balance check
-    if args.input_mint == SOL_NATIVE_MINT {
+    if input_mint == SOL_NATIVE_MINT {
         let lamports = onchainos::get_sol_balance(&wallet, SOLANA_RPC_URL)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to fetch SOL balance: {}", e))?;
@@ -144,16 +160,16 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
             );
         }
     } else {
-        let token_balance = onchainos::get_spl_token_balance(&wallet, &args.input_mint, SOLANA_RPC_URL)
+        let token_balance = onchainos::get_spl_token_balance(&wallet, &input_mint, SOLANA_RPC_URL)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to fetch token balance for mint {}: {}", args.input_mint, e))?;
+            .map_err(|e| anyhow::anyhow!("Failed to fetch token balance for mint {}: {}", input_mint, e))?;
         if token_balance < raw_amount {
             anyhow::bail!(
                 "Insufficient token balance: need {} units, have {} units for mint {}. \
                  Add funds to your wallet before swapping.",
                 raw_amount,
                 token_balance,
-                args.input_mint,
+                input_mint,
             );
         }
     }
@@ -163,8 +179,8 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
     let quote_resp: Value = client
         .get(&quote_url)
         .query(&[
-            ("inputMint", args.input_mint.as_str()),
-            ("outputMint", args.output_mint.as_str()),
+            ("inputMint", input_mint.as_str()),
+            ("outputMint", output_mint.as_str()),
             ("amount", &raw_amount.to_string()),
             ("slippageBps", &args.slippage_bps.to_string()),
             ("txVersion", args.tx_version.as_str()),
@@ -199,14 +215,33 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         );
     }
 
+    // --confirm gate: show preview and exit unless user explicitly confirms
+    if !args.confirm {
+        let output_amount = &quote_resp["data"]["outputAmount"];
+        let route_plan = &quote_resp["data"]["routePlan"];
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "action": "swap",
+            "from_token": input_mint,
+            "to_token": output_mint,
+            "amount": args.amount,
+            "outputAmount": output_amount,
+            "priceImpactPct": price_impact,
+            "route": route_plan,
+            "hint": "Re-run with --confirm to execute"
+        }))?);
+        return Ok(());
+    }
+
     // Step 2: Resolve input token account (required by Raydium API when input is SPL, not native SOL)
-    let input_account: Option<String> = if args.input_mint != SOL_NATIVE_MINT {
-        let acct = onchainos::get_token_account(&wallet, &args.input_mint, SOLANA_RPC_URL)
+    let input_account: Option<String> = if input_mint != SOL_NATIVE_MINT {
+        let acct = onchainos::get_token_account(&wallet, &input_mint, SOLANA_RPC_URL)
             .await
             .map_err(|e| anyhow::anyhow!(
                 "Failed to resolve input token account for mint {}: {}. \
                  Ensure the wallet holds the input token before swapping.",
-                args.input_mint, e
+                input_mint, e
             ))?;
         Some(acct)
     } else {
@@ -271,8 +306,8 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         .unwrap_or_else(|_| args.amount.clone());
     let output = serde_json::json!({
         "ok": true,
-        "inputMint": args.input_mint,
-        "outputMint": args.output_mint,
+        "inputMint": input_mint,
+        "outputMint": output_mint,
         "amount": args.amount,
         "amountDisplay": amount_display,
         "rawAmount": raw_amount,

--- a/skills/raydium-plugin/src/commands/swap.rs
+++ b/skills/raydium-plugin/src/commands/swap.rs
@@ -1,13 +1,15 @@
 /// swap: Execute a token swap on Raydium via the transaction API + onchainos broadcast.
 ///
 /// Flow:
-///   1. (dry_run guard) - return early before wallet resolution
-///   2. Resolve Solana wallet address
-///   3. GET /compute/swap-base-in -> get quote
-///   4. POST /transaction/swap-base-in -> get base64 serialized tx
-///   5. onchainos wallet contract-call --chain 501 --unsigned-tx <base58_tx>
+///   1. Resolve token decimals + parse amount
+///   2. GET /compute/swap-base-in -> get quote
+///   3. (dry_run guard) - return early with full quote data, no wallet resolution
+///   4. Resolve Solana wallet address + pre-flight balance check
+///   5. (--confirm gate) - show preview and exit unless user explicitly confirms
+///   6. POST /transaction/swap-base-in -> get base64 serialized tx
+///   7. onchainos wallet contract-call --chain 501 --unsigned-tx <base58_tx>
 ///
-/// NOTE: Steps 4 and 5 must happen consecutively - Solana blockhash expires in ~60s.
+/// NOTE: Steps 6 and 7 must happen consecutively - Solana blockhash expires in ~60s.
 use anyhow::Result;
 use clap::Args;
 use serde_json::Value;
@@ -111,11 +113,55 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
     let input_decimals = resolve_decimals(&input_mint, &client).await?;
     let raw_amount = parse_human_amount(&args.amount, input_decimals)?;
 
-    // dry_run guard - must come before resolve_wallet_solana()
+    // Step 1: Get swap quote
+    let quote_url = format!("{}/compute/swap-base-in", TX_API_BASE);
+    let quote_resp: Value = client
+        .get(&quote_url)
+        .query(&[
+            ("inputMint", input_mint.as_str()),
+            ("outputMint", output_mint.as_str()),
+            ("amount", &raw_amount.to_string()),
+            ("slippageBps", &args.slippage_bps.to_string()),
+            ("txVersion", args.tx_version.as_str()),
+        ])
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    if !quote_resp["success"].as_bool().unwrap_or(false) {
+        anyhow::bail!(
+            "Failed to get swap quote: {}",
+            serde_json::to_string(&quote_resp)?
+        );
+    }
+
+    // Warn on high price impact
+    let price_impact = quote_resp["data"]["priceImpactPct"]
+        .as_f64()
+        .unwrap_or(0.0);
+    if price_impact >= PRICE_IMPACT_BLOCK_PCT {
+        anyhow::bail!(
+            "Price impact {:.2}% exceeds {:.1}% threshold. Swap aborted to protect funds.",
+            price_impact,
+            PRICE_IMPACT_BLOCK_PCT
+        );
+    }
+    if price_impact >= PRICE_IMPACT_WARN_PCT {
+        eprintln!(
+            "WARNING: Price impact {:.2}% exceeds {:.1}% warning threshold. Proceeding.",
+            price_impact, PRICE_IMPACT_WARN_PCT
+        );
+    }
+
+    // dry_run guard - after quote fetch, before wallet resolution
+    // Returns full quote data so dry-run is useful for previewing amounts
     if dry_run {
         let amount_display = args.amount.parse::<f64>()
             .map(|v| format!("{:.2}", v))
             .unwrap_or_else(|_| args.amount.clone());
+        let output_amount = &quote_resp["data"]["outputAmount"];
+        let route_plan = &quote_resp["data"]["routePlan"];
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -126,8 +172,11 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
                 "amount": args.amount,
                 "amountDisplay": amount_display,
                 "rawAmount": raw_amount,
+                "outputAmount": output_amount,
+                "priceImpactPct": price_impact,
+                "route": route_plan,
                 "slippageBps": args.slippage_bps,
-                "note": "dry_run: tx not built or broadcast"
+                "note": "dry_run: wallet not resolved, tx not built or broadcast"
             }))?
         );
         return Ok(());
@@ -172,47 +221,6 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
                 input_mint,
             );
         }
-    }
-
-    // Step 1: Get swap quote
-    let quote_url = format!("{}/compute/swap-base-in", TX_API_BASE);
-    let quote_resp: Value = client
-        .get(&quote_url)
-        .query(&[
-            ("inputMint", input_mint.as_str()),
-            ("outputMint", output_mint.as_str()),
-            ("amount", &raw_amount.to_string()),
-            ("slippageBps", &args.slippage_bps.to_string()),
-            ("txVersion", args.tx_version.as_str()),
-        ])
-        .send()
-        .await?
-        .json()
-        .await?;
-
-    if !quote_resp["success"].as_bool().unwrap_or(false) {
-        anyhow::bail!(
-            "Failed to get swap quote: {}",
-            serde_json::to_string(&quote_resp)?
-        );
-    }
-
-    // Warn on high price impact
-    let price_impact = quote_resp["data"]["priceImpactPct"]
-        .as_f64()
-        .unwrap_or(0.0);
-    if price_impact >= PRICE_IMPACT_BLOCK_PCT {
-        anyhow::bail!(
-            "Price impact {:.2}% exceeds {:.1}% threshold. Swap aborted to protect funds.",
-            price_impact,
-            PRICE_IMPACT_BLOCK_PCT
-        );
-    }
-    if price_impact >= PRICE_IMPACT_WARN_PCT {
-        eprintln!(
-            "WARNING: Price impact {:.2}% exceeds {:.1}% warning threshold. Proceeding.",
-            price_impact, PRICE_IMPACT_WARN_PCT
-        );
     }
 
     // --confirm gate: show preview and exit unless user explicitly confirms

--- a/skills/raydium-plugin/src/config.rs
+++ b/skills/raydium-plugin/src/config.rs
@@ -2,6 +2,9 @@
 pub const SOLANA_CHAIN_ID: &str = "501";
 #[allow(dead_code)]
 pub const SOL_NATIVE_MINT: &str = "So11111111111111111111111111111111111111112";
+/// Native SOL system program address — treated as SOL with 9 decimals; rewritten to WSOL for API calls.
+#[allow(dead_code)]
+pub const SOL_SYSTEM_PROGRAM: &str = "11111111111111111111111111111111";
 #[allow(dead_code)]
 pub const USDC_SOLANA: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 

--- a/skills/raydium-plugin/src/main.rs
+++ b/skills/raydium-plugin/src/main.rs
@@ -38,6 +38,9 @@ enum Commands {
 
     /// Execute a token swap on Raydium (requires onchainos login)
     Swap(commands::swap::SwapArgs),
+
+    /// Check wallet state and get guided next steps
+    Quickstart,
 }
 
 #[tokio::main]
@@ -51,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::GetPools(args) => commands::get_pools::execute(&args).await?,
         Commands::GetPoolList(args) => commands::get_pool_list::execute(&args).await?,
         Commands::Swap(args) => commands::swap::execute(&args, cli.dry_run).await?,
+        Commands::Quickstart => commands::quickstart::run().await?,
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
1. **Add `quickstart` command** (v0.1.7) — resolves Solana wallet, checks SOL and USDC balance, emits JSON with status + guided next steps for new users
2. **Confirm gate on `swap`** (v0.1.8) — swap now requires `--confirm` flag to execute on-chain; without it, shows a preview quote and exits safely
3. **Price decimal fix** (v0.1.8) — `get-price` was formatting price impact as fractional (0.001) instead of percentage (0.1%); now correct
4. **Native SOL support in `swap`** (v0.1.8) — handles native SOL mint (`So111...`) directly without requiring pre-wrapped WSOL
5. **Native SOL in `get-swap-quote`** (v0.2.0) — same WSOL rewrite applied to `get-swap-quote`; native SOL mint now resolves correctly
6. **`get-token-price` native SOL null fix** (v0.2.1) — when `inputMint` is native SOL, `priceUsdt` was null; now returns the correct SOL/USD price
7. **API error exit codes** (v0.2.1) — Raydium API errors (pool not found, insufficient liquidity) now exit with non-zero codes and structured error JSON
8. **SKILL.md Proactive Onboarding + Quickstart** — added onboarding walkthrough and step-by-step quickstart guide

## Files Changed
| File | Change |
|------|--------|
| `src/commands/quickstart.rs` | New — wallet check + balance status + onboarding steps |
| `src/commands/mod.rs` | Add `pub mod quickstart;` |
| `src/main.rs` | Add `Quickstart` subcommand |
| `src/commands/swap.rs` | Add `--confirm` gate; native SOL WSOL handling |
| `src/commands/get_swap_quote.rs` | Native SOL WSOL handling |
| `src/commands/get_token_price.rs` | Fix native SOL null price |
| `src/config.rs` | API error structured exit |
| `SKILL.md` | Add Proactive Onboarding + Quickstart sections; bump version to 0.2.1 |
| `Cargo.toml`, `plugin.yaml`, `.claude-plugin/plugin.json` | Version bump to 0.2.1 |

## Live Verification

**`swap --confirm`** — SOL → USDC on Solana mainnet, v0.2.1:

```
raydium swap \
  --input-mint So11111111111111111111111111111111111111112 \
  --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
  --amount 0.001 --confirm
```

```json
{
  "amount": "0.001",
  "amountDisplay": "0.00",
  "inputMint": "So11111111111111111111111111111111111111112",
  "ok": true,
  "outputAmount": "88204",
  "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
  "priceImpactPct": 0.0,
  "rawAmount": 1000000,
  "transactions": [
    {
      "txHash": "4DnP5UhVdR5TXvwYYkjU11JdtFzcNAseKTe8m3YFwWa8W4vgWgk8FrNRwExp9NCT13Km4YYtYyXqsCLNLVPa2BAY"
    }
  ]
}
```

tx: `4DnP5UhVdR5TXvwYYkjU11JdtFzcNAseKTe8m3YFwWa8W4vgWgk8FrNRwExp9NCT13Km4YYtYyXqsCLNLVPa2BAY`

## Checklist
- [x] Version consistent across all files (0.2.1)
- [x] `## Proactive Onboarding` section present in SKILL.md
- [x] `## Quickstart` section present in SKILL.md
- [x] `## Data Trust Boundary` section present in SKILL.md
- [x] Confirm gate on swap (`--confirm` required)
- [x] Binary freshness verified (`raydium 0.2.1`)
- [x] Live end-to-end verification (swap with `--confirm`, real tx_hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)