### PR TITLE
fix(curve-plugin): add pre-flight balance check and human-readable outputs (v0.2.7)

### DIFF
--- a/skills/curve-plugin/.claude-plugin/plugin.json
+++ b/skills/curve-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "curve",
   "description": "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC.",
-  "version": "0.2.3",
+  "version": "0.2.7",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/curve-plugin/Cargo.lock
+++ b/skills/curve-plugin/Cargo.lock
@@ -177,8 +177,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "curve"
-version = "0.2.3"
+name = "curve-plugin"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/curve-plugin/Cargo.toml
+++ b/skills/curve-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curve-plugin"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/curve-plugin/SKILL.md
+++ b/skills/curve-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: curve-plugin
 description: "Curve DEX plugin for swapping stablecoins and managing liquidity on Curve Finance. Trigger phrases: swap on Curve, Curve swap, add liquidity Curve, remove liquidity Curve, Curve pool APY, Curve pools, get Curve quote."
-version: "0.2.6"
+version: "0.2.7"
 author: "GeoGu360"
 tags:
   - dex
@@ -24,7 +24,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/curve-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.6"
+LOCAL_VER="0.2.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -97,7 +97,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.6/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/curve-plugin@0.2.7/curve-plugin-${TARGET}${EXT}" -o ~/.local/bin/.curve-plugin-core${EXT}
 chmod +x ~/.local/bin/.curve-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -105,7 +105,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/curve-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.6" > "$HOME/.plugin-store/managed/curve-plugin"
+echo "0.2.7" > "$HOME/.plugin-store/managed/curve-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -125,7 +125,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"curve-plugin","version":"0.2.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"curve-plugin","version":"0.2.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/curve-plugin/plugin.yaml
+++ b/skills/curve-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: curve-plugin
-version: "0.2.6"
+version: "0.2.7"
 description: "Curve DEX plugin — swap stablecoins, add/remove liquidity, query pools and APY across Ethereum, Arbitrum, Base, Polygon, and BSC."
 author:
   name: GeoGu360

--- a/skills/curve-plugin/src/commands/add_liquidity.rs
+++ b/skills/curve-plugin/src/commands/add_liquidity.rs
@@ -43,7 +43,7 @@ pub async fn run(
     }
 
     // Parse human-readable amounts using per-coin decimals
