### PR TITLE
fix(orca-plugin): add pre-flight balance check and amountDisplay (v0.6.3)

### DIFF
--- a/skills/orca-plugin/Cargo.lock
+++ b/skills/orca-plugin/Cargo.lock
@@ -625,8 +625,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "orca"
-version = "0.3.0"
+name = "orca-plugin"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/orca-plugin/Cargo.toml
+++ b/skills/orca-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orca-plugin"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/orca-plugin/SKILL.md
+++ b/skills/orca-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Concentrated liquidity AMM on Solana — swap tokens and query poo
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.6.2"
+  version: "0.6.3"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/orca-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.6.2"
+LOCAL_VER="0.6.3"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/orca-plugin@0.6.2/orca-plugin-${TARGET}${EXT}" -o ~/.local/bin/.orca-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/orca-plugin@0.6.3/orca-plugin-${TARGET}${EXT}" -o ~/.local/bin/.orca-plugin-core${EXT}
 chmod +x ~/.local/bin/.orca-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/orca-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.6.2" > "$HOME/.plugin-store/managed/orca-plugin"
+echo "0.6.3" > "$HOME/.plugin-store/managed/orca-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"orca-plugin","version":"0.6.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"orca-plugin","version":"0.6.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -211,9 +211,10 @@ orca get-quote \
 Execute a token swap on Orca via `onchainos dex swap execute`.
 
 **Pre-swap safety checks:**
-1. Security scan of output token via `onchainos security token-scan`
-2. Price impact check: warns at >2%, blocks at >10%
-3. **Ask user to confirm** before executing on-chain
+1. Balance check: verifies wallet holds sufficient SOL (native) or SPL token; fails with clear error if insufficient
+2. Security scan of output token via `onchainos security token-scan`
+3. Price impact check: warns at >2%, blocks at >10%
+4. **Ask user to confirm** before executing on-chain
 
 ```bash
 orca swap \
@@ -236,7 +237,7 @@ orca swap \
 **Execution Flow:**
 1. Run with `--dry-run` first to preview
 2. **Ask user to confirm** the swap details (amount, tokens, slippage) before proceeding
-3. Execute only after explicit user approval
+3. Execute only after explicit user approval — pre-flight balance check runs automatically before swap
 4. Report transaction hash and Solscan link
 
 **Example:**
@@ -255,7 +256,7 @@ orca swap \
   --slippage-bps 100
 ```
 
-**Output fields:** `ok`, `tx_hash`, `solscan_url`, `from_token`, `to_token`, `amount`, `slippage_bps`, `estimated_price_impact_pct`
+**Output fields:** `ok`, `tx_hash`, `solscan_url`, `from_token`, `to_token`, `amount`, `amount_display` (2 decimal places), `slippage_bps`, `estimated_price_impact_pct`
 
 ---
 

--- a/skills/orca-plugin/plugin.yaml
+++ b/skills/orca-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: orca-plugin
-version: "0.6.2"
+version: "0.6.3"
 description: "Concentrated liquidity AMM on Solana — swap tokens and query pools via the Whirlpools CLMM program"
 author:
   name: "skylavis-sky"

--- a/skills/orca-plugin/plugin.yaml
+++ b/skills/orca-plugin/plugin.yaml
@@ -26,4 +26,5 @@ build:
 api_calls:
   - "https://api.orca.so/v1/whirlpool/list"
   - "https://api.orca.so/v1"
+  - "api.mainnet-beta.solana.com"
 

--- a/skills/orca-plugin/src/commands/swap.rs
+++ b/skills/orca-plugin/src/commands/swap.rs
@@ -1,7 +1,7 @@
 use crate::api;
 use crate::config::{
     DEFAULT_SLIPPAGE_BPS, PRICE_IMPACT_BLOCK_THRESHOLD, PRICE_IMPACT_WARN_THRESHOLD,
-    SOL_NATIVE_MINT, WSOL_MINT,
+    SOL_DECIMALS, SOL_NATIVE_MINT, SOLANA_RPC_URL, WSOL_MINT,
 };
 use crate::onchainos;
 use clap::Args;
