### PR TITLE
fix(polymarket-plugin): add --all batch redeem with on-chain confirmation wait (v0.4.7)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.4",
+  "version": "0.4.7",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit, BTC 5分钟, ETH 5分钟, 5分钟市场, 5min market, 五分钟市场, 短线市场, list 5-minute, BTC up or down, 找5分钟, 看5分钟, 5m updown, crypto 5m, 5分钟涨跌, 五分钟涨跌, updown market, BTC 5min, ETH 5min, SOL 5min, 5分钟预测."
-version: "0.4.6"
+version: "0.4.7"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.6"
+LOCAL_VER="0.4.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.6/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.7/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -309,7 +309,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket-plugin --version
 ```
 
-Expected: `polymarket-plugin 0.4.6`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket-plugin 0.4.7`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -730,45 +730,51 @@ polymarket cancel --all
 
 ### `redeem` — Redeem Winning Outcome Tokens
 
-After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. The binary automatically detects which wallet (EOA or proxy) holds the winning tokens by querying the Data API, then calls the correct redemption path for each wallet. No manual mode selection needed.
+After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. The binary automatically detects which wallet (EOA or proxy) holds the winning tokens by querying the Data API, then calls the correct redemption path for each wallet. Each tx is confirmed on-chain before returning. No manual mode selection needed.
 
 ```
 polymarket redeem --market-id <condition_id_or_slug>
-polymarket redeem --market-id <condition_id_or_slug> --dry-run
+polymarket redeem --all
+polymarket redeem --all --dry-run
 ```
 
 **Flags:**
 | Flag | Description |
 |------|-------------|
-| `--market-id` | Market to redeem from: condition_id (0x-prefixed) or slug |
-| `--dry-run` | Preview the redemption (shows wallets and call details) without submitting any transaction |
+| `--market-id` | Market to redeem from: condition_id (0x-prefixed) or slug. Omit when using `--all`. |
+| `--all` | Discover and redeem **all** redeemable positions across EOA and proxy wallets in one pass, sequentially with on-chain confirmation between each. |
+| `--dry-run` | Preview without submitting: shows which wallets/markets will be redeemed |
 
 **Auth required:** onchainos wallet (for signing the on-chain tx). No CLOB credentials needed.
 
 **Not supported:** `neg_risk: true` (multi-outcome) markets — use the Polymarket web UI for those.
 
 **Wallet routing (automatic):**
-- EOA has winning tokens → direct `redeemPositions` from EOA
-- Proxy has winning tokens → `PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])`
-- Both wallets have tokens → both txs submitted, one `eoa_tx` + one `proxy_tx`
+- EOA has winning tokens → direct `redeemPositions` from EOA, waits for confirmation
+- Proxy has winning tokens → `PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])`, waits for confirmation
+- Both wallets have tokens → EOA tx confirmed first, then proxy tx
 - Data API lag (nothing redeemable yet) → fallback EOA redeem with a warning
 
-**Output fields on success:** `condition_id`, `question`, `note`, and one or both of:
+**Output fields — single market (`--market-id`):** `condition_id`, `question`, `note`, and one or both of:
 - `eoa_tx` + `eoa_note` (if EOA held winning tokens)
 - `proxy_tx` + `proxy_note` (if proxy held winning tokens)
 
+**Output fields — batch (`--all`):** `redeemed_count`, `error_count`, `results` (array of per-market results above), `errors`
+
 **Agent flow:**
-1. Resolve `--market-id` to a condition_id and check `neg_risk` (auto from market lookup)
-2. Offer `--dry-run` first to show the user which wallets will be used
-3. After user confirms, run without `--dry-run` to submit the tx(s)
-4. Return the tx hash(es) — USDC.e lands in the respective wallet once tx confirms on Polygon (~seconds)
+1. If user has multiple resolved positions, prefer `--all` to clear everything in one command
+2. For a specific market, use `--market-id`; offer `--dry-run` first to confirm wallets
+3. Each tx waits for on-chain confirmation — USDC.e lands before the command returns
 
 **Example:**
 ```bash
-# Preview first (shows eoa_wallet + proxy_wallet addresses)
-polymarket redeem --market-id will-trump-win-2024 --dry-run
+# Redeem everything at once (recommended)
+polymarket redeem --all
 
-# After user confirms:
+# Preview batch redeem
+polymarket redeem --all --dry-run
+
+# Single market
 polymarket redeem --market-id will-trump-win-2024
 ```
 
