### PR TITLE
fix(lido-plugin): JSON output for all commands + balance pre-flight checks (v0.2.7)

### DIFF
--- a/skills/lido-plugin/.claude-plugin/plugin.json
+++ b/skills/lido-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lido",
   "description": "Stake ETH with Lido liquid staking protocol to receive stETH",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/lido-plugin/Cargo.lock
+++ b/skills/lido-plugin/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "lido-plugin"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/lido-plugin/Cargo.toml
+++ b/skills/lido-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lido-plugin"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/lido-plugin/SKILL.md
+++ b/skills/lido-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lido-plugin
 description: Stake ETH with Lido liquid staking protocol to receive stETH, manage withdrawals, and track staking rewards. Supports staking, balance queries, withdrawal requests, withdrawal status, and claiming finalized withdrawals on Ethereum mainnet.
-version: "0.2.6"
+version: "0.2.7"
 author: GeoGu360
 ---
 
@@ -18,7 +18,7 @@ author: GeoGu360
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/lido-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.6"
+LOCAL_VER="0.2.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -91,7 +91,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido-plugin@0.2.6/lido-plugin-${TARGET}${EXT}" -o ~/.local/bin/.lido-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/lido-plugin@0.2.7/lido-plugin-${TARGET}${EXT}" -o ~/.local/bin/.lido-plugin-core${EXT}
 chmod +x ~/.local/bin/.lido-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -99,7 +99,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/lido-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.6" > "$HOME/.plugin-store/managed/lido-plugin"
+echo "0.2.7" > "$HOME/.plugin-store/managed/lido-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -119,7 +119,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"lido-plugin","version":"0.2.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"lido-plugin","version":"0.2.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/lido-plugin/plugin.yaml
+++ b/skills/lido-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: lido-plugin
-version: "0.2.6"
+version: "0.2.7"
 description: "Stake ETH with Lido liquid staking protocol — stake, manage withdrawals, and track staking rewards on Ethereum mainnet"
 author:
   name: GeoGu360

--- a/skills/lido-plugin/src/commands/claim_withdrawal.rs
+++ b/skills/lido-plugin/src/commands/claim_withdrawal.rs
@@ -35,12 +35,8 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         anyhow::bail!("Cannot get wallet address. Pass --from or ensure onchainos is logged in.");
     }
 
-    println!("=== Lido Claim Withdrawal ===");
-    println!("From:        {}", wallet);
-    println!("Request IDs: {:?}", args.ids);
-
     // Step 1: getLastCheckpointIndex() -> uint256
-    println!("\nStep 1/3: Getting last checkpoint index...");
+    eprintln!("Step 1/3: Getting last checkpoint index...");
     let checkpoint_calldata = format!("0x{}", config::SEL_GET_LAST_CHECKPOINT_INDEX);
     let checkpoint_result = onchainos::eth_call(
         chain_id,
@@ -54,11 +50,10 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
             anyhow::bail!("Failed to get last checkpoint index: {}", e);
         }
     };
-    println!("Last checkpoint index: {}", last_checkpoint);
+    eprintln!("Last checkpoint index: {}", last_checkpoint);
 
     // Step 2a: getWithdrawalStatus — filter out PENDING / CLAIMED before calling findCheckpointHints.
-    // findCheckpointHints reverts with an opaque error on any non-finalized request ID.
-    println!("Step 2/3: Checking request status...");
+    eprintln!("Step 2/3: Checking request status...");
     let status_calldata = rpc::calldata_get_withdrawal_status(&args.ids);
     let status_result = onchainos::eth_call(
         chain_id,
@@ -98,8 +93,8 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Step 2b: findCheckpointHints(uint256[] requestIds, uint256 firstIndex, uint256 lastIndex)
-    println!("  Finding checkpoint hints...");
+    // Step 2b: findCheckpointHints
+    eprintln!("  Finding checkpoint hints...");
     let hints_calldata =
         rpc::calldata_find_checkpoint_hints(&args.ids, 1, last_checkpoint);
     let hints_result = onchainos::eth_call(
@@ -122,26 +117,37 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
             args.ids.len()
         );
     }
-    println!("Hints: {:?}", hints);
 
     // Step 3: claimWithdrawals(uint256[] requestIds, uint256[] hints)
     let claim_calldata = rpc::calldata_claim_withdrawals(&args.ids, &hints);
 
