### PR TITLE
fix(aave-v3-plugin): fix supply/repay/withdraw edge cases (v0.2.5)

### DIFF
--- a/skills/aave-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/aave-v3-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "aave-v3-plugin",
   "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/skills/aave-v3-plugin/Cargo.lock
+++ b/skills/aave-v3-plugin/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aave-v3-plugin"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/aave-v3-plugin/Cargo.toml
+++ b/skills/aave-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aave-v3-plugin"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/aave-v3-plugin/SKILL.md
+++ b/skills/aave-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aave-v3-plugin
 description: "Aave V3 lending and borrowing. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
-version: "0.2.4"
+version: "0.2.5"
 author: "skylavis-sky"
 tags:
   - lending
@@ -249,21 +249,25 @@ aave-v3-plugin --chain 8453 --confirm supply --asset USDC --amount 1000
 **What it does:**
 1. Resolves token contract address via `onchainos token search` (or uses address directly if provided)
 2. Resolves Pool address at runtime via `PoolAddressesProvider.getPool()`
-3. **Ask user to confirm** the approval before broadcasting
-4. Approves token to Pool: `onchainos wallet contract-call` → ERC-20 `approve(pool, amount)`
-5. **Ask user to confirm** the deposit before broadcasting
-6. Deposits to Pool: `onchainos wallet contract-call` → `Pool.supply(asset, amount, onBehalfOf, 0)`
+3. **WETH pre-flight**: if supplying WETH, checks on-chain WETH balance. If insufficient but wallet has enough ETH, automatically calls `WETH.deposit()` to wrap the needed amount first
+4. **Non-WETH pre-flight**: checks ERC-20 balance; errors with a clear message if insufficient
+5. **Ask user to confirm** the approval before broadcasting
+6. Approves token to Pool: `onchainos wallet contract-call` → ERC-20 `approve(pool, amount)`
+7. **Ask user to confirm** the deposit before broadcasting
+8. Deposits to Pool: `onchainos wallet contract-call` → `Pool.supply(asset, amount, onBehalfOf, 0)`
 
 **Expected output:**
 <external-content>
 ```json
 {
   "ok": true,
+  "wrapTxHash": null,
   "approveTxHash": "0xabc...",
   "supplyTxHash": "0xdef...",
   "asset": "USDC",
   "tokenAddress": "0x833589...",
   "amount": 1000,
+  "amountDisplay": "1000.00",
   "poolAddress": "0xa238dd..."
 }
 ```
@@ -284,7 +288,11 @@ aave-v3-plugin --chain 8453 withdraw --asset USDC --all
 **Key parameters:**
 - `--asset` — token symbol or ERC-20 address
 - `--amount` — partial withdrawal amount
-- `--all` — withdraw the full balance
+- `--all` — withdraw the full balance (uses `type(uint256).max`, safe with outstanding debt)
+
+**Notes:**
+- If outstanding debt exists, a warning is printed when using `--amount`; consider `--all` or repay first
+- `--amount` automatically caps to actual aToken balance to prevent precision-mismatch revert (e.g. aToken balance 0.999998 when user requests 1.0)
 
 **Expected output:**
 <external-content>
@@ -293,7 +301,8 @@ aave-v3-plugin --chain 8453 withdraw --asset USDC --all
   "ok": true,
   "txHash": "0xabc...",
   "asset": "USDC",
