### PR TITLE
fix(pancakeswap-v3): human-readable outputs + safe balance check (v1.0.2)

### DIFF
--- a/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v3",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap-v3",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/pancakeswap-v3-plugin/Cargo.lock
+++ b/skills/pancakeswap-v3-plugin/Cargo.lock
@@ -1614,8 +1614,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pancakeswap-v3"
-version = "1.0.0"
+name = "pancakeswap-v3-plugin"
+version = "1.0.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap-v3-plugin/Cargo.toml
+++ b/skills/pancakeswap-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v3-plugin"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v3-plugin/SKILL.md
+++ b/skills/pancakeswap-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v3-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on Ethereum, BNB Chain, Base, Arbitrum, and Linea"
-version: "1.0.1"
+version: "1.0.2"
 author: "GeoGu360"
 tags:
   - dex
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v3-plugin"
 CACHE_MAX=3600
-LOCAL_VER="1.0.1"
+LOCAL_VER="1.0.2"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.1/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.2/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/pancakeswap-v3-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "1.0.1" > "$HOME/.plugin-store/managed/pancakeswap-v3-plugin"
+echo "1.0.2" > "$HOME/.plugin-store/managed/pancakeswap-v3-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.1"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.2"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pancakeswap-v3-plugin/plugin.yaml
+++ b/skills/pancakeswap-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v3-plugin
-version: "1.0.1"
+version: "1.0.2"
 description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360

--- a/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
@@ -75,6 +75,57 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         _ => anyhow::bail!("Provide both --tick-lower and --tick-upper, or omit both for auto ±10% range."),
     };
 
+    // Fetch wallet address early — needed for balance check and as mint recipient
+    let wallet_address = if args.dry_run {
+        "0x0000000000000000000000000000000000000001".to_string()
+    } else {
+        crate::onchainos::get_wallet_address().await?
+    };
+
+    // Pre-flight balance check — cap desired amounts to actual wallet balance.
+    // V3 math uses at most amount0_desired / amount1_desired, so if the wallet
+    // holds slightly less (e.g. dust gap from a prior tx), we cap down and proceed
+    // rather than bailing. If the shortfall is large (> 1%), we bail clearly.
+    let (amount0_desired, amount1_desired) = if args.dry_run {
+        (amount0_desired, amount1_desired)
+    } else {
+        let bal0 = crate::rpc::get_balance(token0, &wallet_address, cfg.rpc_url).await?;
+        let bal1 = crate::rpc::get_balance(token1, &wallet_address, cfg.rpc_url).await?;
+
+        let cap = |bal: u128, desired: u128, sym: &str, dec: u8| -> anyhow::Result<u128> {
+            if bal >= desired {
+                return Ok(desired);
+            }
+            let shortfall_pct = (desired - bal) as f64 / desired as f64 * 100.0;
+            if shortfall_pct > 1.0 {
+                anyhow::bail!(
+                    "Insufficient {} balance: need {:.6}, have {:.6}. Add funds before adding liquidity.",
+                    sym,
+                    desired as f64 / 10f64.powi(dec as i32),
+                    bal as f64 / 10f64.powi(dec as i32),
+                );
+            }
+            eprintln!(
+                "[pancakeswap-v3] NOTE: Requested {:.6} {} but wallet holds {:.6}. \
+                 Adjusting down to available balance ({:.4}% gap).",
+                desired as f64 / 10f64.powi(dec as i32),
+                sym,
+                bal as f64 / 10f64.powi(dec as i32),
+                shortfall_pct,
+            );
+            Ok(bal)
+        };
+
+        let d0 = cap(bal0, amount0_desired, &sym0, decimals0)?;
+        let d1 = cap(bal1, amount1_desired, &sym1, decimals1)?;
+        println!(
+            "Balance check OK: {:.6} {} available, {:.6} {} available",
+            bal0 as f64 / 10f64.powi(decimals0 as i32), sym0,
+            bal1 as f64 / 10f64.powi(decimals1 as i32), sym1,
+        );
+        (d0, d1)
+    };
+
     // Compute actual deposit amounts using V3 math, then apply slippage to those.
     // V3 deposits the optimal ratio for current price — applying slippage to the
     // desired amounts produces incorrect (too-tight) minimums and causes reverts.
