### PR TITLE
fix(polymarket-plugin): fix proxy wallet redeem + sell mode detection (v0.4.4)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
-description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit."
-version: "0.4.3"
+description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit, BTC 5分钟, ETH 5分钟, 5分钟市场, 5min market, 五分钟市场, 短线市场, list 5-minute, BTC up or down, 找5分钟, 看5分钟, 5m updown, crypto 5m, 5分钟涨跌, 五分钟涨跌, updown market, BTC 5min, ETH 5min, SOL 5min, 5分钟预测."
+version: "0.4.4"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.3"
+LOCAL_VER="0.4.4"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.3/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.4/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/polymarket-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.4.3" > "$HOME/.plugin-store/managed/polymarket-plugin"
+echo "0.4.4" > "$HOME/.plugin-store/managed/polymarket-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.3"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.4"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -309,7 +309,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket-plugin --version
 ```
 
-Expected: `polymarket-plugin 0.4.3`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket-plugin 0.4.4`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -730,7 +730,7 @@ polymarket cancel --all
 
 ### `redeem` — Redeem Winning Outcome Tokens
 
-After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. This calls `redeemPositions` on the Gnosis CTF contract with `indexSets=[1, 2]` (covers both YES and NO outcomes; the CTF contract no-ops silently for non-winning tokens, so passing both is safe).
+After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. The binary automatically detects which wallet (EOA or proxy) holds the winning tokens by querying the Data API, then calls the correct redemption path for each wallet. No manual mode selection needed.
 
 ```
 polymarket redeem --market-id <condition_id_or_slug>
@@ -741,23 +741,31 @@ polymarket redeem --market-id <condition_id_or_slug> --dry-run
 | Flag | Description |
 |------|-------------|
 | `--market-id` | Market to redeem from: condition_id (0x-prefixed) or slug |
-| `--dry-run` | Preview the redemption (shows condition_id and call details) without submitting any transaction |
+| `--dry-run` | Preview the redemption (shows wallets and call details) without submitting any transaction |
 
 **Auth required:** onchainos wallet (for signing the on-chain tx). No CLOB credentials needed.
 
 **Not supported:** `neg_risk: true` (multi-outcome) markets — use the Polymarket web UI for those.
 
-**Output fields on success:** `condition_id`, `question`, `tx_hash`, `note`
+**Wallet routing (automatic):**
+- EOA has winning tokens → direct `redeemPositions` from EOA
+- Proxy has winning tokens → `PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])`
+- Both wallets have tokens → both txs submitted, one `eoa_tx` + one `proxy_tx`
+- Data API lag (nothing redeemable yet) → fallback EOA redeem with a warning
+
+**Output fields on success:** `condition_id`, `question`, `note`, and one or both of:
+- `eoa_tx` + `eoa_note` (if EOA held winning tokens)
+- `proxy_tx` + `proxy_note` (if proxy held winning tokens)
 
 **Agent flow:**
 1. Resolve `--market-id` to a condition_id and check `neg_risk` (auto from market lookup)
-2. Offer `--dry-run` first to show the user what will happen
-3. After user confirms, run without `--dry-run` to submit the tx
-4. Return the `tx_hash` — redemption settles once the tx confirms on Polygon (~seconds)
+2. Offer `--dry-run` first to show the user which wallets will be used
+3. After user confirms, run without `--dry-run` to submit the tx(s)
+4. Return the tx hash(es) — USDC.e lands in the respective wallet once tx confirms on Polygon (~seconds)
 
 **Example:**
 ```bash
-# Preview first
+# Preview first (shows eoa_wallet + proxy_wallet addresses)
 polymarket redeem --market-id will-trump-win-2024 --dry-run
 
 # After user confirms:
@@ -1071,4 +1079,4 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.4.3** (2026-04-14).
+See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.4.4** (2026-04-14).

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.3"
+version: "0.4.4"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/redeem.rs
+++ b/skills/polymarket-plugin/src/commands/redeem.rs
@@ -2,12 +2,19 @@ use anyhow::{bail, Result};
 use reqwest::Client;
 
 use crate::api::{get_clob_market, get_gamma_market_by_slug, get_positions};
-use crate::onchainos::{ctf_redeem_positions, get_wallet_address};
+use crate::config::load_credentials;
+use crate::onchainos::{ctf_redeem_positions, ctf_redeem_via_proxy, get_wallet_address};
 
 /// Run the redeem command.
 ///
-/// market_id: condition_id (0x-prefixed) or slug
-/// dry_run: if true, print preview and exit without submitting the tx
+/// Automatically determines which wallet (EOA / proxy) holds the winning outcome tokens
+/// by querying the Data API, then submits the correct redeemPositions path for each.
+///
+/// This handles all four cases correctly regardless of the current trading mode setting:
+///   - Tokens in EOA only          → EOA direct redeem
+///   - Tokens in proxy only        → proxy redeem via PROXY_FACTORY
+///   - Tokens in both              → both redeems submitted
+///   - Data API lag / no positions → fallback to EOA redeem with a warning
 pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
     let client = Client::new();
 
