### PR TITLE
fix(raydium-plugin): add pre-flight balance check and amountDisplay (v0.1.5)

### DIFF
--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -870,8 +870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "raydium"
-version = "0.1.3"
+name = "raydium-plugin"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.4"
+  version: "0.1.5"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/raydium-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.4"
+LOCAL_VER="0.1.5"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -93,7 +93,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.4/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/raydium-plugin@0.1.5/raydium-plugin-${TARGET}${EXT}" -o ~/.local/bin/.raydium-plugin-core${EXT}
 chmod +x ~/.local/bin/.raydium-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -101,7 +101,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/raydium-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.4" > "$HOME/.plugin-store/managed/raydium-plugin"
+echo "0.1.5" > "$HOME/.plugin-store/managed/raydium-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -121,7 +121,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"raydium-plugin","version":"0.1.4"}' >/dev/null 2>&1 || true
+    -d '{"name":"raydium-plugin","version":"0.1.5"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -220,7 +220,7 @@ raydium get-pool-list \
 Execution flow:
 1. Run with `--dry-run` first to preview (no on-chain action)
 2. **Ask user to confirm** the swap details, price impact, and fees
-3. Execute only after explicit user approval
+3. Execute only after explicit user approval — pre-flight balance check runs automatically before swap
 4. Reports transaction hash(es) on completion
 
 ```bash
@@ -241,7 +241,10 @@ raydium swap \
   --unwrap-sol true
 ```
 
+**Output fields:** `ok`, `inputMint`, `outputMint`, `amount`, `amountDisplay` (2 decimal places), `rawAmount`, `outputAmount`, `priceImpactPct`, `transactions` (array of `txHash`)
+
 **Safety guards:**
+- Insufficient SOL/SPL balance: aborts before any API call, reports available vs. required
 - Price impact ≥ 5%: warns the user
 - Price impact ≥ 20%: aborts swap to protect funds
 

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.4"
+version: "0.1.5"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/src/commands/swap.rs
+++ b/skills/raydium-plugin/src/commands/swap.rs
@@ -97,6 +97,9 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
 
     // dry_run guard - must come before resolve_wallet_solana()
     if dry_run {
+        let amount_display = args.amount.parse::<f64>()
+            .map(|v| format!("{:.2}", v))
+            .unwrap_or_else(|_| args.amount.clone());
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -105,6 +108,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
                 "inputMint": args.input_mint,
                 "outputMint": args.output_mint,
                 "amount": args.amount,
+                "amountDisplay": amount_display,
                 "rawAmount": raw_amount,
                 "slippageBps": args.slippage_bps,
                 "note": "dry_run: tx not built or broadcast"
@@ -125,6 +129,34 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         }
         w
     };
+
+    // Pre-flight balance check
+    if args.input_mint == SOL_NATIVE_MINT {
+        let lamports = onchainos::get_sol_balance(&wallet, SOLANA_RPC_URL)
+            .await
+            .unwrap_or(0);
+        if lamports < raw_amount {
+            anyhow::bail!(
+                "Insufficient SOL balance: need {:.9} SOL, have {:.9} SOL. \
+                 Add funds to your wallet before swapping.",
+                raw_amount as f64 / 1e9,
+                lamports as f64 / 1e9,
+            );
+        }
+    } else {
+        let token_balance = onchainos::get_spl_token_balance(&wallet, &args.input_mint, SOLANA_RPC_URL)
+            .await
+            .unwrap_or(0);
+        if token_balance < raw_amount {
+            anyhow::bail!(
+                "Insufficient token balance: need {} units, have {} units for mint {}. \
+                 Add funds to your wallet before swapping.",
+                raw_amount,
+                token_balance,
+                args.input_mint,
+            );
+        }
+    }
 
     // Step 1: Get swap quote
     let quote_url = format!("{}/compute/swap-base-in", TX_API_BASE);
@@ -234,11 +266,15 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
         }));
     }
 