-    println!("\nStep 3/3: Claiming withdrawals");
-    println!("  Contract:  {}", config::WITHDRAWAL_QUEUE_ADDRESS);
-    println!("  Calldata:  {}", claim_calldata);
-
     if args.dry_run {
-        println!("\n[dry-run] Transaction NOT submitted.");
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "dry_run": true,
+            "action": "claimWithdrawal",
+            "from": wallet,
+            "requestIds": args.ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+            "contract": config::WITHDRAWAL_QUEUE_ADDRESS,
+            "calldata": claim_calldata,
+            "note": "Add --confirm to broadcast"
+        }));
         return Ok(());
     }
 
-    // ── Preview mode: show TX details without broadcasting ──────────────────
-    if !args.confirm && !args.dry_run {
-        println!("=== Transaction Preview (NOT broadcast) ===");
-        println!("Add --confirm to execute this transaction.");
+    if !args.confirm {
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "action": "claimWithdrawal",
+            "from": wallet,
+            "requestIds": args.ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+            "note": "Add --confirm to execute"
+        }));
         return Ok(());
     }
+
+    eprintln!("Step 3/3: Claiming withdrawals...");
     let claim_result = onchainos::wallet_contract_call(
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
@@ -154,8 +160,14 @@ pub async fn run(args: ClaimWithdrawalArgs) -> anyhow::Result<()> {
     .await?;
 
     let tx_hash = onchainos::extract_tx_hash(&claim_result);
-    println!("\nClaim transaction submitted: {}", tx_hash);
-    println!("ETH will be sent to your wallet. The unstETH NFT(s) are burned.");
+    println!("{}", serde_json::json!({
+        "ok": true,
+        "action": "claimWithdrawal",
+        "from": wallet,
+        "requestIds": args.ids.iter().map(|id| id.to_string()).collect::<Vec<_>>(),
+        "txHash": tx_hash,
+        "note": "ETH sent to wallet, unstETH NFT(s) burned"
+    }));
 
     Ok(())
 }

--- a/skills/lido-plugin/src/commands/get_withdrawals.rs
+++ b/skills/lido-plugin/src/commands/get_withdrawals.rs
@@ -35,14 +35,14 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
     };
 
     if ids.is_empty() {
-        println!("No withdrawal requests found for {}", address);
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "address": address,
+            "count": 0,
+            "requests": []
+        }));
         return Ok(());
     }
-
-    println!("=== Lido Withdrawal Requests ===");
-    println!("Address: {}", address);
-    println!("Found {} request(s): {:?}", ids.len(), ids);
-    println!();
 
     // Step 2: getWithdrawalStatus(uint256[]) -> WithdrawalRequestStatus[]
     let status_calldata = rpc::calldata_get_withdrawal_status(&ids);
@@ -55,11 +55,10 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
     // Try to fetch estimated wait times from wq-api
     let wait_times = fetch_wait_times(&ids).await;
 
-    // Print raw status data
+    let mut requests: Vec<serde_json::Value> = Vec::new();
+
     match rpc::extract_return_data(&status_result) {
         Ok(hex) => {
-            println!("Status data (hex): {}", &hex[..hex.len().min(128)], );
-            // Parse each status entry (each is 6 * 32 bytes = 192 bytes = 384 hex chars)
             let hex = hex.trim_start_matches("0x");
             // Skip ABI array header (offset + length = 128 hex chars)
             let data = if hex.len() > 128 { &hex[128..] } else { hex };
@@ -70,41 +69,59 @@ pub async fn run(args: GetWithdrawalsArgs) -> anyhow::Result<()> {
                     break;
                 }
                 let entry = &data[start..start + entry_size];
-                let amount_steth_wei =
-                    u128::from_str_radix(&entry[0..64], 16).unwrap_or(0);
+
+                // EVM-012 fix: propagate parse error instead of silently returning 0
+                let amount_steth_wei = match u128::from_str_radix(&entry[0..64], 16) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("[lido] Warning: failed to decode amountOfStETH for request #{}: {}", id, e);
+                        continue;
+                    }
+                };
                 let amount_steth = amount_steth_wei as f64 / 1e18;
                 let is_finalized = u128::from_str_radix(&entry[4 * 64..5 * 64], 16)
-                    .unwrap_or(0)
-                    != 0;
+                    .unwrap_or(0) != 0;
                 let is_claimed = u128::from_str_radix(&entry[5 * 64..6 * 64], 16)
-                    .unwrap_or(0)
-                    != 0;
+                    .unwrap_or(0) != 0;
 
                 let status = if is_claimed {
                     "CLAIMED"
                 } else if is_finalized {
-                    "READY TO CLAIM"
+                    "READY_TO_CLAIM"
                 } else {
                     "PENDING"
                 };
 