@@ -43,6 +43,7 @@ struct SwapOutput {
     from_token: String,
     to_token: String,
     amount: f64,
+    amount_display: String,
     slippage_bps: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     estimated_price_impact_pct: Option<f64>,
@@ -65,6 +66,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
             from_token: args.from_token.clone(),
             to_token: args.to_token.clone(),
             amount: args.amount,
+            amount_display: format!("{:.2}", args.amount),
             slippage_bps: args.slippage_bps,
             estimated_price_impact_pct: None,
             warning: Some("dry_run=true — transaction not submitted".to_string()),
@@ -73,6 +75,37 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
         };
         println!("{}", serde_json::to_string_pretty(&output)?);
         return Ok(());
+    }
+
+    // ─── Resolve wallet and pre-flight balance check ───
+    let wallet = onchainos::resolve_wallet_solana()?;
+
+    if args.from_token == SOL_NATIVE_MINT {
+        let lamports = onchainos::get_sol_balance(&wallet, SOLANA_RPC_URL)
+            .await
+            .unwrap_or(0);
+        let lamports_needed = (args.amount * 10u64.pow(SOL_DECIMALS) as f64) as u64;
+        if lamports < lamports_needed {
+            anyhow::bail!(
+                "Insufficient SOL balance: need {:.6} SOL, have {:.6} SOL. \
+                 Add funds to your wallet before swapping.",
+                args.amount,
+                lamports as f64 / 10u64.pow(SOL_DECIMALS) as f64,
+            );
+        }
+    } else {
+        let ui_balance = onchainos::get_spl_balance(&wallet, &args.from_token, SOLANA_RPC_URL)
+            .await
+            .unwrap_or(0.0);
+        if ui_balance < args.amount {
+            anyhow::bail!(
+                "Insufficient token balance: need {:.6}, have {:.6} for mint {}. \
+                 Add funds to your wallet before swapping.",
+                args.amount,
+                ui_balance,
+                args.from_token,
+            );
+        }
     }
 
     // ─── Security scan of output token ───
@@ -92,6 +125,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
                     from_token: args.from_token.clone(),
                     to_token: args.to_token.clone(),
                     amount: args.amount,
+                    amount_display: format!("{:.2}", args.amount),
                     slippage_bps: args.slippage_bps,
                     estimated_price_impact_pct: None,
                     warning: None,
@@ -164,6 +198,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
             from_token: args.from_token.clone(),
             to_token: args.to_token.clone(),
             amount: args.amount,
+            amount_display: format!("{:.2}", args.amount),
             slippage_bps: args.slippage_bps,
             estimated_price_impact_pct: Some(price_impact),
             warning: None,