+    let amount_display = args.amount.parse::<f64>()
+        .map(|v| format!("{:.2}", v))
+        .unwrap_or_else(|_| args.amount.clone());
     let output = serde_json::json!({
         "ok": true,
         "inputMint": args.input_mint,
         "outputMint": args.output_mint,
         "amount": args.amount,
+        "amountDisplay": amount_display,
         "rawAmount": raw_amount,
         "outputAmount": quote_resp["data"]["outputAmount"],
         "priceImpactPct": price_impact,

--- a/skills/raydium-plugin/src/onchainos.rs
+++ b/skills/raydium-plugin/src/onchainos.rs
@@ -62,6 +62,62 @@ pub async fn wallet_contract_call_solana(
 }
 
 
+/// Return native SOL balance in lamports for the given wallet.
+pub async fn get_sol_balance(wallet: &str, rpc_url: &str) -> anyhow::Result<u64> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getBalance",
+        "params": [wallet]
+    });
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    resp["result"]["value"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("Failed to parse SOL balance: {}", resp))
+}
+
+/// Return SPL token balance in raw units (u64) for the given wallet and mint.
+/// Returns 0 if the wallet holds no token account for this mint.
+pub async fn get_spl_token_balance(owner: &str, mint: &str, rpc_url: &str) -> anyhow::Result<u64> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getTokenAccountsByOwner",
+        "params": [
+            owner,
+            { "mint": mint },
+            { "encoding": "jsonParsed" }
+        ]
+    });
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let accounts = resp["result"]["value"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Unexpected RPC response: {}", resp))?;
+    if accounts.is_empty() {
+        return Ok(0);
+    }
+    let amount_str = accounts[0]["account"]["data"]["parsed"]["info"]["tokenAmount"]["amount"]
+        .as_str()
+        .unwrap_or("0");
+    amount_str
+        .parse::<u64>()
+        .map_err(|_| anyhow::anyhow!("Failed to parse token amount: {}", amount_str))
+}
+
 /// Resolve the user's Associated Token Account (ATA) for a given SPL mint via Solana RPC.
 /// Required by Raydium's /transaction/swap-base-in API as `inputAccount` when input is SPL.
 pub async fn get_token_account(owner: &str, mint: &str, rpc_url: &str) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

- **Problem 1 (balance check)**: Before executing a swap, verify the wallet holds sufficient SOL or SPL token. Previously the plugin called the Raydium quote API and built a transaction without checking wallet balance; the transaction would then fail on-chain. Now a clear pre-flight error is returned before any API call is made: `Insufficient SOL balance: need X SOL, have Y SOL`.
- **Problem 5 (amountDisplay)**: Both dry-run and live swap JSON output now include `amountDisplay` (formatted to 2 decimal places) alongside the raw `amount` string, for consistent display in agent UI.

## Changes

- `src/onchainos.rs`: Add `get_sol_balance` (lamports via `getBalance`) and `get_spl_token_balance` (raw units via `getTokenAccountsByOwner` + `jsonParsed`)
- `src/commands/swap.rs`: After wallet resolution, check SOL lamports vs `raw_amount` or SPL raw balance vs `raw_amount`; bail early if insufficient. Add `amountDisplay` to dry-run and live output JSON.
- `SKILL.md`: Document pre-flight balance check in swap flow; add output fields table including `amountDisplay`
- Version bump: `0.1.4 → 0.1.5` (PATCH)

## Test plan

- [x] `raydium swap --input-mint <SOL_WSOL> --amount 999` → `Insufficient SOL balance: need 999 SOL, have 0.166 SOL`
- [x] `raydium swap --input-mint <USDC> --amount 100` (wallet has ~6 USDC) → `Insufficient token balance: need 100000000 units, have 5998079 units`
- [x] `raydium swap --dry-run` → output includes `"amountDisplay": "X.XX"`
- [x] `cargo build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)