-    let amounts: Vec<u128> = if let Some(p) = pool {
+    let mut amounts: Vec<u128> = if let Some(p) = pool {
         let mut parsed = Vec::with_capacity(n_coins);
         for (i, s) in amount_strs.iter().enumerate() {
             let coin_decimals: u8 = p
@@ -66,7 +66,50 @@ pub async fn run(
     // Parse min_mint as LP tokens (always 18 decimals)
     let min_mint = rpc::parse_human_amount(&min_mint_str, 18)?;
 
-    // Build add_liquidity calldata based on coin count
+    // Pre-flight balance check — verify wallet holds enough of each token before approving.
+    // Slippage from a prior swap can leave a small shortfall (e.g. 1.499471 USDT when 1.5 was
+    // requested). Cap down if gap ≤ 1%; bail with a human-readable error if gap > 1%.
+    if !dry_run {
+        if let Some(p) = pool {
+            for (i, coin) in p.coins.iter().enumerate() {
+                if amounts[i] == 0 {
+                    continue;
+                }
+                let coin_decimals: u8 = coin
+                    .decimals
+                    .as_deref()
+                    .and_then(|d| d.parse().ok())
+                    .unwrap_or(18);
+                let bal = rpc::balance_of(&coin.address, &wallet_addr, rpc_url)
+                    .await
+                    .unwrap_or(0);
+                let desired = amounts[i];
+                if bal < desired {
+                    let shortfall_pct = (desired - bal) as f64 / desired as f64 * 100.0;
+                    if shortfall_pct > 1.0 {
+                        anyhow::bail!(
+                            "Insufficient {} balance: need {:.6}, have {:.6}. \
+                             Add funds or reduce --amounts before adding liquidity.",
+                            coin.symbol,
+                            desired as f64 / 10f64.powi(coin_decimals as i32),
+                            bal as f64 / 10f64.powi(coin_decimals as i32),
+                        );
+                    }
+                    eprintln!(
+                        "[curve] NOTE: Requested {:.6} {} but wallet holds {:.6}. \
+                         Adjusting down to available balance ({:.4}% gap).",
+                        desired as f64 / 10f64.powi(coin_decimals as i32),
+                        coin.symbol,
+                        bal as f64 / 10f64.powi(coin_decimals as i32),
+                        shortfall_pct,
+                    );
+                    amounts[i] = bal;
+                }
+            }
+        }
+    }
+
+    // Build add_liquidity calldata using (potentially capped) amounts
     let calldata = match n_coins {
         2 => curve_abi::encode_add_liquidity_2([amounts[0], amounts[1]], min_mint),
         3 => curve_abi::encode_add_liquidity_3([amounts[0], amounts[1], amounts[2]], min_mint),
@@ -79,6 +122,17 @@ pub async fn run(
 
     if dry_run {
         let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
+        let amounts_display: Vec<String> = if let Some(p) = pool {
+            amounts.iter().enumerate().map(|(i, &a)| {
+                let dec: u8 = p.coins.get(i)
+                    .and_then(|c| c.decimals.as_deref())
+                    .and_then(|d| d.parse().ok())
+                    .unwrap_or(18);
+                format!("{:.6}", a as f64 / 10f64.powi(dec as i32))
+            }).collect()
+        } else {
+            amounts.iter().map(|&a| format!("{:.6}", a as f64 / 1e18)).collect()
+        };
         println!(
             "{}",
             serde_json::json!({
@@ -87,6 +141,7 @@ pub async fn run(
                 "chain": chain_name,
                 "pool_address": pool_address,
                 "pool_name": pool_name,
+                "amounts": amounts_display,
                 "amounts_raw": amounts.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
                 "min_mint_raw": min_mint.to_string(),
                 "calldata": calldata
@@ -142,6 +197,18 @@ pub async fn run(
     let explorer = config::explorer_url(chain_id, &tx_hash);
     let pool_name = pool.map(|p| p.name.as_str()).unwrap_or("unknown");
 
+    let amounts_display: Vec<String> = if let Some(p) = pool {
+        amounts.iter().enumerate().map(|(i, &a)| {
+            let dec: u8 = p.coins.get(i)
+                .and_then(|c| c.decimals.as_deref())
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(18);
+            format!("{:.6}", a as f64 / 10f64.powi(dec as i32))
+        }).collect()
+    } else {
+        amounts.iter().map(|&a| format!("{:.6}", a as f64 / 1e18)).collect()
+    };
+
     println!(
         "{}",
         serde_json::json!({
@@ -149,6 +216,7 @@ pub async fn run(
             "chain": chain_name,
             "pool_address": pool_address,
             "pool_name": pool_name,
+            "amounts": amounts_display,
             "amounts_raw": amounts.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
             "min_mint_raw": min_mint.to_string(),
             "tx_hash": tx_hash,

--- a/skills/curve-plugin/src/commands/quote.rs
+++ b/skills/curve-plugin/src/commands/quote.rs
@@ -87,6 +87,10 @@ pub async fn run(
         ((in_f - out_f) / in_f * 100.0).max(0.0)
     };
 
+    let amount_in_display = format!("{:.6}", amount_minimal as f64 / 10f64.powi(in_decimals as i32));
+    let amount_out_display = format!("{:.6}", amount_out as f64 / 10f64.powi(out_decimals as i32));
+    let min_expected_display = format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32));
+
     println!(
         "{}",
         serde_json::json!({
@@ -95,8 +99,11 @@ pub async fn run(
             "pool": { "id": pool.id, "name": pool.name, "address": pool.address },
             "token_in": { "symbol": in_symbol, "address": token_in_addr, "index": in_idx },
             "token_out": { "symbol": out_symbol, "address": token_out_addr, "index": out_idx },
+            "amount_in": amount_in_display,
             "amount_in_raw": amount_minimal.to_string(),
+            "amount_out": amount_out_display,
             "amount_out_raw": amount_out.to_string(),
+            "min_expected": min_expected_display,
             "min_expected_raw": min_expected.to_string(),
             "slippage_pct": slippage * 100.0,
             "price_impact_pct": format!("{:.4}", price_impact_pct),

--- a/skills/curve-plugin/src/commands/remove_liquidity.rs
+++ b/skills/curve-plugin/src/commands/remove_liquidity.rs
@@ -88,6 +88,11 @@ pub async fn run(
                 .await
                 .unwrap_or_default();
             let estimated = rpc::decode_uint128(&est_hex);
+            let coin_decimals: u8 = pool
+                .and_then(|p| p.coins.get(idx as usize))
+                .and_then(|c| c.decimals.as_deref())
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(18);
             println!(
                 "{}",
                 serde_json::json!({
@@ -95,9 +100,12 @@ pub async fn run(
                     "dry_run": true,
                     "chain": chain_name,
                     "pool_address": pool_address,
+                    "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
                     "lp_amount_raw": actual_lp_amount.to_string(),
                     "coin_index": idx,
+                    "estimated_out": format!("{:.6}", estimated as f64 / 10f64.powi(coin_decimals as i32)),
                     "estimated_out_raw": estimated.to_string(),
+                    "min_amount": format!("{:.6}", min_out as f64 / 10f64.powi(coin_decimals as i32)),
                     "min_amount_raw": min_out.to_string()
                 })
             );
@@ -143,6 +151,7 @@ pub async fn run(
                 "dry_run": true,
                 "chain": chain_name,
                 "pool_address": pool_address,
+                "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
                 "lp_amount_raw": actual_lp_amount.to_string(),
                 "calldata": calldata
             })
@@ -173,6 +182,7 @@ pub async fn run(
             "chain": chain_name,
             "pool_address": pool_address,
             "pool_name": pool_name,
+            "lp_amount": format!("{:.6}", actual_lp_amount as f64 / 1e18),
             "lp_amount_raw": actual_lp_amount.to_string(),
             "tx_hash": tx_hash,
             "explorer": explorer

--- a/skills/curve-plugin/src/commands/swap.rs
+++ b/skills/curve-plugin/src/commands/swap.rs
@@ -68,6 +68,10 @@ pub async fn run(
         .and_then(|c| c.decimals.as_deref())
         .and_then(|d| d.parse().ok())
         .unwrap_or(18);
+    let out_decimals: u32 = out_coin
+        .and_then(|c| c.decimals.as_deref())
+        .and_then(|d| d.parse().ok())
+        .unwrap_or(18);
 
     // Convert human-readable amount to minimal units
     let amount_minimal = (amount_in * 10f64.powi(in_decimals as i32)) as u128;
@@ -107,8 +111,11 @@ pub async fn run(
                 "pool": { "id": pool.id, "name": pool.name, "address": pool.address },
                 "token_in": { "symbol": in_symbol, "address": token_in_addr, "index": in_idx },
                 "token_out": { "symbol": out_symbol, "address": token_out_addr, "index": out_idx },
+                "amount_in": format!("{:.6}", amount_minimal as f64 / 10f64.powi(in_decimals as i32)),
                 "amount_in_raw": amount_minimal.to_string(),
+                "expected_out": format!("{:.6}", amount_out as f64 / 10f64.powi(out_decimals as i32)),
                 "expected_out_raw": amount_out.to_string(),
+                "min_expected": format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32)),
                 "min_expected_raw": min_expected.to_string(),
                 "slippage_pct": slippage * 100.0,
                 "calldata": calldata,
@@ -116,6 +123,19 @@ pub async fn run(
             })
         );
         return Ok(());
+    }
+
+    // Pre-flight balance check for ERC-20 input tokens
+    if !is_native {
+        let bal = rpc::balance_of(&token_in_addr, &wallet_addr, rpc_url).await.unwrap_or(0);
+        if bal < amount_minimal {
+            anyhow::bail!(
+                "Insufficient {} balance: need {:.6}, have {:.6}.",
+                in_symbol,
+                amount_minimal as f64 / 10f64.powi(in_decimals as i32),
+                bal as f64 / 10f64.powi(in_decimals as i32),
+            );
+        }
     }
 
     // ERC-20 approve if not native ETH
@@ -165,8 +185,11 @@ pub async fn run(
             "pool": { "id": pool.id, "name": pool.name, "address": pool.address },
             "token_in": { "symbol": in_symbol, "address": token_in_addr },
             "token_out": { "symbol": out_symbol, "address": token_out_addr },
+            "amount_in": format!("{:.6}", amount_minimal as f64 / 10f64.powi(in_decimals as i32)),
             "amount_in_raw": amount_minimal.to_string(),
+            "expected_out": format!("{:.6}", amount_out as f64 / 10f64.powi(out_decimals as i32)),
             "expected_out_raw": amount_out.to_string(),
+            "min_expected": format!("{:.6}", min_expected as f64 / 10f64.powi(out_decimals as i32)),
             "min_expected_raw": min_expected.to_string(),
             "tx_hash": tx_hash,
             "explorer": explorer


### PR DESCRIPTION
## Summary

- **Pre-flight balance check in `add-liquidity`**: verifies wallet holds enough of each token before submitting approvals. If shortfall ≤ 1% (common after a prior swap due to slippage), caps down to available balance with a NOTE; bails with a clear error if > 1%.
- **Pre-flight balance check in `swap`**: same pattern — checks ERC-20 balance before approve, fails fast with human-readable amounts.
- **Human-readable output fields**: all commands now include display fields alongside `_raw` fields:
  - `quote`: `amount_in`, `amount_out`, `min_expected`
  - `swap`: `amount_in`, `expected_out`, `min_expected`
  - `add-liquidity`: `amounts` (per-coin, using pool decimals)
  - `remove-liquidity`: `lp_amount` (18 dec), plus `estimated_out` and `min_amount` for single-coin dry-run

## Root Cause Fixed

When a Curve agent runs swap → add-liquidity in sequence, the swap output is slightly less than requested (e.g. 1.499471 USDT for 1.5 USDC input). Without a balance check, `add-liquidity` would attempt `transferFrom` for the full 1.5 USDT, causing an `estimateGas` revert. The cap-down logic resolves this automatically.

## Test Plan

- [ ] `curve quote --token-in USDC --token-out USDT --amount 1.5` → output includes `amount_in`, `amount_out`, `min_expected`
- [ ] `curve swap --token-in USDC --token-out USDT --amount 1.5 --dry-run` → output includes `amount_in`, `expected_out`, `min_expected`
- [ ] `curve add-liquidity --pool <addr> --amounts "0,1.5,1.5" --min-mint 0 --dry-run` → output includes `amounts`
- [ ] `curve remove-liquidity --pool <addr> --lp-amount 1.0 --coin-index 1 --dry-run` → output includes `lp_amount`, `estimated_out`, `min_amount`
- [ ] `curve remove-liquidity --pool <addr> --lp-amount 1.0 --dry-run` → output includes `lp_amount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)