@@ -85,40 +136,20 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
     let slippage_bps = (args.slippage * 100.0) as u128;
     let amount0_min = actual0.saturating_mul(10000 - slippage_bps) / 10000;
     let amount1_min = actual1.saturating_mul(10000 - slippage_bps) / 10000;
-    println!("Expected deposit: {} {} / {} {} → min: {} / {} ({}% slippage)",
-        actual0, sym0, actual1, sym1, amount0_min, amount1_min, args.slippage);
+    println!(
+        "Expected deposit: {:.6} {} / {:.6} {} → min: {:.6} / {:.6} ({}% slippage)",
+        actual0 as f64 / 10f64.powi(decimals0 as i32), sym0,
+        actual1 as f64 / 10f64.powi(decimals1 as i32), sym1,
+        amount0_min as f64 / 10f64.powi(decimals0 as i32),
+        amount1_min as f64 / 10f64.powi(decimals1 as i32),
+        args.slippage,
+    );
 
     // Deadline: 20 minutes from now
     let deadline = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() + 1200)
         .unwrap_or(9_999_999_999);
-
-    // Fetch wallet address early — needed for balance check and as mint recipient
-    let wallet_address = if args.dry_run {
-        "0x0000000000000000000000000000000000000001".to_string()
-    } else {
-        crate::onchainos::get_wallet_address().await?
-    };
-
-    // Bug 1 fix: pre-flight balance check — bail before wasting gas on approve
-    if !args.dry_run {
-        let bal0 = crate::rpc::get_balance(token0, &wallet_address, cfg.rpc_url).await?;
-        let bal1 = crate::rpc::get_balance(token1, &wallet_address, cfg.rpc_url).await?;
-        if bal0 < amount0_desired {
-            anyhow::bail!(
-                "Insufficient {} balance: wallet has {} but {} required (minimal units). Deposit more {} before adding liquidity.",
-                sym0, bal0, amount0_desired, sym0
-            );
-        }
-        if bal1 < amount1_desired {
-            anyhow::bail!(
-                "Insufficient {} balance: wallet has {} but {} required (minimal units). Deposit more {} before adding liquidity.",
-                sym1, bal1, amount1_desired, sym1
-            );
-        }
-        println!("Balance check OK: {} {} available, {} {} available", bal0, sym0, bal1, sym1);
-    }
 
     println!("Add Liquidity (chain {}):", args.chain);
     println!("  Token0 (token0 < token1): {} {}", amount_a_str, sym0);