@@ -1048,7 +1054,8 @@ User wants to trade:
 | Cancel a specific order | `polymarket cancel --order-id <0x...>` |
 | Cancel all orders for market | `polymarket cancel --market <condition_id>` |
 | Cancel all open orders | `polymarket cancel --all` |
-| Redeem winning tokens after market resolves | `polymarket redeem --market-id <slug_or_condition_id>` |
+| Redeem all redeemable positions at once | `polymarket redeem --all` |
+| Redeem a specific market | `polymarket redeem --market-id <slug_or_condition_id>` |
 
 ---
 

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.6"
+version: "0.4.7"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/redeem.rs
+++ b/skills/polymarket-plugin/src/commands/redeem.rs
@@ -3,94 +3,67 @@ use reqwest::Client;
 
 use crate::api::{get_clob_market, get_gamma_market_by_slug, get_positions};
 use crate::config::load_credentials;
-use crate::onchainos::{ctf_redeem_positions, ctf_redeem_via_proxy, get_wallet_address};
+use crate::onchainos::{
+    ctf_redeem_positions, ctf_redeem_via_proxy, get_wallet_address, wait_for_tx_receipt,
+};
 
-/// Run the redeem command.
-///
-/// Automatically determines which wallet (EOA / proxy) holds the winning outcome tokens
-/// by querying the Data API, then submits the correct redeemPositions path for each.
-///
-/// This handles all four cases correctly regardless of the current trading mode setting:
-///   - Tokens in EOA only          → EOA direct redeem
-///   - Tokens in proxy only        → proxy redeem via PROXY_FACTORY
-///   - Tokens in both              → both redeems submitted
-///   - Data API lag / no positions → fallback to EOA redeem with a warning
-pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
-    let client = Client::new();
-
-    // Resolve condition_id and check neg_risk
-    let (condition_id, neg_risk, question) = if market_id.starts_with("0x") {
-        let m = get_clob_market(&client, market_id).await?;
+/// Resolve (condition_id, neg_risk, question) from a market_id (condition_id or slug).
+async fn resolve_market(client: &Client, market_id: &str) -> Result<(String, bool, String)> {
+    if market_id.starts_with("0x") {
+        let m = get_clob_market(client, market_id).await?;
         let q = m.question.unwrap_or_default();
-        (m.condition_id, m.neg_risk, q)
+        Ok((m.condition_id, m.neg_risk, q))
     } else {
-        let m = get_gamma_market_by_slug(&client, market_id).await?;
+        let m = get_gamma_market_by_slug(client, market_id).await?;
         let cid = m
             .condition_id
             .ok_or_else(|| anyhow::anyhow!("market has no conditionId: {}", market_id))?;
         let q = m.question.unwrap_or_default();
-        // Get authoritative neg_risk from CLOB (same fix as buy/sell)
-        let neg_risk = match get_clob_market(&client, &cid).await {
+        let neg_risk = match get_clob_market(client, &cid).await {
             Ok(clob) => clob.neg_risk,
             Err(_) => m.neg_risk,
         };
-        (cid, neg_risk, q)
-    };
-
-    if neg_risk {
-        bail!(
-            "redeem is not supported for neg_risk (multi-outcome) markets — use the Polymarket web UI to redeem positions in this market"
-        );
+        Ok((cid, neg_risk, q))
     }
+}
 
+/// Core redeem logic for a single condition_id.
+///
+/// Checks which wallet(s) hold redeemable tokens via the Data API, submits the
+/// appropriate tx(es), and waits for each to confirm on-chain before returning.
+///
+/// Returns a JSON Value summarising the result (for use in both single and batch flows).
+async fn redeem_one(
+    client: &Client,
+    condition_id: &str,
+    question: &str,
+    eoa_addr: &str,
+    proxy_addr: Option<&str>,
+) -> Result<serde_json::Value> {
     let cid_hex = condition_id.trim_start_matches("0x");
     let cid_display = format!("0x{}", cid_hex);
 
-    // Resolve EOA and proxy wallet addresses
-    let eoa_addr  = get_wallet_address().await?;
-    let creds     = load_credentials().unwrap_or_default();
-    let proxy_addr = creds.and_then(|c| c.proxy_wallet);
-
-    if dry_run {
-        let out = serde_json::json!({
-            "ok": true,
-            "data": {
-                "dry_run": true,
-                "market_id": market_id,
-                "condition_id": cid_display,
-                "question": question,
-                "neg_risk": false,
-                "eoa_wallet": eoa_addr,
-                "proxy_wallet": proxy_addr,
-                "action": "redeemPositions",
-                "index_sets": [1, 2],
-                "note": "dry-run: will redeem from whichever wallet (EOA / proxy) holds the winning tokens, regardless of current trading mode."
-            }
-        });
-        println!("{}", serde_json::to_string_pretty(&out)?);
-        return Ok(());
-    }
-
-    // Determine which wallet(s) have redeemable positions for this condition_id.
-    // We check the Data API for each address independently — this is correct regardless
-    // of the current trading mode setting, since the mode may have changed after the order.
     let eoa_redeemable = {
-        let positions = get_positions(&client, &eoa_addr).await.unwrap_or_default();
+        let positions = get_positions(client, eoa_addr).await.unwrap_or_default();
         let has = positions.iter().any(|p| {
-            (p.condition_id.as_deref() == Some(&condition_id)
+            (p.condition_id.as_deref() == Some(condition_id)
                 || p.condition_id.as_deref() == Some(&cid_display))
                 && p.redeemable
         });
-        // Also warn if EOA positions exist but have no value (resolved against us)
         if !has {
-            let lost: f64 = positions.iter()
-                .filter(|p| p.condition_id.as_deref() == Some(&condition_id)
-                    || p.condition_id.as_deref() == Some(&cid_display))
+            let lost: f64 = positions
+                .iter()
+                .filter(|p| {
+                    p.condition_id.as_deref() == Some(condition_id)
+                        || p.condition_id.as_deref() == Some(&cid_display)
+                })
                 .map(|p| p.current_value.unwrap_or(0.0))
                 .sum();
-            if lost < 0.000_001 && positions.iter().any(|p|
-                p.condition_id.as_deref() == Some(&condition_id)
-                || p.condition_id.as_deref() == Some(&cid_display))
+            if lost < 0.000_001
+                && positions.iter().any(|p| {
+                    p.condition_id.as_deref() == Some(condition_id)
+                        || p.condition_id.as_deref() == Some(&cid_display)
+                })
             {
                 eprintln!(
                     "[polymarket] Note: EOA has positions for this market but current_value ≈ $0 \
@@ -101,10 +74,10 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
         has
     };
 
-    let proxy_redeemable = if let Some(ref proxy) = proxy_addr {
-        let positions = get_positions(&client, proxy).await.unwrap_or_default();
+    let proxy_redeemable = if let Some(proxy) = proxy_addr {
+        let positions = get_positions(client, proxy).await.unwrap_or_default();
         positions.iter().any(|p| {
-            (p.condition_id.as_deref() == Some(&condition_id)
+            (p.condition_id.as_deref() == Some(condition_id)
                 || p.condition_id.as_deref() == Some(&cid_display))
                 && p.redeemable
         })
@@ -112,59 +85,214 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
         false
     };
 
-    // If Data API shows nothing redeemable in either wallet, fall back to EOA redeem.
-    // The API can lag after resolution — we still attempt rather than blocking the user.
+    let mut out = serde_json::json!({
+        "condition_id": cid_display,
+        "question": question,
+    });
+
+    // Fallback: if Data API shows nothing (can lag after resolution), attempt EOA redeem.
     if !eoa_redeemable && !proxy_redeemable {
         eprintln!(
-            "[polymarket] Warning: Data API shows no redeemable positions for {} in EOA or proxy wallet \
-             (API may lag after market resolution). Attempting EOA redeem as fallback.",
+            "[polymarket] Warning: Data API shows no redeemable positions for {} \
+             (may lag after resolution). Attempting EOA redeem as fallback.",
             cid_display
         );
-        let tx_hash = ctf_redeem_positions(&condition_id).await?;
-        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
-            "ok": true,
-            "data": {
-                "condition_id": cid_display,
-                "question": question,
-                "eoa_tx": tx_hash,
-                "source": "fallback_eoa",
-                "note": "EOA redeemPositions submitted (fallback — Data API showed no positions). USDC.e arrives once tx confirms."
-            }
-        }))?);
-        return Ok(());
+        let tx_hash = ctf_redeem_positions(condition_id).await?;
+        eprintln!("[polymarket] Waiting for EOA redeem tx to confirm...");
+        wait_for_tx_receipt(&tx_hash, 120).await?;
+        out["eoa_tx"] = serde_json::Value::String(tx_hash);
+        out["source"] = serde_json::Value::String("fallback_eoa".into());
+        out["note"] = serde_json::Value::String(
+            "EOA redeemPositions confirmed (fallback).".into(),
+        );
+        return Ok(out);
     }
-
-    // Execute the correct path(s) based on actual token ownership
-    let mut out = serde_json::json!({
-        "ok": true,
-        "data": {
-            "condition_id": cid_display,
-            "question": question,
-        }
-    });
 
     if eoa_redeemable {
         eprintln!("[polymarket] EOA has winning tokens — submitting EOA redeemPositions...");
-        let tx = ctf_redeem_positions(&condition_id).await?;
-        out["data"]["eoa_tx"]   = serde_json::Value::String(tx);
-        out["data"]["eoa_note"] = serde_json::Value::String(
-            "EOA redeemPositions submitted.".into()
-        );
+        let tx = ctf_redeem_positions(condition_id).await?;
+        eprintln!("[polymarket] Waiting for EOA redeem tx to confirm...");
+        wait_for_tx_receipt(&tx, 120).await?;
+        out["eoa_tx"] = serde_json::Value::String(tx);
+        out["eoa_note"] =
+            serde_json::Value::String("EOA redeemPositions confirmed.".into());
     }
 
     if proxy_redeemable {
-        eprintln!("[polymarket] Proxy has winning tokens — submitting proxy redeemPositions via PROXY_FACTORY...");
-        let tx = ctf_redeem_via_proxy(&condition_id).await?;
-        out["data"]["proxy_tx"]   = serde_json::Value::String(tx);
-        out["data"]["proxy_note"] = serde_json::Value::String(
-            "Proxy redeemPositions submitted via PROXY_FACTORY.".into()
+        eprintln!(
+            "[polymarket] Proxy has winning tokens — submitting proxy redeemPositions via PROXY_FACTORY..."
+        );
+        let tx = ctf_redeem_via_proxy(condition_id).await?;
+        eprintln!("[polymarket] Waiting for proxy redeem tx to confirm...");
+        wait_for_tx_receipt(&tx, 120).await?;
+        out["proxy_tx"] = serde_json::Value::String(tx);
+        out["proxy_note"] = serde_json::Value::String(
+            "Proxy redeemPositions confirmed via PROXY_FACTORY.".into(),
         );
     }
 
-    out["data"]["note"] = serde_json::Value::String(
-        "USDC.e will be transferred to the respective wallet(s) once tx(s) confirm on Polygon.".into()
+    out["note"] = serde_json::Value::String(
+        "USDC.e transferred to the respective wallet(s).".into(),
+    );
+    Ok(out)
+}
+
+/// Redeem a single market by market_id (condition_id or slug).
+pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
+    let client = Client::new();
+    let (condition_id, neg_risk, question) = resolve_market(&client, market_id).await?;
+
+    if neg_risk {
+        bail!(
+            "redeem is not supported for neg_risk (multi-outcome) markets — \
+             use the Polymarket web UI to redeem positions in this market"
+        );
+    }
+
+    let cid_display = format!("0x{}", condition_id.trim_start_matches("0x"));
+    let eoa_addr = get_wallet_address().await?;
+    let creds = load_credentials().unwrap_or_default();
+    let proxy_addr = creds.and_then(|c| c.proxy_wallet);
+
+    if dry_run {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "data": {
+                    "dry_run": true,
+                    "market_id": market_id,
+                    "condition_id": cid_display,
+                    "question": question,
+                    "neg_risk": false,
+                    "eoa_wallet": eoa_addr,
+                    "proxy_wallet": proxy_addr,
+                    "action": "redeemPositions",
+                    "index_sets": [1, 2],
+                    "note": "dry-run: will redeem from whichever wallet (EOA / proxy) holds the winning tokens."
+                }
+            }))?
+        );
+        return Ok(());
+    }
+
+    let result = redeem_one(&client, &condition_id, &question, &eoa_addr, proxy_addr.as_deref()).await?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({ "ok": true, "data": result }))?
+    );
+    Ok(())
+}
+
+/// Redeem ALL redeemable positions across EOA and proxy wallets in one pass.
+///
+/// Discovers redeemable condition_ids from both wallets via the Data API, then
+/// redeems each sequentially, waiting for on-chain confirmation between markets.
+pub async fn run_all(dry_run: bool) -> Result<()> {
+    let client = Client::new();
+    let eoa_addr = get_wallet_address().await?;
+    let creds = load_credentials().unwrap_or_default();
+    let proxy_addr = creds.and_then(|c| c.proxy_wallet);
+
+    // Collect all unique redeemable condition_ids from both wallets.
+    let mut redeemable: Vec<(String, String)> = Vec::new(); // (condition_id, title)
+
+    let eoa_positions = get_positions(&client, &eoa_addr).await.unwrap_or_default();
+    for p in &eoa_positions {
+        if p.redeemable {
+            if let Some(cid) = &p.condition_id {
+                let title = p.title.clone().unwrap_or_default();
+                if !redeemable.iter().any(|(c, _)| c == cid) {
+                    redeemable.push((cid.clone(), title));
+                }
+            }
+        }
+    }
+
+    if let Some(ref proxy) = proxy_addr {
+        let proxy_positions = get_positions(&client, proxy).await.unwrap_or_default();
+        for p in &proxy_positions {
+            if p.redeemable {
+                if let Some(cid) = &p.condition_id {
+                    let title = p.title.clone().unwrap_or_default();
+                    if !redeemable.iter().any(|(c, _)| c == cid) {
+                        redeemable.push((cid.clone(), title));
+                    }
+                }
+            }
+        }
+    }
+
+    if redeemable.is_empty() {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "data": {
+                    "message": "No redeemable positions found.",
+                    "redeemed_count": 0
+                }
+            }))?
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "[polymarket] Found {} redeemable position(s). Redeeming sequentially...",
+        redeemable.len()
     );
 