-                print!(
-                    "  Request #{}: {:.6} stETH — {}",
-                    id, amount_steth, status
-                );
-                if let Some(Some(wait)) = wait_times.as_ref().and_then(|w| w.get(i)) {
-                    print!(" (est. wait: {})", wait);
+                let estimated_wait = wait_times
+                    .as_ref()
+                    .and_then(|w| w.get(i))
+                    .and_then(|v| v.as_deref())
+                    .unwrap_or("");
+
+                let mut entry_json = serde_json::json!({
+                    "id": id.to_string(),
+                    "amountStEth": format!("{:.6}", amount_steth),
+                    "amountStEthWei": amount_steth_wei.to_string(),
+                    "status": status
+                });
+                if !estimated_wait.is_empty() {
+                    entry_json["estimatedWait"] = serde_json::Value::String(estimated_wait.to_string());
                 }
-                println!();
+                requests.push(entry_json);
             }
         }
-        Err(_) => {
-            println!("Status: {}", status_result);
+        Err(e) => {
+            anyhow::bail!("Failed to decode withdrawal status: {}", e);
         }
     }
 
-    println!();
-    println!("Use `lido claim-withdrawal --ids <ID1,ID2,...>` to claim finalized requests.");
+    println!("{}", serde_json::json!({
+        "ok": true,
+        "address": address,
+        "count": requests.len(),
+        "requests": requests,
+        "hint": "Use `lido claim-withdrawal --ids <ID1,ID2,...>` to claim finalized requests."
+    }));
 
     Ok(())
 }

--- a/skills/lido-plugin/src/commands/request_withdrawal.rs
+++ b/skills/lido-plugin/src/commands/request_withdrawal.rs
@@ -54,33 +54,57 @@ pub async fn run(args: RequestWithdrawalArgs) -> anyhow::Result<()> {
     // Build requestWithdrawals calldata
     let request_calldata = rpc::calldata_request_withdrawals(&[amount_wei], &wallet);
 
-    println!("=== Lido Request Withdrawal ===");
-    println!("From:        {}", wallet);
-    println!("Amount:      {} stETH ({} wei)", args.amount_eth, amount_wei);
-    println!("Step 1:      Approve stETH to WithdrawalQueueERC721");
-    println!("  Contract:  {}", config::STETH_ADDRESS);
-    println!("  Calldata:  {}", approve_calldata);
-    println!("Step 2:      Submit requestWithdrawals");
-    println!("  Contract:  {}", config::WITHDRAWAL_QUEUE_ADDRESS);
-    println!("  Calldata:  {}", request_calldata);
-    println!();
-    println!(
-        "Warning: Withdrawal finalization typically takes 1-5 days (longer during Bunker mode)."
-    );
-
     if args.dry_run {
-        println!("[dry-run] Transactions NOT submitted.");
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "dry_run": true,
+            "action": "requestWithdrawal",
+            "from": wallet,
+            "amountStEth": format!("{:.6}", args.amount_eth),
+            "amountWei": amount_wei.to_string(),
+            "step1_approve": {
+                "contract": config::STETH_ADDRESS,
+                "calldata": approve_calldata
+            },
+            "step2_request": {
+                "contract": config::WITHDRAWAL_QUEUE_ADDRESS,
+                "calldata": request_calldata
+            },
+            "note": "Add --confirm to broadcast. Withdrawal finalization typically takes 1–5 days."
+        }));
         return Ok(());
     }
 
+    // Pre-flight: stETH balance check (EVM-001)
+    let balance_calldata = rpc::calldata_single_address(config::SEL_BALANCE_OF, &wallet);
+    let balance_result = onchainos::eth_call(chain_id, config::STETH_ADDRESS, &balance_calldata).await
+        .map_err(|e| anyhow::anyhow!("Failed to check stETH balance: {}", e))?;
+    let steth_balance = rpc::extract_return_data(&balance_result)
+        .and_then(|h| rpc::decode_uint256(&h))
+        .map_err(|e| anyhow::anyhow!("Failed to decode stETH balance: {}", e))?;
+    if steth_balance < amount_wei {
+        anyhow::bail!(
+            "Insufficient stETH balance: need {:.6} stETH, have {:.6} stETH.",
+            amount_wei as f64 / 1e18,
+            steth_balance as f64 / 1e18
+        );
+    }
+
     if !args.confirm {
-        println!("=== Transaction Preview (NOT broadcast) ===");
-        println!("Add --confirm to execute this transaction.");
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "action": "requestWithdrawal",
+            "from": wallet,
+            "amountStEth": format!("{:.6}", args.amount_eth),
+            "amountWei": amount_wei.to_string(),
+            "note": "Add --confirm to execute. Withdrawal finalization typically takes 1–5 days."
+        }));
         return Ok(());
     }
 
     // Step 1: Approve stETH spend — must be mined before step 2 can succeed
