### PR TITLE
fix(meteora-plugin): derive bin arrays from position range, not deposit range (v0.3.7)

### DIFF
--- a/skills/meteora-plugin/.claude-plugin/plugin.json
+++ b/skills/meteora-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "meteora",
   "description": "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity",
-  "version": "0.3.6"
+  "version": "0.3.7"
 }

--- a/skills/meteora-plugin/Cargo.lock
+++ b/skills/meteora-plugin/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "meteora-plugin"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/meteora-plugin/Cargo.toml
+++ b/skills/meteora-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meteora-plugin"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/meteora-plugin/SKILL.md
+++ b/skills/meteora-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meteora-plugin
 description: "Meteora DLMM plugin for Solana — search liquidity pools, get swap quotes, view user positions, execute token swaps, add and remove liquidity, quickstart wallet check"
-version: "0.3.6"
+version: "0.3.7"
 tags:
   - solana
   - dex
@@ -21,7 +21,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/meteora-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.3.6"
+LOCAL_VER="0.3.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -94,7 +94,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora-plugin@0.3.6/meteora-plugin-${TARGET}${EXT}" -o ~/.local/bin/.meteora-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/meteora-plugin@0.3.7/meteora-plugin-${TARGET}${EXT}" -o ~/.local/bin/.meteora-plugin-core${EXT}
 chmod +x ~/.local/bin/.meteora-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -102,7 +102,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/meteora-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.3.6" > "$HOME/.plugin-store/managed/meteora-plugin"
+echo "0.3.7" > "$HOME/.plugin-store/managed/meteora-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -122,7 +122,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"meteora-plugin","version":"0.3.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"meteora-plugin","version":"0.3.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/meteora-plugin/plugin.yaml
+++ b/skills/meteora-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: meteora-plugin
-version: "0.3.6"
+version: "0.3.7"
 description: "Meteora DLMM plugin for searching pools, getting swap quotes, checking positions, executing swaps, and adding liquidity on Solana"
 author:
   name: "skylavis-sky"