-    println!("{}", serde_json::to_string_pretty(&out)?);
+    if dry_run {
+        let items: Vec<_> = redeemable
+            .iter()
+            .map(|(cid, title)| serde_json::json!({ "condition_id": cid, "title": title }))
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "data": {
+                    "dry_run": true,
+                    "redeemable_count": items.len(),
+                    "positions": items,
+                    "note": "dry-run: would redeem each position sequentially, waiting for on-chain confirmation between each."
+                }
+            }))?
+        );
+        return Ok(());
+    }
+
+    let mut results = Vec::new();
+    let mut errors = Vec::new();
+
+    for (i, (cid, title)) in redeemable.iter().enumerate() {
+        eprintln!(
+            "[polymarket] [{}/{}] Redeeming: {}",
+            i + 1,
+            redeemable.len(),
+            title
+        );
+        match redeem_one(&client, cid, title, &eoa_addr, proxy_addr.as_deref()).await {
+            Ok(r) => results.push(r),
+            Err(e) => {
+                eprintln!("[polymarket] Error redeeming {}: {}", cid, e);
+                errors.push(serde_json::json!({ "condition_id": cid, "error": e.to_string() }));
+            }
+        }
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "ok": errors.is_empty(),
+            "data": {
+                "redeemed_count": results.len(),
+                "error_count": errors.len(),
+                "results": results,
+                "errors": errors,
+                "note": "USDC.e transferred to respective wallet(s) for all confirmed redemptions."
+            }
+        }))?
+    );
     Ok(())
 }