-    println!("Step 1/2: Approving stETH spend...");
+    eprintln!("Step 1/2: Approving stETH spend...");
     let approve_result = onchainos::wallet_contract_call(
         chain_id,
         config::STETH_ADDRESS,
@@ -92,17 +116,11 @@ pub async fn run(args: RequestWithdrawalArgs) -> anyhow::Result<()> {
     )
     .await?;
     let approve_tx = onchainos::extract_tx_hash_or_err(&approve_result, "Approve")?;
-    println!("Approve tx: {}", approve_tx);
-
-    // Wait for approve to be mined before submitting requestWithdrawals.
-    // The contract checks allowance at execution time, so the approve must
-    // land on-chain first.
-    if args.confirm {
-        onchainos::wait_for_receipt(chain_id, &approve_tx, 120).await?;
-    }
+    eprintln!("Approve tx: {} — waiting for confirmation...", approve_tx);
+    onchainos::wait_for_receipt(chain_id, &approve_tx, 120).await?;
 
     // Step 2: Request withdrawal
-    println!("Step 2/2: Submitting withdrawal request...");
+    eprintln!("Step 2/2: Submitting withdrawal request...");
     let request_result = onchainos::wallet_contract_call(
         chain_id,
         config::WITHDRAWAL_QUEUE_ADDRESS,
@@ -114,15 +132,19 @@ pub async fn run(args: RequestWithdrawalArgs) -> anyhow::Result<()> {
     )
     .await?;
     let request_tx = onchainos::extract_tx_hash_or_err(&request_result, "requestWithdrawals")?;
-    println!("Request tx: {}", request_tx);
+    eprintln!("Request tx: {} — waiting for confirmation...", request_tx);
+    onchainos::wait_for_receipt(chain_id, &request_tx, 120).await?;
 
-    // Verify requestWithdrawals landed on-chain
-    if args.confirm {
-        onchainos::wait_for_receipt(chain_id, &request_tx, 120).await?;
-    }
-    println!();
-    println!("Withdrawal request submitted. You will receive an unstETH NFT (ERC-721).");
-    println!("Use `lido get-withdrawals` to check status.");
+    println!("{}", serde_json::json!({
+        "ok": true,
+        "action": "requestWithdrawal",
+        "from": wallet,
+        "amountStEth": format!("{:.6}", args.amount_eth),
+        "amountWei": amount_wei.to_string(),
+        "approveTxHash": approve_tx,
+        "requestTxHash": request_tx,
+        "note": "Withdrawal request submitted. Use `lido get-withdrawals` to check status. Finalization typically takes 1–5 days."
+    }));
 
     Ok(())
 }

--- a/skills/lido-plugin/src/commands/stake.rs
+++ b/skills/lido-plugin/src/commands/stake.rs
@@ -61,26 +61,48 @@ pub async fn run(args: StakeArgs) -> anyhow::Result<()> {
     // Build calldata: submit(address _referral)
     let calldata = format!("0x{}{}", config::SEL_SUBMIT, referral_padded);
 
-    println!("=== Lido Stake ===");
-    println!("From:        {}", wallet);
-    println!("Amount:      {} ETH ({} wei)", args.amount_eth, amount_wei);
-    println!("Referral:    {}", referral);
-    println!("Contract:    {}", config::STETH_ADDRESS);
-    println!("Calldata:    {}", calldata);
-    println!();
-
     if args.dry_run {
-        println!("[dry-run] Transaction NOT submitted.");
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "dry_run": true,
+            "action": "stake",
+            "from": wallet,
+            "amountEth": format!("{:.6}", args.amount_eth),
+            "amountWei": amount_wei.to_string(),
+            "referral": referral,
+            "contract": config::STETH_ADDRESS,
+            "calldata": calldata,
+            "note": "Add --confirm to broadcast"
+        }));
         return Ok(());
     }
 
