### PR TITLE
fix(polymarket): correct GCD divisibility step — minimum 1 share not 10

### DIFF
--- a/skills/polymarket-plugin/CHANGELOG.md
+++ b/skills/polymarket-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polymarket Plugin Changelog
 
+### v0.4.5 (2026-04-15)
+
+- **fix**: Correct GCD divisibility step in `buy` and `sell` — minimum order is now 1 share (≈$1) instead of an inflated 10 shares (≈$9.87) for prices coprime with 10,000,000 (e.g. 0.987, 0.983, 0.991). The `tick_scale * 10_000` factor in the original GCD formula caused `gcd = 1` for such prices, making `step_raw = 10,000,000` (10 shares). New formula aligns to whole shares (1,000,000 raw) and computes the smallest valid share count from `gcd(price_ticks × SHARE_RAW, tick_scale)`.
+
 ### v0.4.2 (2026-04-14)
 
 - **feat**: `get-series` command — get current/next slot for 12 recurring Up/Down series markets (BTC/ETH/SOL/XRP × 5m/15m/4h). Returns `condition_id`, `up_token_id`, `down_token_id`, prices, and window times. NYSE trading hours enforced for 5m/15m series; 4h runs 24/7.

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.4"
+version: "0.4.5"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/buy.rs
+++ b/skills/polymarket-plugin/src/commands/buy.rs
@@ -177,17 +177,30 @@ pub async fn run(
         fp
     };
 
-    // Build order amounts using GCD-based integer arithmetic.
+    // Build order amounts using integer arithmetic.
+    //
+    // Constraint: maker_amount_raw = price_ticks × taker_amount_raw / tick_scale
+    // must be a non-negative integer (USDC in millionths).
+    //
+    // The minimum taker_amount_raw (shares in millionths) that satisfies this is:
+    //   tick_scale / gcd(price_ticks, tick_scale)
+    //
+    // However, since Polymarket treats outcome token amounts as whole shares,
+    // we align to 1 share (1_000_000 raw) as the minimum step. We then find
+    // the smallest multiple of 1 share for which the USDC amount is also an integer.
     fn gcd(mut a: u128, mut b: u128) -> u128 {
         while b != 0 { let t = b; b = a % b; a = t; }
         a
     }
     let tick_scale = (1.0 / tick_size).round() as u128;
     let price_ticks = (limit_price / tick_size).round() as u128;
-    let g = gcd(price_ticks, tick_scale * 10_000);
-    let step_raw = tick_scale * 10_000 / g;
-    let g2 = gcd(step_raw, 10_000);
-    let step = step_raw / g2 * 10_000;
+    const SHARE_RAW: u128 = 1_000_000; // 1 whole share in raw units (6 decimal places)
+    // Minimum k such that price_ticks × (k × SHARE_RAW) is divisible by tick_scale.
+    // = tick_scale / gcd(price_ticks × SHARE_RAW, tick_scale)
+    let g = gcd(price_ticks * SHARE_RAW % tick_scale.max(1), tick_scale.max(1));
+    let shares_per_step = tick_scale.max(1) / g.max(1);
+    // step is in share-raw units (millionths of shares)
+    let step = shares_per_step * SHARE_RAW;
 
     let max_taker_raw = (usdc_amount / limit_price * 1_000_000.0).floor() as u128;
     let mut taker_amount_raw = if round_up {

--- a/skills/polymarket-plugin/src/commands/sell.rs
+++ b/skills/polymarket-plugin/src/commands/sell.rs
@@ -180,17 +180,22 @@ pub async fn run(
         }
     };
 
-    // Build order amounts (SELL) using GCD-based integer arithmetic.
+    // Build order amounts (SELL) using integer arithmetic.
+    //
+    // Constraint: taker_amount_raw = price_ticks × maker_amount_raw / tick_scale
+    // must be a non-negative integer (USDC in millionths).
+    //
+    // Align to whole shares (1_000_000 raw) as the minimum step — same logic as buy.
     fn gcd(mut a: u128, mut b: u128) -> u128 {
         while b != 0 { let t = b; b = a % b; a = t; }
         a
     }
     let tick_scale = (1.0 / tick_size).round() as u128;
     let price_ticks = (limit_price / tick_size).round() as u128;
-    let g = gcd(price_ticks, tick_scale * 10_000);
-    let step_raw = tick_scale * 10_000 / g;
-    let g2 = gcd(step_raw, 10_000);
-    let step = step_raw / g2 * 10_000;
+    const SHARE_RAW: u128 = 1_000_000;
+    let g = gcd((price_ticks * SHARE_RAW) % tick_scale.max(1), tick_scale.max(1));
+    let shares_per_step = tick_scale.max(1) / g.max(1);
+    let step = shares_per_step * SHARE_RAW;
 
     let max_maker_raw = (share_amount * 1_000_000.0).floor() as u128;
     let maker_amount_raw = (max_maker_raw / step) * step;


### PR DESCRIPTION
## Summary

- The `tick_scale * 10_000` GCD formula in `buy.rs` and `sell.rs` inflated the minimum order step by 10x for prices coprime with 10,000,000 (e.g. 0.987, 0.983, 0.991)
- At YES@0.987 (e.g. Fed no-change market) a \$1 order errored with _"minimum amount is \$9.87"_ (10 shares × \$0.987) instead of the correct 1 share ≈ \$1
- The bug was present since v0.3.0; a prior C1 fix changed `gcd(step_raw, 100)` → `gcd(step_raw, 10_000)` for a different edge case but left this path unchanged

## Root cause

For price=0.987, tick_size=0.001:
```
g = gcd(987, 1000 × 10_000) = gcd(987, 10_000_000) = 1   ← coprime
step_raw = 10_000_000 / 1 = 10_000_000                    ← 10 shares
```
987 shares no prime factors with 10,000,000 (= 2⁷ × 5⁷), so `g = 1` and the full 10M lands in `step_raw`. The `g2` reduction cannot recover it since both 100 and 10,000 divide 10,000,000 evenly.

## Fix

Replace the formula with share-aligned steps: minimum granularity is **1 whole share** (1,000,000 raw units), which always satisfies the integer USDC constraint:

```rust
const SHARE_RAW: u128 = 1_000_000;
let g = gcd((price_ticks * SHARE_RAW) % tick_scale.max(1), tick_scale.max(1));
let shares_per_step = tick_scale.max(1) / g.max(1);
let step = shares_per_step * SHARE_RAW;
```

Verified correct (integer USDC, step = 1 share) for: 0.987/0.001, 0.50/0.001, 0.65/0.001, 0.90/0.001, 0.50/0.01, 0.65/0.01, 0.10/0.01.

## Test plan

- [ ] `buy --market-id <fed-no-change-april> --outcome yes --amount 1` — should place 1 share at ~\$0.989, no minimum error
- [ ] `buy --market-id <any> --outcome yes --amount 5 --price 0.987` — should produce 5 shares (\$4.935), no minimum error
- [ ] `sell --outcome yes --shares 1 --price 0.987` — should encode correctly without rounding to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)