### PR TITLE
fix(meteora-plugin): WSOL repeat deposit + stale position detection (v0.3.6)

### DIFF
--- a/skills/meteora-plugin/.claude-plugin/plugin.json
+++ b/skills/meteora-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "meteora",
   "description": "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity",
-  "version": "0.3.5"
+  "version": "0.3.6"
 }

--- a/skills/meteora-plugin/Cargo.lock
+++ b/skills/meteora-plugin/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meteora-plugin"
-version = "0.3.4"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/meteora-plugin/Cargo.toml
+++ b/skills/meteora-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meteora-plugin"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [[bin]]

--- a/skills/meteora-plugin/SKILL.md
+++ b/skills/meteora-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meteora-plugin
 description: "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity, quickstart wallet check"
-version: "0.3.5"
+version: "0.3.6"
 tags:
   - solana
   - dex
@@ -21,7 +21,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/meteora-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.3.5"
+LOCAL_VER="0.3.6"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -94,7 +94,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora-plugin@0.3.5/meteora-plugin-${TARGET}${EXT}" -o ~/.local/bin/.meteora-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora-plugin@0.3.6/meteora-plugin-${TARGET}${EXT}" -o ~/.local/bin/.meteora-plugin-core${EXT}
 chmod +x ~/.local/bin/.meteora-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -102,7 +102,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/meteora-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.3.5" > "$HOME/.plugin-store/managed/meteora-plugin"
+echo "0.3.6" > "$HOME/.plugin-store/managed/meteora-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -122,7 +122,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"meteora-plugin","version":"0.3.5"}' >/dev/null 2>&1 || true
+    -d '{"name":"meteora-plugin","version":"0.3.6"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/meteora-plugin/plugin.yaml
+++ b/skills/meteora-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: meteora-plugin
-version: "0.3.5"
+version: "0.3.6"
 description: "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, executing swaps, and adding liquidity on Solana"
 author:
   name: "skylavis-sky"

--- a/skills/meteora-plugin/src/commands/add_liquidity.rs
+++ b/skills/meteora-plugin/src/commands/add_liquidity.rs
@@ -316,8 +316,13 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
             solana_rpc::find_token_account(&client, &wallet_str, &mint_y_str2, &ata_y_str),
             solana_rpc::account_exists(&client, &pos_str),
         )?;
-    // Reconcile: if we found an existing spanning position above, trust on-chain state
-    let position_exists = position_exists || position_exists_onchain;
+    // Use on-chain account_exists as the authoritative source.
+    // get_dlmm_positions_by_owner (getProgramAccounts) can return stale data — e.g. a
+    // recently-closed position may still appear in the index for a few seconds after
+    // close_position_if_empty confirms. If we trust stale data we skip ix_initialize_position_pda,
+    // then the DLMM instruction fails with "account owned by a different program" because the
+    // closed account reverts to System Program ownership.
+    let position_exists = position_exists_onchain;
     let user_token_x: Pubkey = token_x_acct.parse()?;
     let user_token_y: Pubkey = token_y_acct.parse()?;
 

--- a/skills/meteora-plugin/src/commands/add_liquidity.rs
+++ b/skills/meteora-plugin/src/commands/add_liquidity.rs
@@ -398,14 +398,6 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
                 &wallet, &user_token_y, &wallet, &token_y_mint,
             ));
         }
-        if token_x_mint == WSOL_MINT && amount_x_raw > 0 {
-            setup_ixs.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_x, amount_x_raw));
-            setup_ixs.push(meteora_ix::ix_sync_native(&user_token_x));
-        }
-        if token_y_mint == WSOL_MINT && amount_y_raw > 0 {
-            setup_ixs.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_y, amount_y_raw));
-            setup_ixs.push(meteora_ix::ix_sync_native(&user_token_y));
-        }
         if !ba_lower_exists {
             setup_ixs.push(meteora_ix::ix_initialize_bin_array(
                 &lb_pair, &bin_array_lower, &wallet, lower_idx,
@@ -452,7 +444,23 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
     // one side of the active bin. addLiquidityByStrategy (two-sided) will silently
     // deposit 0 when one amount is zero (SpotBalanced) or reject the range
     // (SpotImBalanced), so it is only used when both amounts are non-zero.
+    // ── WSOL wrapping (always, not just on first deposit) ────────────────────
+    // Wrapping is placed in the liquidity TX (not setup TX) so it fires on EVERY
+    // deposit — including repeat deposits where needs_setup=false and all accounts
+    // already exist. The wSOL ATA is guaranteed to exist at this point:
+    //   - first deposit:  created in setup TX, confirmed after the 8s wait
+    //   - repeat deposit: pre-existing on-chain
     let blockhash = solana_rpc::get_latest_blockhash(&client).await?;
+    let mut liq_ixs = vec![meteora_ix::ix_set_compute_unit_limit(400_000)];
+    if token_x_mint == WSOL_MINT && amount_x_raw > 0 {
+        liq_ixs.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_x, amount_x_raw));
+        liq_ixs.push(meteora_ix::ix_sync_native(&user_token_x));
+    }
+    if token_y_mint == WSOL_MINT && amount_y_raw > 0 {
+        liq_ixs.push(meteora_ix::ix_sol_transfer(&wallet, &user_token_y, amount_y_raw));
+        liq_ixs.push(meteora_ix::ix_sync_native(&user_token_y));
+    }
+
     let liquidity_ix = if amount_x_raw > 0 && amount_y_raw == 0 {
         meteora_ix::ix_add_liquidity_by_strategy_one_side(
             &position, &lb_pair,
@@ -488,7 +496,7 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
             effective_liq_lower, effective_liq_upper,
         )
     };
-    let liq_ixs = vec![meteora_ix::ix_set_compute_unit_limit(400_000), liquidity_ix];
+    liq_ixs.push(liquidity_ix);
 
     let liq_b58 = meteora_ix::build_tx_b58(&liq_ixs, &wallet, blockhash)?;
     eprintln!("[liquidity] Submitting add_liquidity tx...");


### PR DESCRIPTION
## Summary

Two add-liquidity bugs fixed in v0.3.6:

### Fix 1 — WSOL repeat deposit fails (regression in v0.3.5)

`ix_sol_transfer + ix_sync_native` (SOL → wSOL wrapping) was placed inside the setup TX, which only runs on the first deposit when accounts are missing. On subsequent deposits (`needs_setup=false`), wrapping was skipped entirely — the liquidity TX read from an empty wSOL ATA and failed.

**Fix:** moved wrapping to the liquidity TX so it fires on every `add-liquidity` call, regardless of whether a setup TX was needed.

### Fix 2 — "account owned by a different program" after position close

`get_dlmm_positions_by_owner` (getProgramAccounts) has eventual consistency — a recently-closed position can linger in the index for a few seconds after the account is deleted on-chain. Trusting this stale data caused the code to set `needs_setup=false`, skip `ix_initialize_position_pda`, and then fail when DLMM tried to use the closed PDA (now owned by System Program).

**Fix:** `account_exists` (getAccountInfo) is used as the sole authoritative source for whether the position PDA exists on-chain.

## Test plan

- [x] Fresh account (no ATAs, no position): `add-liquidity` creates wSOL ATA + position, deposits — ✅ tested live
- [x] Repeat deposit to existing position: second `add-liquidity` skips setup TX, still wraps SOL — ✅ tested live  
- [x] `cargo build --release` passes for v0.3.6
- [x] Diff limited to `skills/meteora-plugin/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)