-    println!("Submitting stake transaction...");
-    // ── Preview mode: show TX details without broadcasting ──────────────────
-    if !args.confirm && !args.dry_run {
-        println!("=== Transaction Preview (NOT broadcast) ===");
-        println!("Add --confirm to execute this transaction.");
+    // Pre-flight: ETH balance check (EVM-001)
+    let eth_balance = onchainos::eth_get_balance(&wallet, chain_id).await
+        .map_err(|e| anyhow::anyhow!("Failed to check ETH balance: {}", e))?;
+    if eth_balance < amount_wei {
+        anyhow::bail!(
+            "Insufficient ETH balance: need {:.6} ETH, have {:.6} ETH.",
+            amount_wei as f64 / 1e18,
+            eth_balance as f64 / 1e18
+        );
+    }
+
+    if !args.confirm {
+        println!("{}", serde_json::json!({
+            "ok": true,
+            "preview": true,
+            "action": "stake",
+            "from": wallet,
+            "amountEth": format!("{:.6}", args.amount_eth),
+            "amountWei": amount_wei.to_string(),
+            "referral": referral,
+            "stEthExpected": format!("~{:.6}", args.amount_eth),
+            "note": "Add --confirm to execute"
+        }));
         return Ok(());
     }
+
     let result = onchainos::wallet_contract_call(
         chain_id,
         config::STETH_ADDRESS,
@@ -93,11 +115,16 @@ pub async fn run(args: StakeArgs) -> anyhow::Result<()> {
     .await?;
 
     let tx_hash = onchainos::extract_tx_hash(&result);
-    println!("Transaction submitted: {}", tx_hash);
-    println!(
-        "You will receive approximately {} stETH. Balance grows daily via rebase.",
-        args.amount_eth
-    );
+    println!("{}", serde_json::json!({
+        "ok": true,
+        "action": "stake",
+        "from": wallet,
+        "amountEth": format!("{:.6}", args.amount_eth),
+        "amountWei": amount_wei.to_string(),
+        "txHash": tx_hash,
+        "stEthExpected": format!("~{:.6}", args.amount_eth),
+        "note": "stETH balance grows daily via rebase"
+    }));
 
     Ok(())
 }

--- a/skills/lido-plugin/src/onchainos.rs
+++ b/skills/lido-plugin/src/onchainos.rs
@@ -142,6 +142,34 @@ pub async fn wait_for_receipt(chain_id: u64, tx_hash: &str, timeout_secs: u64) -
     )
 }
 
+/// Query native ETH balance via eth_getBalance JSON-RPC.
+pub async fn eth_get_balance(address: &str, chain_id: u64) -> anyhow::Result<u128> {
+    let rpc_url = match chain_id {
+        1 => "https://ethereum.publicnode.com",
+        _ => anyhow::bail!("Unsupported chain_id for eth_getBalance: {}", chain_id),
+    };
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [address, "latest"],
+        "id": 1
+    });
+    let client = reqwest::Client::new();
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    if let Some(err) = resp.get("error") {
+        anyhow::bail!("eth_getBalance RPC error: {}", err);
+    }
+    let hex = resp["result"].as_str().unwrap_or("0x0");
+    let hex = hex.trim_start_matches("0x");
+    Ok(u128::from_str_radix(hex, 16).unwrap_or(0))
+}
+
 pub fn extract_tx_hash(result: &Value) -> &str {
     result["data"]["txHash"]
         .as_str()


### PR DESCRIPTION
## Summary

Step 1.5 full-codebase scan on lido-plugin found three categories of pre-existing issues in commands shipped with v0.2.6. This PR fixes all of them:

- **EVM-002 (JSON output)**: `stake`, `request-withdrawal`, `claim-withdrawal`, `get-withdrawals` previously output plain `println!` text — agent-unreadable. All now output structured JSON to stdout; progress messages (approve wait, checkpoint steps) moved to stderr.
- **EVM-001 (pre-flight balance check)**: `stake` now checks ETH balance before submitting; `request-withdrawal` now checks stETH balance before approve. Both bail with a clear human-readable error if funds are insufficient.
- **EVM-012 (unwrap_or(0) fix)**: `get-withdrawals` silently showed 0 stETH when ABI decode failed for `amountOfStETH`. Now logs a warning and skips the entry instead.
- Added `eth_get_balance` helper to `onchainos.rs` for native ETH balance queries via `eth_getBalance` JSON-RPC.

## Test plan

- [ ] `lido stake --amount-eth 0.1 --dry-run` → JSON with `dry_run: true`, calldata visible
- [ ] `lido stake --amount-eth 9999 --confirm` → fails with "Insufficient ETH balance" before broadcast
- [ ] `lido request-withdrawal --amount-eth 0.1 --dry-run` → JSON with step1/step2 calldatas
- [ ] `lido claim-withdrawal --ids 12345 --dry-run` → JSON with claimWithdrawals calldata
- [ ] `lido get-withdrawals` → JSON array with `id`, `amountStEth`, `amountStEthWei`, `status` per entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)