--- a/skills/polymarket-plugin/src/main.rs
+++ b/skills/polymarket-plugin/src/main.rs
@@ -242,9 +242,13 @@ enum Commands {
 
     /// Redeem winning outcome tokens after a market resolves (signs via onchainos wallet)
     Redeem {
-        /// Market identifier: condition_id (0x-prefixed hex) or slug
+        /// Market identifier: condition_id (0x-prefixed hex) or slug. Omit when using --all.
         #[arg(long)]
-        market_id: String,
+        market_id: Option<String>,
+
+        /// Redeem all redeemable positions across EOA and proxy wallets in one pass
+        #[arg(long)]
+        all: bool,
 
         /// Preview the redemption call without submitting the transaction
         #[arg(long)]
@@ -348,8 +352,15 @@ async fn main() {
         Commands::SwitchMode { mode } => {
             commands::switch_mode::run(&mode).await
         }
-        Commands::Redeem { market_id, dry_run } => {
-            commands::redeem::run(&market_id, dry_run).await
+        Commands::Redeem { market_id, all, dry_run } => {
+            if all {
+                commands::redeem::run_all(dry_run).await
+            } else if let Some(mid) = market_id {
+                commands::redeem::run(&mid, dry_run).await
+            } else {
+                eprintln!("Error: provide --market-id <ID> or --all");
+                std::process::exit(1);
+            }
         }
         Commands::Cancel { order_id, market, all } => {
             if all {


### PR DESCRIPTION
## Summary

- **Root cause**: `redeem` submitted tx and returned immediately without waiting for on-chain confirmation. This caused the Data API to still show positions as `redeemable: true` on the next run (tx not yet confirmed), requiring multiple manual invocations to fully clear positions.
- **Fix 1**: Add `wait_for_tx_receipt` to all three redeem paths (EOA, proxy via PROXY_FACTORY, fallback EOA) — each tx is now confirmed on-chain before the command returns.
- **Fix 2**: Add `redeem --all` flag — discovers all redeemable positions across EOA and proxy wallets via Data API and redeems them sequentially in one invocation.

## Changes

- `src/commands/redeem.rs`: extract `resolve_market()` + `redeem_one()` helpers; add `wait_for_tx_receipt` to every tx path; add `run_all()` for batch redemption
- `src/main.rs`: `--market-id` becomes optional, add `--all` flag
- `SKILL.md`: document `--all` flag, updated output fields and Agent flow
- Version bump: `0.4.6 → 0.4.7`

## Test plan

- [x] `redeem --all --dry-run` — correctly discovers redeemable positions
- [x] `redeem --all` — redeemed 1 proxy position in single invocation, tx confirmed on-chain (`0x45735c1114b27a4e16521d8c6becaa5e33ecec85f50641e223eba77dece5ef94`), position cleared from Data API
- [x] `get-positions` after redeem — position count dropped, no redeemable entries remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)