--- a/skills/pancakeswap-v3-plugin/src/commands/positions.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/positions.rs
@@ -89,13 +89,17 @@ async fn query_onchain(
             Ok(pos) => {
                 let sym0 = crate::rpc::get_symbol(&pos.token0, cfg.rpc_url).await.unwrap_or_else(|_| pos.token0.clone());
                 let sym1 = crate::rpc::get_symbol(&pos.token1, cfg.rpc_url).await.unwrap_or_else(|_| pos.token1.clone());
+                let dec0 = crate::rpc::get_decimals(&pos.token0, cfg.rpc_url).await.unwrap_or(18);
+                let dec1 = crate::rpc::get_decimals(&pos.token1, cfg.rpc_url).await.unwrap_or(18);
 
                 println!("  Position #{}", token_id);
                 println!("    Pair:         {}/{}", sym0, sym1);
                 println!("    Fee tier:     {}%", pos.fee as f64 / 10000.0);
                 println!("    Tick range:   {} to {}", pos.tick_lower, pos.tick_upper);
                 println!("    Liquidity:    {}", pos.liquidity);
-                println!("    Owed fees:    {} {} / {} {}", pos.tokens_owed0, sym0, pos.tokens_owed1, sym1);
+                println!("    Owed fees:    {:.6} {} / {:.6} {}",
+                    pos.tokens_owed0 as f64 / 10f64.powi(dec0 as i32), sym0,
+                    pos.tokens_owed1 as f64 / 10f64.powi(dec1 as i32), sym1);
                 println!();
             }
             Err(e) => {

--- a/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
@@ -30,6 +30,8 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
 
     let sym0 = crate::rpc::get_symbol(&pos.token0, cfg.rpc_url).await.unwrap_or_else(|_| pos.token0.clone());
     let sym1 = crate::rpc::get_symbol(&pos.token1, cfg.rpc_url).await.unwrap_or_else(|_| pos.token1.clone());
+    let dec0 = crate::rpc::get_decimals(&pos.token0, cfg.rpc_url).await.unwrap_or(18);
+    let dec1 = crate::rpc::get_decimals(&pos.token1, cfg.rpc_url).await.unwrap_or(18);
 
     // Use integer arithmetic for 100% to avoid f64 precision loss on large u128 values
     // (f64 has 53-bit mantissa; a 18-digit liquidity value would round up, causing
@@ -66,9 +68,16 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
     println!("  Total liq:    {}{}", effective_liquidity, if pos.liquidity == 0 && args.dry_run { " [synthetic for dry-run]" } else { "" });
     println!("  Remove:       {}% = {}", args.liquidity_pct, liquidity_to_remove);
     println!("  Tick range:   {} to {}", pos.tick_lower, pos.tick_upper);
-    println!("  Expected out: {} {} / {} {} (before slippage)", amount0_out, sym0, amount1_out, sym1);
-    println!("  Min out:      {} {} / {} {} ({}% slippage)", amount0_min, sym0, amount1_min, sym1, args.slippage);
-    println!("  Owed fees:    {} {} / {} {}", pos.tokens_owed0, sym0, pos.tokens_owed1, sym1);
+    println!("  Expected out: {:.6} {} / {:.6} {} (before slippage)",
+        amount0_out as f64 / 10f64.powi(dec0 as i32), sym0,
+        amount1_out as f64 / 10f64.powi(dec1 as i32), sym1);
+    println!("  Min out:      {:.6} {} / {:.6} {} ({}% slippage)",
+        amount0_min as f64 / 10f64.powi(dec0 as i32), sym0,
+        amount1_min as f64 / 10f64.powi(dec1 as i32), sym1,
+        args.slippage);
+    println!("  Owed fees:    {:.6} {} / {:.6} {}",
+        pos.tokens_owed0 as f64 / 10f64.powi(dec0 as i32), sym0,
+        pos.tokens_owed1 as f64 / 10f64.powi(dec1 as i32), sym1);
     println!("  NPM:          {}", cfg.npm);
 
     // Deadline: 20 minutes from now
@@ -86,8 +95,8 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
 
     // Step 1: decreaseLiquidity
     println!("\nStep 1: Calling decreaseLiquidity...");
-    println!("  amount0Min: {} (slippage {}%)", amount0_min, args.slippage);
-    println!("  amount1Min: {} (slippage {}%)", amount1_min, args.slippage);
+    println!("  amount0Min: {:.6} {} (slippage {}%)", amount0_min as f64 / 10f64.powi(dec0 as i32), sym0, args.slippage);
+    println!("  amount1Min: {:.6} {} (slippage {}%)", amount1_min as f64 / 10f64.powi(dec1 as i32), sym1, args.slippage);
     let decrease_calldata = crate::calldata::encode_decrease_liquidity(
         args.token_id,
         liquidity_to_remove,


### PR DESCRIPTION
## Summary

- **add-liquidity balance check too strict**: previously bailed when wallet had even a tiny dust shortfall (e.g. 0.19% less than requested). Replaced with cap-down pattern: shortfall ≤1% → silently adjust to available balance with NOTE; >1% → bail with human-readable amounts.
- **Raw minimal-unit outputs**: all three commands printed raw atomic values (e.g. `4288000000000000`) instead of human-readable amounts. Fixed across `add-liquidity`, `remove-liquidity`, and `positions` (on-chain path).

## Affected commands

| Command | Fix |
|---------|-----|
| `add-liquidity` | Balance check cap-down + human-readable expected deposit / balance check lines |
| `remove-liquidity` | Human-readable expected out, min out, owed fees, amount0/1Min |
| `positions` | Human-readable owed fees (on-chain path) |

## Test plan

- [ ] `pancakeswap add-liquidity --dry-run` — amounts show as `0.001234 WETH` not `1234000000000000`
- [ ] `pancakeswap remove-liquidity --dry-run` — expected out / min out / owed fees human-readable
- [ ] `pancakeswap positions` — owed fees human-readable in on-chain path
- [ ] Balance shortfall ≤1%: proceeds with NOTE instead of bailing
- [ ] Balance shortfall >1%: bails with human-readable amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)