@@ -39,6 +46,11 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
     let cid_hex = condition_id.trim_start_matches("0x");
     let cid_display = format!("0x{}", cid_hex);
 
+    // Resolve EOA and proxy wallet addresses
+    let eoa_addr  = get_wallet_address().await?;
+    let creds     = load_credentials().unwrap_or_default();
+    let proxy_addr = creds.and_then(|c| c.proxy_wallet);
+
     if dry_run {
         let out = serde_json::json!({
             "ok": true,
@@ -48,54 +60,111 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
                 "condition_id": cid_display,
                 "question": question,
                 "neg_risk": false,
+                "eoa_wallet": eoa_addr,
+                "proxy_wallet": proxy_addr,
                 "action": "redeemPositions",
                 "index_sets": [1, 2],
-                "note": "dry-run: CTF redeemPositions tx not submitted. index_sets [1,2] covers YES and NO outcomes — the CTF contract pays out winning tokens and silently no-ops for losing ones."
+                "note": "dry-run: will redeem from whichever wallet (EOA / proxy) holds the winning tokens, regardless of current trading mode."
             }
         });
         println!("{}", serde_json::to_string_pretty(&out)?);
         return Ok(());
     }
 
-    // Pre-flight: check if this market has any redeemable value.
-    // If all positions for this condition_id show current_value ≈ 0, the user
-    // would waste gas on a no-op redemption — warn and require explicit confirmation
-    // (agent should surface this; binary just logs a clear warning).
-    let wallet_addr = get_wallet_address().await?;
-    let positions = get_positions(&client, &wallet_addr).await.unwrap_or_default();
-    let market_positions: Vec<_> = positions
-        .iter()
-        .filter(|p| p.condition_id.as_deref() == Some(&condition_id)
-            || p.condition_id.as_deref() == Some(&cid_display))
-        .collect();
-
-    if !market_positions.is_empty() {
-        let total_value: f64 = market_positions
-            .iter()
-            .filter(|p| p.redeemable)
-            .map(|p| p.current_value.unwrap_or(0.0))
-            .sum();
-
-        if total_value < 0.000_001 {
-            eprintln!(
-                "[polymarket] Warning: all redeemable positions for this market have current_value ≈ $0. \
-                 This market resolved against your positions — redeeming will cost gas and receive nothing. \
-                 Use --dry-run to preview, or proceed only if you are certain."
-            );
+    // Determine which wallet(s) have redeemable positions for this condition_id.
+    // We check the Data API for each address independently — this is correct regardless
+    // of the current trading mode setting, since the mode may have changed after the order.
+    let eoa_redeemable = {
+        let positions = get_positions(&client, &eoa_addr).await.unwrap_or_default();
+        let has = positions.iter().any(|p| {
+            (p.condition_id.as_deref() == Some(&condition_id)
+                || p.condition_id.as_deref() == Some(&cid_display))
+                && p.redeemable
+        });
+        // Also warn if EOA positions exist but have no value (resolved against us)
+        if !has {
+            let lost: f64 = positions.iter()
+                .filter(|p| p.condition_id.as_deref() == Some(&condition_id)
+                    || p.condition_id.as_deref() == Some(&cid_display))
+                .map(|p| p.current_value.unwrap_or(0.0))
+                .sum();
+            if lost < 0.000_001 && positions.iter().any(|p|
+                p.condition_id.as_deref() == Some(&condition_id)
+                || p.condition_id.as_deref() == Some(&cid_display))
+            {
+                eprintln!(
+                    "[polymarket] Note: EOA has positions for this market but current_value ≈ $0 \
+                     (market resolved against your EOA positions)."
+                );
+            }
         }
+        has
+    };
+
+    let proxy_redeemable = if let Some(ref proxy) = proxy_addr {
+        let positions = get_positions(&client, proxy).await.unwrap_or_default();
+        positions.iter().any(|p| {
+            (p.condition_id.as_deref() == Some(&condition_id)
+                || p.condition_id.as_deref() == Some(&cid_display))
+                && p.redeemable
+        })
+    } else {
+        false
+    };
+
+    // If Data API shows nothing redeemable in either wallet, fall back to EOA redeem.
+    // The API can lag after resolution — we still attempt rather than blocking the user.
+    if !eoa_redeemable && !proxy_redeemable {
+        eprintln!(
+            "[polymarket] Warning: Data API shows no redeemable positions for {} in EOA or proxy wallet \
+             (API may lag after market resolution). Attempting EOA redeem as fallback.",
+            cid_display
+        );
+        let tx_hash = ctf_redeem_positions(&condition_id).await?;
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "data": {
+                "condition_id": cid_display,
+                "question": question,
+                "eoa_tx": tx_hash,
+                "source": "fallback_eoa",
+                "note": "EOA redeemPositions submitted (fallback — Data API showed no positions). USDC.e arrives once tx confirms."
+            }
+        }))?);
+        return Ok(());
     }
 