--- a/skills/meteora-plugin/src/commands/add_liquidity.rs
+++ b/skills/meteora-plugin/src/commands/add_liquidity.rs
@@ -255,49 +255,30 @@ pub async fn execute(args: &AddLiquidityArgs, dry_run: bool) -> anyhow::Result<(
     // ── 6. Derive PDAs ───────────────────────────────────────────────────────
     let position = meteora_ix::position_pda(&lb_pair, &wallet, pos_lower, width);
     // DLMM requires bin_array_lower.index < bin_array_upper.index (program cannot
-    // borrow the same account twice). Determine the two bin array indices:
+    // borrow the same account twice).
     //
-    // For X-only / Y-only: the range often falls within a single bin array.
-    // In those cases use the adjacent array on the OTHER side as a structurally
-    // required second account — the program simply won't access it for those bins.
+    // The Meteora program validates that the passed bin arrays span the POSITION's
+    // full bin range (pos_lower..pos_upper), not just the deposit range
+    // (liq_lower..liq_upper). Derive indices from pos_lower / pos_upper so the
+    // arrays always cover the entire position even for narrow X-only / Y-only deposits.
     //
-    // For two-sided: if both bounds are already in different arrays, use them directly;
-    // otherwise extend liq_lower into the previous array (or liq_upper into the next).
-    let lower_idx_raw = meteora_ix::bin_array_index(liq_lower);
-    let upper_idx_raw = meteora_ix::bin_array_index(liq_upper);
-    let (lower_idx, upper_idx, effective_liq_lower, effective_liq_upper) =
-        if lower_idx_raw == upper_idx_raw {
-            if amount_x_raw > 0 && amount_y_raw == 0 {
-                // X-only: all bins are >= active_id (upper side). Use the adjacent
-                // lower array as a structural placeholder; min_bin_id stays at active_id.
-                (lower_idx_raw - 1, lower_idx_raw, liq_lower, liq_upper)
-            } else if amount_y_raw > 0 && amount_x_raw == 0 {
-                // Y-only: all bins are in bin_array at upper_idx_raw.
-                // Use (upper_idx_raw - 1) as the structural lower placeholder.
-                // Key: DO NOT use upper_idx_raw + 1 as the placeholder because
-                // that bin array starts at higher bin IDs (above active_id), and
-                // the program might validate bins from it, failing the Y-only check.
-                // With lower=(actual-1), upper=(actual), bins are found in "upper".
-                (upper_idx_raw - 1, upper_idx_raw, liq_lower, liq_upper)
-            } else {
-                // Two-sided: extend liq_lower into previous bin array (clamped to pos_lower),
-                // or liq_upper into the next bin array if that's the only option.
-                let prev_idx = upper_idx_raw - 1;
-                let prev_last_bin = (prev_idx * 70 + 69) as i32;
-                let adj_lower = prev_last_bin.max(pos_lower);
-                let new_lower_idx = meteora_ix::bin_array_index(adj_lower);
-                if new_lower_idx != upper_idx_raw {
-                    (new_lower_idx, upper_idx_raw, adj_lower, liq_upper)
-                } else {
-                    let next_idx = upper_idx_raw + 1;
-                    let next_first_bin = (next_idx * 70) as i32;
-                    let adj_upper = next_first_bin.min(pos_upper);
-                    (lower_idx_raw, meteora_ix::bin_array_index(adj_upper), liq_lower, adj_upper)
-                }
-            }
+    // Edge case: if pos_lower and pos_upper fall in the same bin array (happens when
+    // pos_lower lands exactly at an array boundary so all 70 bins stay in one array),
+    // use the adjacent array on the appropriate side as the structural second account.
+    let pos_lower_arr = meteora_ix::bin_array_index(pos_lower);
+    let pos_upper_arr = meteora_ix::bin_array_index(pos_upper);
+    let (lower_idx, upper_idx) = if pos_lower_arr == pos_upper_arr {
+        if amount_x_raw > 0 && amount_y_raw == 0 {
+            // X-only (bins go up): placeholder is the next-higher array
+            (pos_lower_arr, pos_lower_arr + 1)
         } else {
-            (lower_idx_raw, upper_idx_raw, liq_lower, liq_upper)
-        };
+            // Y-only or two-sided (bins go down / both sides): placeholder is lower
+            (pos_lower_arr - 1, pos_lower_arr)
+        }
+    } else {
+        (pos_lower_arr, pos_upper_arr)
+    };
+    let (effective_liq_lower, effective_liq_upper) = (liq_lower, liq_upper);
     let bin_array_lower = meteora_ix::bin_array_pda(&lb_pair, lower_idx);
     let bin_array_upper = meteora_ix::bin_array_pda(&lb_pair, upper_idx);
     // Precompute ATAs to use as hints for find_token_account

--- a/skills/meteora-plugin/src/commands/remove_liquidity.rs
+++ b/skills/meteora-plugin/src/commands/remove_liquidity.rs
@@ -164,8 +164,14 @@ pub async fn execute(args: &RemoveLiquidityArgs, dry_run: bool) -> anyhow::Resul
         solana_rpc::find_token_account(&client, &wallet_str, &mint_y_str, &ata_y_str).await?;
 
     // ── 5. Derive bin array PDAs ─────────────────────────────────────────────
+    // Derive from the position's stored lower/upper bin IDs (always covers the full
+    // position range). Edge case: if both fall in the same array (position width 70
+    // aligned to boundary), use adjacent array to avoid passing same account twice.
     let lower_idx = meteora_ix::bin_array_index(lower_bin_id);
-    let upper_idx = meteora_ix::bin_array_index(upper_bin_id);
+    let upper_idx = {
+        let idx = meteora_ix::bin_array_index(upper_bin_id);
+        if idx == lower_idx { lower_idx + 1 } else { idx }
+    };
     let bin_array_lower = meteora_ix::bin_array_pda(&lb_pair, lower_idx);
     let bin_array_upper = meteora_ix::bin_array_pda(&lb_pair, upper_idx);
 

--- a/skills/meteora-plugin/src/meteora_ix.rs
+++ b/skills/meteora-plugin/src/meteora_ix.rs
@@ -256,13 +256,9 @@ pub fn ix_add_liquidity_by_strategy(
 /// For X-only: pass user_token_x / reserve_x / token_x_mint, range = [active_id, max_bin_id].
 /// For Y-only: pass user_token_y / reserve_y / token_y_mint, range = [min_bin_id, active_id-1].
 ///
-/// `bin_array_lower` and `bin_array_upper` must satisfy lower.index < upper.index.
-/// When both range bounds fall in the same bin array, pass the adjacent array as the
-/// "other" account — it will not be accessed for out-of-range bins.
-///
-/// Y-only bin array ordering rule: pass (actual_array - 1, actual_array) so that the
-/// real Y bins are in the "upper" account. Using (actual_array, actual_array + 1) fails
-/// because array+1 starts at bins above active_id, causing the program to reject the range.
+/// `bin_array_lower` and `bin_array_upper` must satisfy lower.index < upper.index and
+/// together span the position's FULL bin range (position.lower_bin_id..position.upper_bin_id).
+/// Derive these from pos_lower / pos_upper in the caller, not from the deposit range.
 #[allow(clippy::too_many_arguments)]
 pub fn ix_add_liquidity_by_strategy_one_side(
     position: &Pubkey,


### PR DESCRIPTION
## Summary

- **Root cause**: `add-liquidity` computed bin array PDAs from the 10-bin *deposit* range (`liq_lower`/`liq_upper`). Meteora's DLMM program requires the two bin arrays to span the *position's* full 70-bin range (`pos_lower`..`pos_upper`). For single-sided (X-only/Y-only) deposits the deposit window often falls entirely in one array while the position spans two — passing the wrong array caused error 6030 `Invalid input` / `IncorrectProgramId`.
- **Fix in `add_liquidity.rs`**: Replace 40-line placeholder heuristic with a clean 11-line version that derives `lower_idx`/`upper_idx` from `pos_lower`/`pos_upper`. Edge case: position width 70 aligned to exact array boundary → use adjacent array.
- **Fix in `remove_liquidity.rs`**: Add same edge-case guard (`lower_idx == upper_idx → lower_idx + 1`) to prevent Solana rejecting duplicate account references.

## Test plan

- [x] `add-liquidity --amount-x 0.001 --dry-run` → `bin_array_lower_idx: -89, bin_array_upper_idx: -88` ✓
- [x] `add-liquidity --amount-y 1 --dry-run` → same arrays ✓
- [x] `add-liquidity --amount-x 0.001 --amount-y 1 --dry-run` → same arrays ✓
- [x] `cargo build` succeeds with v0.3.7 ✓
- [x] `git diff okx/main --name-only` shows only `skills/meteora-plugin/` files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)