@@ -182,6 +217,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
     let slippage_pct = format!("{:.4}", args.slippage_bps as f64 / 100.0);
 
     let result = execute_swap_onchainos(
+        &wallet,
         &args.from_token,
         &args.to_token,
         args.amount,
@@ -204,6 +240,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
         from_token: args.from_token.clone(),
         to_token: args.to_token.clone(),
         amount: args.amount,
+        amount_display: format!("{:.2}", args.amount),
         slippage_bps: args.slippage_bps,
         estimated_price_impact_pct: Some(price_impact),
         warning: pool_warning,
@@ -225,13 +262,12 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> anyhow::Result<()> {
 /// Execute swap via `onchainos swap execute`.
 /// This is the primary path — onchainos handles routing, signing, and broadcasting.
 async fn execute_swap_onchainos(
+    wallet: &str,
     from_token: &str,
     to_token: &str,
     amount: f64,
     slippage_pct: &str,
 ) -> anyhow::Result<serde_json::Value> {
-    // Resolve wallet address
-    let wallet = crate::onchainos::resolve_wallet_solana()?;
     let amount_str = amount.to_string();
     let output = Command::new("onchainos")
         .args([

--- a/skills/orca-plugin/src/config.rs
+++ b/skills/orca-plugin/src/config.rs
@@ -21,6 +21,9 @@ pub const WHIRLPOOL_PROGRAM: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
 // Orca REST API base URL (v1 — the publicly working endpoint)
 pub const ORCA_API_BASE: &str = "https://api.orca.so/v1";
 
+// Solana public RPC endpoint
+pub const SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
+
 // Default configuration
 pub const DEFAULT_SLIPPAGE_BPS: u64 = 50; // 0.5%
 pub const DEFAULT_MIN_POOL_TVL_USD: f64 = 10_000.0;

--- a/skills/orca-plugin/src/onchainos.rs
+++ b/skills/orca-plugin/src/onchainos.rs
@@ -28,6 +28,60 @@ pub fn resolve_wallet_solana() -> anyhow::Result<String> {
     )
 }
 
+/// Return native SOL balance in lamports for the given wallet.
+pub async fn get_sol_balance(wallet: &str, rpc_url: &str) -> anyhow::Result<u64> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getBalance",
+        "params": [wallet]
+    });
+    let resp: serde_json::Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    resp["result"]["value"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("Failed to parse SOL balance: {}", resp))
+}
+
+/// Return SPL token balance in UI units (f64) for the given wallet and mint.
+/// Returns 0.0 if the wallet holds no token accounts for this mint.
+pub async fn get_spl_balance(wallet: &str, mint: &str, rpc_url: &str) -> anyhow::Result<f64> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getTokenAccountsByOwner",
+        "params": [
+            wallet,
+            { "mint": mint },
+            { "encoding": "jsonParsed" }
+        ]
+    });
+    let resp: serde_json::Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let accounts = resp["result"]["value"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Unexpected RPC response: {}", resp))?;
+    if accounts.is_empty() {
+        return Ok(0.0);
+    }
+    let ui_amount = accounts[0]["account"]["data"]["parsed"]["info"]["tokenAmount"]["uiAmount"]
+        .as_f64()
+        .unwrap_or(0.0);
+    Ok(ui_amount)
+}
+
 /// Execute a Solana DEX swap via `onchainos dex swap execute`.
 /// This is the primary swap path — onchainos handles routing, signing, and broadcasting.
 /// NOTE: Solana dex swap does NOT require --force.


### PR DESCRIPTION
## Summary

- **Problem 1 (balance check)**: Before executing a swap, verify the wallet holds sufficient SOL (native) or SPL token. Previously the plugin went straight to `onchainos dex swap execute` without checking; if the wallet had insufficient funds, the transaction would fail on-chain with a cryptic error. Now a clear pre-flight error is returned: `Insufficient SOL balance: need X SOL, have Y SOL`.
- **Problem 5 (amountDisplay)**: All `SwapOutput` JSON paths now include `amount_display` (formatted to 2 decimal places) alongside the raw `amount` float, for consistent display in agent UI.

## Changes

- `src/config.rs`: Add `SOLANA_RPC_URL` constant
- `src/onchainos.rs`: Add `get_sol_balance` (lamports via `getBalance`) and `get_spl_balance` (UI units via `getTokenAccountsByOwner` + `jsonParsed`)
- `src/commands/swap.rs`: Resolve wallet before security scan; run SOL/SPL balance check; add `amount_display` to `SwapOutput` struct and all instantiation sites; pass wallet into `execute_swap_onchainos` instead of resolving it twice
- `SKILL.md`: Document pre-flight balance check in swap flow; add `amount_display` to output fields
- Version bump: `0.6.2 → 0.6.3` (PATCH)

## Test plan

- [x] `orca swap --from-token <SOL> --amount 999` → `Insufficient SOL balance: need 999 SOL, have 0.166 SOL`
- [x] `orca swap --from-token <ORCA_mint> --amount 10` (wallet has 0 ORCA) → `Insufficient token balance: need 10.000000, have 0.000000`
- [x] `orca swap --dry-run` → output includes `"amount_display": "X.XX"`
- [x] `cargo build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)