-    let tx_hash = ctf_redeem_positions(&condition_id).await?;
-
-    let out = serde_json::json!({
+    // Execute the correct path(s) based on actual token ownership
+    let mut out = serde_json::json!({
         "ok": true,
         "data": {
             "condition_id": cid_display,
             "question": question,
-            "tx_hash": tx_hash,
-            "note": "redeemPositions submitted. USDC.e will be transferred to your wallet once the tx confirms on Polygon."
         }
     });
+
+    if eoa_redeemable {
+        eprintln!("[polymarket] EOA has winning tokens — submitting EOA redeemPositions...");
+        let tx = ctf_redeem_positions(&condition_id).await?;
+        out["data"]["eoa_tx"]   = serde_json::Value::String(tx);
+        out["data"]["eoa_note"] = serde_json::Value::String(
+            "EOA redeemPositions submitted.".into()
+        );
+    }
+
+    if proxy_redeemable {
+        eprintln!("[polymarket] Proxy has winning tokens — submitting proxy redeemPositions via PROXY_FACTORY...");
+        let tx = ctf_redeem_via_proxy(&condition_id).await?;
+        out["data"]["proxy_tx"]   = serde_json::Value::String(tx);
+        out["data"]["proxy_note"] = serde_json::Value::String(
+            "Proxy redeemPositions submitted via PROXY_FACTORY.".into()
+        );
+    }
+
+    out["data"]["note"] = serde_json::Value::String(
+        "USDC.e will be transferred to the respective wallet(s) once tx(s) confirm on Polygon.".into()
+    );
+
     println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
 }

--- a/skills/polymarket-plugin/src/commands/sell.rs
+++ b/skills/polymarket-plugin/src/commands/sell.rs
@@ -271,11 +271,13 @@ pub async fn run(
     // Check CTF token balance (from maker's address).
     // EOA mode: use CLOB API (reliable for EOA wallets).
     // POLY_PROXY mode: CLOB API returns 0 for proxy wallets regardless of actual balance;
-    // skip the pre-flight check and let the CLOB server validate at order submission.
+    // skip the proxy pre-flight and let the CLOB server validate at order submission.
+    // However, as a heuristic we check if the EOA holds the tokens — if so, warn the
+    // user that they may have the wrong mode set (bought in EOA, now selling in proxy).
+    let shares_needed_raw = to_token_units(share_amount);
     if effective_mode == TradingMode::Eoa {
         let token_balance = get_balance_allowance(&client, &maker_addr, &creds, "CONDITIONAL", Some(&token_id)).await?;
         let balance_raw = token_balance.balance.as_deref().unwrap_or("0").parse::<u64>().unwrap_or(0);
-        let shares_needed_raw = to_token_units(share_amount);
 
         if balance_raw < shares_needed_raw {
             // Check if the proxy wallet might hold these tokens and hint mode switch.
@@ -295,6 +297,26 @@ pub async fn run(
                 share_amount,
                 proxy_hint
             );
+        }
+    } else {
+        // Proxy mode: CLOB API can't verify proxy token balance directly.
+        // Check EOA balance as a heuristic — if EOA holds enough tokens the user
+        // likely bought in EOA mode and is now selling in proxy mode (wrong mode).
+        if let Ok(eoa_bal) = get_balance_allowance(
+            &client, &signer_addr, &creds, "CONDITIONAL", Some(&token_id)
+        ).await {
+            let eoa_raw = eoa_bal.balance.as_deref()
+                .unwrap_or("0").parse::<u64>().unwrap_or(0);
+            if eoa_raw >= shares_needed_raw {
+                eprintln!(
+                    "[polymarket] Warning: found {:.6} {} tokens in EOA wallet ({}) — \
+                     your position may be in EOA, not proxy. \
+                     If sell fails, switch modes with: polymarket switch-mode --mode eoa",
+                    eoa_raw as f64 / 1_000_000.0,
+                    outcome,
+                    signer_addr
+                );
+            }
         }
     }
 

--- a/skills/polymarket-plugin/src/onchainos.rs
+++ b/skills/polymarket-plugin/src/onchainos.rs
@@ -689,6 +689,73 @@ pub async fn ctf_redeem_positions(condition_id: &str) -> Result<String> {
     extract_tx_hash(&result)
 }
 
+/// ABI-encode and submit CTF redeemPositions via the PROXY_FACTORY.
+///
+/// Used when winning outcome tokens are held by the proxy wallet (POLY_PROXY mode).
+/// Routes: EOA → PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])
+/// The factory forwards the call from the proxy wallet's context, so CTF sees
+/// msg.sender = proxy wallet, which holds the winning tokens.
+pub async fn ctf_redeem_via_proxy(condition_id: &str) -> Result<String> {
+    use sha3::{Digest, Keccak256};
+    use crate::config::Contracts;
+
+    // Build inner redeemPositions calldata (identical to ctf_redeem_positions)
+    let inner_selector = Keccak256::digest(b"redeemPositions(address,bytes32,bytes32,uint256[])");
+    let inner_selector_hex = hex::encode(&inner_selector[..4]);
+    let collateral   = pad_address(Contracts::USDC_E);
+    let parent_id    = format!("{:064x}", 0u128);
+    let cond_id_hex  = condition_id.trim_start_matches("0x");
+    let cond_id_pad  = format!("{:0>64}", cond_id_hex);
+    let array_offset = pad_u256(4 * 32);
+    let array_len    = pad_u256(2);
+    let index_yes    = pad_u256(1);
+    let index_no     = pad_u256(2);
+
+    let inner_hex = format!(
+        "{}{}{}{}{}{}{}{}",
+        inner_selector_hex, collateral, parent_id, cond_id_pad,
+        array_offset, array_len, index_yes, index_no
+    );
+    // inner calldata = 4 + 7*32 = 228 bytes
+    let inner_bytes = hex::decode(&inner_hex).expect("inner redeem calldata");
+    let inner_len   = inner_bytes.len();
+    let pad_len     = (32 - inner_len % 32) % 32;
+    let inner_padded = format!("{}{}", inner_hex, "00".repeat(pad_len));
+
+    // Wrap in PROXY_FACTORY.proxy([(CALL, CTF, 0, inner_calldata)])
+    // Layout mirrors withdraw_usdc_from_proxy exactly, only `to` changes to CTF.
+    let outer_selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
+    let outer_selector_hex = hex::encode(&outer_selector[..4]);
+    let ctf_padded     = pad_address(Contracts::CTF);
+    let data_len_padded = format!("{:064x}", inner_len);
+
+    let calldata = format!(
+        "0x{}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}\
+         {}",
+        outer_selector_hex,
+        "0000000000000000000000000000000000000000000000000000000000000020", // params array offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // array length = 1
+        "0000000000000000000000000000000000000000000000000000000000000020", // tuple[0] offset
+        "0000000000000000000000000000000000000000000000000000000000000001", // op = 1 (CALL)
+        ctf_padded,                                                         // to = CTF
+        "0000000000000000000000000000000000000000000000000000000000000000", // value = 0
+        "0000000000000000000000000000000000000000000000000000000000000080", // data offset in tuple
+        data_len_padded,
+        inner_padded,
+    );
+
+    let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
+    extract_tx_hash(&result)
+}
+
 /// Get native POL balance for an address (eth_getBalance). Returns human-readable f64 (POL).
 pub async fn get_pol_balance(addr: &str) -> Result<f64> {
     use crate::config::Urls;


### PR DESCRIPTION
## Summary

- **redeem bug fix**: `redeem` always called `ctf_redeem_positions` from EOA — if tokens were in the proxy wallet, the CTF contract saw `msg.sender = EOA` (not proxy) and silently paid $0. Now auto-detects which wallet holds the winning tokens via Data API and routes correctly.
- **new `ctf_redeem_via_proxy()`**: ABI-encodes `redeemPositions` calldata wrapped in `PROXY_FACTORY.proxy([(CALL, CTF, 0, calldata)])` so CTF sees `msg.sender = proxy wallet`. Verified on Polygon mainnet.
- **sell UX improvement**: in POLY_PROXY mode, checks EOA token balance as heuristic — if EOA holds the tokens, warns user they may have the wrong mode set before the CLOB rejects the order.
- **SKILL.md**: adds 5-minute market trigger phrases to `description`; updates `redeem` section with wallet routing docs and new output fields.

## Wallet routing logic (redeem)

| Condition | Action |
|-----------|--------|
| EOA has redeemable tokens | `ctf_redeem_positions()` — direct EOA call |
| Proxy has redeemable tokens | `ctf_redeem_via_proxy()` — PROXY_FACTORY routes call from proxy context |
| Both wallets have tokens | Both txs submitted, output includes `eoa_tx` + `proxy_tx` |
| Data API lag (nothing redeemable) | Fallback EOA redeem with warning |

## Test plan

- [x] Placed orders from both EOA and proxy on BTC 5-min market (Polygon mainnet)
- [x] Confirmed `ctf_redeem_via_proxy` tx on-chain (`0x9f9a16dd...`)
- [x] Verified proxy path correctly triggered after Data API update
- [x] EOA fallback path triggered correctly during Data API lag window
- [x] `cargo build` passes, v0.4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)