-  "amount": "500"
+  "amount": "500.00",
+  "amountDisplay": "500.00"
 }
 ```
 </external-content>
@@ -362,7 +371,7 @@ aave-v3-plugin --chain 137 --confirm repay --asset 0x2791Bca1f2de4661ED88A30C99A
 
 **Notes:**
 - ERC-20 approval is checked automatically; if insufficient, an approve tx is submitted first
-- `--all` repay uses the wallet's actual token balance to avoid revert when accrued interest exceeds wallet balance
+- `--all` repay passes `type(uint256).max` to Aave, which pulls the exact full debt (including last-second accrued interest) from the wallet — no dust risk
 
 **Expected output:**
 <external-content>
@@ -371,7 +380,8 @@ aave-v3-plugin --chain 137 --confirm repay --asset 0x2791Bca1f2de4661ED88A30C99A
   "ok": true,
   "txHash": "0xabc...",
   "asset": "0x2791...",
-  "repayAmount": "all (1005230000)",
+  "repayAmount": "all",
+  "repayAmountDisplay": "all",
   "totalDebtBefore": "1005.23",
   "approvalExecuted": true
 }

--- a/skills/aave-v3-plugin/plugin.yaml
+++ b/skills/aave-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: aave-v3-plugin
-version: "0.2.4"
+version: "0.2.5"
 description: "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
 author:
   name: skylavis-sky

--- a/skills/aave-v3-plugin/src/commands/repay.rs
+++ b/skills/aave-v3-plugin/src/commands/repay.rs
@@ -58,24 +58,21 @@ pub async fn run(
         None
     };
 
-    // Compute repay amount in minimal units
-    // For --all: query the wallet's actual token balance and use that as the repay amount.
-    // Using uint256.max reverts when wallet balance < accrued dust interest.
+    // Compute repay amount in minimal units.
+    // For --all: use u128::MAX, which encode_repay maps to type(uint256).max.
+    // Aave interprets uint256.max as "repay full debt including all accrued interest",
+    // pulling the exact outstanding amount from the wallet — no dust risk.
     let (amount_minimal, amount_display) = if all {
-        let balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
-            .await
-            .context("Failed to fetch token balance for full repay")?;
-        if balance == 0 {
-            anyhow::bail!("No {} balance in wallet to repay with", asset);
-        }
-        (balance, format!("all ({})", balance))
+        (u128::MAX, "all".to_string())
     } else {
         let v = amount.unwrap();
         let minimal = (v * 10u128.pow(decimals as u32) as f64) as u128;
         (minimal, v.to_string())
     };
 
-    // Step 4: Check ERC-20 allowance for token → pool
+    // Step 4: Check ERC-20 allowance for token → pool.
+    // For --all (amount_minimal == u128::MAX), always approve with u128::MAX (unlimited)
+    // so Aave can pull the full debt amount including last-second interest.
     let needs_approval = if all {
         true
     } else {
@@ -87,7 +84,8 @@ pub async fn run(
 
     let mut approval_result: Option<Value> = None;
     if needs_approval {
-        let approve_calldata = calldata::encode_erc20_approve(&pool_addr, amount_minimal)
+        let approve_amount = if all { u128::MAX } else { amount_minimal };
+        let approve_calldata = calldata::encode_erc20_approve(&pool_addr, approve_amount)
             .context("Failed to encode approve calldata")?;
         let approve_res = onchainos::wallet_contract_call(
             chain_id,
@@ -131,11 +129,18 @@ pub async fn run(
         .or_else(|| result["hash"].as_str())
         .unwrap_or("pending");
 
+    let amount_display_fmt = if all {
+        "all".to_string()
+    } else {
+        format!("{:.2}", amount.unwrap_or(0.0))
+    };
+
     Ok(json!({
         "ok": true,
         "txHash": tx_hash,
         "asset": asset,
         "repayAmount": amount_display,
+        "repayAmountDisplay": amount_display_fmt,
         "poolAddress": pool_addr,
         "totalDebtBefore": format!("{:.2}", account_data.total_debt_usd()),
         "healthFactorBefore": format!("{:.4}", account_data.health_factor_f64()),

--- a/skills/aave-v3-plugin/src/commands/supply.rs
+++ b/skills/aave-v3-plugin/src/commands/supply.rs
@@ -29,11 +29,81 @@ pub async fn run(
         .with_context(|| format!("Could not resolve token address for '{}'", asset))?;
 
     let amount_minimal = human_to_minimal(amount, decimals as u64);
+    let amount_display = format!("{:.2}", amount);
 
     // Resolve Pool address at runtime
     let pool_addr = rpc::get_pool(cfg.pool_addresses_provider, cfg.rpc_url)
         .await
         .context("Failed to resolve Pool address")?;
+
+    // Pre-flight: if supplying WETH and wallet has insufficient WETH, auto-wrap ETH.
+    // WETH.deposit{value: needed}() selector: 0xd0e30db0 (no parameters, ETH sent via --amt)
+    let is_weth = cfg.weth_address.to_lowercase() == token_addr.to_lowercase();
+    let mut wrap_tx: Option<String> = None;
+
+    if is_weth {
+        let weth_balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
+            .await
+            .unwrap_or(0);
+        if weth_balance < amount_minimal {
+            let needed = amount_minimal - weth_balance;
+            let eth_balance = rpc::get_eth_balance(&from_addr, cfg.rpc_url)
+                .await
+                .unwrap_or(0);
+            if eth_balance < needed {
+                anyhow::bail!(
+                    "Insufficient balance: need {:.6} WETH to supply, have {:.6} WETH and {:.6} ETH. \
+                     Add more ETH or WETH to your wallet.",
+                    amount_minimal as f64 / 1e18,
+                    weth_balance as f64 / 1e18,
+                    eth_balance as f64 / 1e18,
+                );
+            }
+            // Auto-wrap: call WETH.deposit() with ETH value = needed amount
+            if dry_run {
+                let wrap_cmd = format!(
+                    "onchainos wallet contract-call --chain {} --to {} --input-data 0xd0e30db0 --amt {} --from {}",
+                    chain_id, token_addr, needed, from_addr
+                );
+                eprintln!("[dry-run] step 0 wrap ETH→WETH: {}", wrap_cmd);
+            } else {
+                let wrap_result = onchainos::wallet_contract_call_with_value(
+                    chain_id,
+                    &token_addr,
+                    "0xd0e30db0",
+                    Some(&from_addr),
+                    needed,
+                    false,
+                )
+                .context("WETH.deposit() (ETH→WETH wrap) failed")?;
+                let tx = wrap_result["data"]["txHash"]
+                    .as_str()
+                    .or_else(|| wrap_result["txHash"].as_str())
+                    .or_else(|| wrap_result["hash"].as_str())
+                    .unwrap_or("pending")
+                    .to_string();
+                if tx != "pending" && tx.starts_with("0x") {
+                    rpc::wait_for_tx(cfg.rpc_url, &tx)
+                        .await
+                        .context("WETH wrap tx did not confirm in time")?;
+                }
+                wrap_tx = Some(tx);
+            }
+        }
+    } else {
+        // Non-WETH: check ERC-20 balance before attempting supply
+        let token_balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
+            .await
+            .unwrap_or(0);
+        if token_balance < amount_minimal && !dry_run {
+            anyhow::bail!(
+                "Insufficient {} balance: need {:.6}, have {:.6}. Add funds to your wallet before supplying.",
+                asset,
+                amount_minimal as f64 / 10f64.powi(decimals as i32),
+                token_balance as f64 / 10f64.powi(decimals as i32),
+            );
+        }
+    }
 
     if dry_run {
         let approve_calldata = calldata::encode_erc20_approve(&pool_addr, amount_minimal)
@@ -56,6 +126,7 @@ pub async fn run(
             "asset": asset,
             "tokenAddress": token_addr,
             "amount": amount,
+            "amountDisplay": amount_display,
             "amountMinimal": amount_minimal.to_string(),
             "poolAddress": pool_addr,
             "steps": [
@@ -112,8 +183,10 @@ pub async fn run(
         "asset": asset,
         "tokenAddress": token_addr,
         "amount": amount,
+        "amountDisplay": amount_display,
         "amountMinimal": amount_minimal.to_string(),
         "poolAddress": pool_addr,
+        "wrapTxHash": wrap_tx,
         "approveTxHash": approve_tx,
         "supplyTxHash": supply_tx.to_string(),
         "dryRun": false

--- a/skills/aave-v3-plugin/src/commands/withdraw.rs
+++ b/skills/aave-v3-plugin/src/commands/withdraw.rs
@@ -34,18 +34,72 @@ pub async fn run(
     let (token_addr, decimals) = onchainos::resolve_token(asset, chain_id)
         .with_context(|| format!("Could not resolve token address for '{}'", asset))?;
 
-    let (amount_minimal, amount_display) = if all {
-        (u128::MAX, "all".to_string())
-    } else {
-        let amt = amount.unwrap();
-        let minimal = super::supply::human_to_minimal(amt, decimals as u64);
-        (minimal, amt.to_string())
-    };
-
     // Resolve Pool address at runtime
     let pool_addr = rpc::get_pool(cfg.pool_addresses_provider, cfg.rpc_url)
         .await
         .context("Failed to resolve Pool address")?;
+
+    // Pre-flight: check outstanding debt (Problem 3)
+    let account_data = rpc::get_user_account_data(&pool_addr, &from_addr, cfg.rpc_url)
+        .await
+        .context("Failed to fetch user account data")?;
+
+    if account_data.total_debt_base > 0 && !all {
+        // Warn but don't block — let Aave enforce HF constraints on-chain
+        eprintln!(
+            "[aave-v3] WARNING: You have outstanding debt (${:.2}). Withdrawing collateral reduces \
+             your health factor (currently {:.2}). If HF drops below 1.0, the transaction will revert. \
+             Use --all to withdraw the maximum safe amount, or repay debt first.",
+            account_data.total_debt_usd(),
+            account_data.health_factor_f64(),
+        );
+    }
+
+    let (amount_minimal, amount_display) = if all {
+        (u128::MAX, "all".to_string())
+    } else {
+        let amt = amount.unwrap();
+        let mut minimal = super::supply::human_to_minimal(amt, decimals as u64);
+
+        // Pre-flight: cap --amount to actual aToken balance to prevent precision-mismatch revert.
+        // aToken balance may differ slightly from the "round" amount the user sees
+        // (e.g. 0.999998 USDC when user requests 1.0) due to Aave internal rounding.
+        let actual_atoken_balance: Option<u128> = async {
+            let pdp = rpc::get_pool_data_provider(cfg.pool_addresses_provider, cfg.rpc_url)
+                .await
+                .ok()?;
+            let atoken_addr = rpc::get_atoken_address(&pdp, &token_addr, cfg.rpc_url)
+                .await
+                .ok()?;
+            rpc::get_erc20_balance(&atoken_addr, &from_addr, cfg.rpc_url)
+                .await
+                .ok()
+        }
+        .await;
+
+        if let Some(bal) = actual_atoken_balance {
+            if bal == 0 && !dry_run {
+                anyhow::bail!(
+                    "No {} supplied to Aave on this chain. Nothing to withdraw.",
+                    asset
+                );
+            } else if bal > 0 && minimal > bal {
+                // Precision fix: requested amount slightly exceeds aToken balance
+                // (e.g. user requests 1.0 but balance is 0.999998 due to Aave rounding)
+                eprintln!(
+                    "[aave-v3] NOTE: Requested {:.6} {} but aToken balance is {:.6}. \
+                     Adjusting withdrawal amount down to actual balance.",
+                    minimal as f64 / 10f64.powi(decimals as i32),
+                    asset,
+                    bal as f64 / 10f64.powi(decimals as i32),
+                );
+                minimal = bal;
+            }
+        }
+
+        let display_amt = minimal as f64 / 10f64.powi(decimals as i32);
+        (minimal, format!("{:.2}", display_amt))
+    };
 
     // Encode calldata
     let calldata = calldata::encode_withdraw(&token_addr, amount_minimal, &from_addr)
@@ -63,6 +117,7 @@ pub async fn run(
             "asset": asset,
             "tokenAddress": token_addr,
             "amount": amount_display,
+            "amountDisplay": amount_display,
             "poolAddress": pool_addr,
             "simulatedCommand": cmd
         }));
@@ -88,6 +143,7 @@ pub async fn run(
         "asset": asset,
         "tokenAddress": token_addr,
         "amount": amount_display,
+        "amountDisplay": amount_display,
         "poolAddress": pool_addr,
         "dryRun": false,
         "raw": result

--- a/skills/aave-v3-plugin/src/config.rs
+++ b/skills/aave-v3-plugin/src/config.rs
@@ -20,6 +20,8 @@ pub struct ChainConfig {
     pub pool_addresses_provider: &'static str,
     pub rpc_url: &'static str,
     pub name: &'static str,
+    /// WETH contract address on this chain (used for ETH→WETH auto-wrap in supply)
+    pub weth_address: &'static str,
 }
 
 pub static CHAINS: &[ChainConfig] = &[
@@ -28,24 +30,28 @@ pub static CHAINS: &[ChainConfig] = &[
         pool_addresses_provider: "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
         rpc_url: "https://ethereum.publicnode.com",
         name: "Ethereum Mainnet",
+        weth_address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     },
     ChainConfig {
         chain_id: 137,
         pool_addresses_provider: "0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb",
         rpc_url: "https://polygon-bor-rpc.publicnode.com",
         name: "Polygon",
+        weth_address: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
     },
     ChainConfig {
         chain_id: 42161,
         pool_addresses_provider: "0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb",
         rpc_url: "https://arbitrum-one-rpc.publicnode.com",
         name: "Arbitrum One",
+        weth_address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     },
     ChainConfig {
         chain_id: 8453,
         pool_addresses_provider: "0xe20fCBdBfFC4Dd138cE8b2E6FBb6CB49777ad64D",
         rpc_url: "https://base-rpc.publicnode.com",
         name: "Base",
+        weth_address: "0x4200000000000000000000000000000000000006",
     },
 ];
 

--- a/skills/aave-v3-plugin/src/onchainos.rs
+++ b/skills/aave-v3-plugin/src/onchainos.rs
@@ -203,6 +203,48 @@ pub fn wallet_contract_call(
     run_cmd(cmd)
 }
 
+/// Same as wallet_contract_call but attaches a native ETH value (--amt).
+/// Used for WETH.deposit() and similar payable calls.
+pub fn wallet_contract_call_with_value(
+    chain_id: u64,
+    to: &str,
+    input_data: &str,
+    from: Option<&str>,
+    value_wei: u128,
+    dry_run: bool,
+) -> anyhow::Result<Value> {
+    let mut args: Vec<String> = vec![
+        "wallet".to_string(),
+        "contract-call".to_string(),
+        "--chain".to_string(),
+        chain_id.to_string(),
+        "--to".to_string(),
+        to.to_string(),
+        "--input-data".to_string(),
+        input_data.to_string(),
+        "--amt".to_string(),
+        value_wei.to_string(),
+    ];
+    if let Some(addr) = from {
+        args.push("--from".to_string());
+        args.push(addr.to_string());
+    }
+    if dry_run {
+        args.push("--dry-run".to_string());
+        let cmd_str = format!("onchainos {}", args.join(" "));
+        eprintln!("[dry-run] would execute: {}", cmd_str);
+        return Ok(serde_json::json!({
+            "ok": true,
+            "dryRun": true,
+            "simulatedCommand": cmd_str
+        }));
+    }
+    args.push("--force".to_string());
+    let mut cmd = base_cmd();
+    cmd.args(&args);
+    run_cmd(cmd)
+}
+
 /// Approve an ERC-20 token spend via wallet contract-call (approve(spender, uint256.max)).
 /// Uses unlimited approval (type(uint256).max) for simplicity.
 pub fn dex_approve(

--- a/skills/aave-v3-plugin/src/rpc.rs
+++ b/skills/aave-v3-plugin/src/rpc.rs
@@ -261,6 +261,55 @@ pub async fn get_erc20_symbol(token_addr: &str, rpc_url: &str) -> anyhow::Result
     Ok(String::from_utf8_lossy(&bytes).to_string())
 }
 
+/// Get native ETH balance via eth_getBalance.
+pub async fn get_eth_balance(account: &str, rpc_url: &str) -> anyhow::Result<u128> {
+    let client = reqwest::Client::new();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [account, "latest"],
+        "id": 1
+    });
+    let resp: RpcResponse = client
+        .post(rpc_url)
+        .json(&req)
+        .send()
+        .await
+        .context("eth_getBalance HTTP request failed")?
+        .json()
+        .await
+        .context("eth_getBalance response parse failed")?;
+    if let Some(err) = resp.error {
+        anyhow::bail!("eth_getBalance RPC error: {}", err);
+    }
+    let hex_str = resp.result.ok_or_else(|| anyhow::anyhow!("eth_getBalance returned null"))?;
+    let raw = strip_0x(&hex_str);
+    u128::from_str_radix(raw, 16).context("eth_getBalance: hex parse error")
+}
+
+/// Get the aToken address for an asset via IPoolDataProvider.getReserveTokensAddresses(asset).
+/// Selector 0xd2493b6c — verified against Aave V3 PoolDataProvider.
+/// Returns the aTokenAddress (first of the three returned addresses).
+pub async fn get_atoken_address(
+    data_provider: &str,
+    asset: &str,
+    rpc_url: &str,
+) -> anyhow::Result<String> {
+    let asset_bytes = parse_address(asset)?;
+    let mut data = hex::decode("d2493b6c")?;
+    data.extend_from_slice(&[0u8; 12]);
+    data.extend_from_slice(&asset_bytes);
+    let data_hex = format!("0x{}", hex::encode(&data));
+    let hex_result = eth_call(rpc_url, data_provider, &data_hex).await?;
+    let raw = strip_0x(&hex_result);
+    // Returns 3 x address (each 32 bytes = 64 hex chars), total 192 hex chars minimum
+    if raw.len() < 192 {
+        anyhow::bail!("getReserveTokensAddresses: short response ({} hex chars)", raw.len());
+    }
+    // First slot (bytes 0..64) = aTokenAddress
+    decode_address_result(&format!("0x{}", &raw[0..64]))
+}
+
 // ── helpers ─────────────────────────────────────────────────────────────────
 
 fn strip_0x(s: &str) -> &str {


### PR DESCRIPTION
## Summary

5 user-reported bug fixes across supply, repay, and withdraw commands:

- **supply**: Added ERC-20 balance pre-flight check. For WETH specifically, auto-wraps ETH→WETH via `WETH.deposit()` when wallet has ETH but insufficient WETH. Added `amountDisplay` (2 decimal places) to output.
- **repay**: `--all` now passes `type(uint256).max` to Aave instead of a wallet-balance snapshot, eliminating residual dust debt caused by per-block interest accrual. Unlimited approval also used for `--all`. Added `repayAmountDisplay` field.
- **withdraw**: Added pre-flight debt warning when `--amount` is used with outstanding debt. `--amount` now caps to actual on-chain aToken balance to prevent precision-mismatch revert (e.g. aToken balance 0.999998 when user requests 1.0). Added `amountDisplay` field.
- **config**: Added canonical WETH addresses for all supported chains (Ethereum, Polygon, Arbitrum, Base).
- **onchainos/rpc**: Added `wallet_contract_call_with_value` (supports `--amt` for payable calls), `get_eth_balance`, and `get_atoken_address` helpers.

## Test plan

- [ ] `supply --asset WETH` with ETH but no WETH → auto-wrap fires, supply succeeds
- [ ] `supply --asset USDC` with zero balance → clear error before approve
- [ ] `repay --all` → approve + repay calldata both end in `fff...fff` (uint256.max)
- [ ] `repay --amount X` → partial repay unchanged
- [ ] `withdraw --amount 1` when aToken balance is 0.999998 → auto-adjusted to 0.999998
- [ ] `withdraw --amount X` with outstanding debt → WARNING printed, tx proceeds
- [ ] All commands output `amountDisplay` with 2 decimal places

🤖 Generated with [Claude Code](https://claude.com/claude-code)