### PR TITLE
fix(pancakeswap-v3-plugin): replace sleep with receipt polling, fix u256 decode (v1.0.3)

### DIFF
--- a/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/pancakeswap-v3-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pancakeswap-v3",
   "description": "Swap tokens and manage liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {"name": "GeoGu360", "github": "GeoGu360"},
   "homepage": "https://github.com/okx/plugin-store/tree/main/skills/pancakeswap-v3",
   "repository": "https://github.com/okx/plugin-store",

--- a/skills/pancakeswap-v3-plugin/Cargo.lock
+++ b/skills/pancakeswap-v3-plugin/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "pancakeswap-v3-plugin"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/pancakeswap-v3-plugin/Cargo.toml
+++ b/skills/pancakeswap-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pancakeswap-v3-plugin"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/pancakeswap-v3-plugin/SKILL.md
+++ b/skills/pancakeswap-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pancakeswap-v3-plugin
 description: "Swap tokens and manage liquidity on PancakeSwap V3 on Ethereum, BNB Chain, Base, Arbitrum, and Linea"
-version: "1.0.2"
+version: "1.0.3"
 author: "GeoGu360"
 tags:
   - dex
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pancakeswap-v3-plugin"
 CACHE_MAX=3600
-LOCAL_VER="1.0.2"
+LOCAL_VER="1.0.3"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.2/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pancakeswap-v3-plugin@1.0.3/pancakeswap-v3-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 chmod +x ~/.local/bin/.pancakeswap-v3-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/pancakeswap-v3-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "1.0.2" > "$HOME/.plugin-store/managed/pancakeswap-v3-plugin"
+echo "1.0.3" > "$HOME/.plugin-store/managed/pancakeswap-v3-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"pancakeswap-v3-plugin","version":"1.0.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/pancakeswap-v3-plugin/plugin.yaml
+++ b/skills/pancakeswap-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pancakeswap-v3-plugin
-version: "1.0.2"
+version: "1.0.3"
 description: "Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain, Base, and Arbitrum"
 author:
   name: GeoGu360

--- a/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/add_liquidity.rs
@@ -167,9 +167,10 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         println!("  [dry-run] onchainos wallet contract-call --chain {} --to {} --input-data {}", args.chain, token0, approve0_calldata);
     } else {
         let r = crate::onchainos::wallet_contract_call(args.chain, token0, &approve0_calldata, None, None, args.dry_run, args.confirm).await?;
-        println!("  Approve tx: {}", crate::onchainos::extract_tx_hash(&r));
-        // Wait for nonce to settle before next sequential transaction
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let approve0_hash = crate::onchainos::extract_tx_hash(&r).to_string();
+        eprintln!("  Approve {} tx: {} — waiting for confirmation...", sym0, approve0_hash);
+        crate::onchainos::wait_and_check_receipt(&approve0_hash, cfg.rpc_url).await
+            .map_err(|e| anyhow::anyhow!("{} approve did not confirm: {}", sym0, e))?;
     }
 
     // Step 2: Approve token1 for NPM
@@ -181,9 +182,10 @@ pub async fn run(args: AddLiquidityArgs) -> Result<()> {
         println!("  [dry-run] onchainos wallet contract-call --chain {} --to {} --input-data {}", args.chain, token1, approve1_calldata);
     } else {
         let r = crate::onchainos::wallet_contract_call(args.chain, token1, &approve1_calldata, None, None, args.dry_run, args.confirm).await?;
-        println!("  Approve tx: {}", crate::onchainos::extract_tx_hash(&r));
-        // Wait for nonce to settle before mint
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let approve1_hash = crate::onchainos::extract_tx_hash(&r).to_string();
+        eprintln!("  Approve {} tx: {} — waiting for confirmation...", sym1, approve1_hash);
+        crate::onchainos::wait_and_check_receipt(&approve1_hash, cfg.rpc_url).await
+            .map_err(|e| anyhow::anyhow!("{} approve did not confirm: {}", sym1, e))?;
     }
 
     // Step 3: Mint position

--- a/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/remove_liquidity.rs
@@ -109,9 +109,10 @@ pub async fn run(args: RemoveLiquidityArgs) -> Result<()> {
         println!("  [dry-run] onchainos wallet contract-call --chain {} --to {} --input-data {}", args.chain, cfg.npm, decrease_calldata);
     } else {
         let r = crate::onchainos::wallet_contract_call(args.chain, cfg.npm, &decrease_calldata, None, None, args.dry_run, args.confirm).await?;
-        println!("  decreaseLiquidity tx: {}", crate::onchainos::extract_tx_hash(&r));
-        // Wait for nonce to settle before collect
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let decrease_hash = crate::onchainos::extract_tx_hash(&r).to_string();
+        eprintln!("  decreaseLiquidity tx: {} — waiting for confirmation...", decrease_hash);
+        crate::onchainos::wait_and_check_receipt(&decrease_hash, cfg.rpc_url).await
+            .map_err(|e| anyhow::anyhow!("decreaseLiquidity did not confirm: {}", e))?;
     }
 
     // Step 2: collect — MUST always follow decreaseLiquidity

--- a/skills/pancakeswap-v3-plugin/src/commands/swap.rs
+++ b/skills/pancakeswap-v3-plugin/src/commands/swap.rs
@@ -131,7 +131,11 @@ pub async fn run(args: SwapArgs) -> Result<()> {
 
     // Check existing allowance to avoid unnecessary approve (prevents nonce conflicts)
     let allowance = crate::rpc::get_allowance(&from_addr, &wallet_addr, cfg.smart_router, cfg.rpc_url)
-        .await.unwrap_or(0);
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("  [warn] allowance check failed ({}), proceeding with approve.", e);
+            0
+        });
     if allowance >= amount_in {
         println!("  Allowance already sufficient ({}), skipping approve.", allowance);
     } else {

--- a/skills/pancakeswap-v3-plugin/src/rpc.rs
+++ b/skills/pancakeswap-v3-plugin/src/rpc.rs
@@ -179,7 +179,7 @@ pub async fn get_slot0(pool: &str, rpc_url: &str) -> Result<(u128, i32)> {
     let sqrt_price_hex = &raw[0..64];
     let tick_hex = &raw[64..128];
 
-    let sqrt_price = u128::from_str_radix(sqrt_price_hex, 16).unwrap_or(0);
+    let sqrt_price = decode_u256_from_hex(sqrt_price_hex);
 
     // tick is int24, ABI-padded to 32 bytes (64 hex chars) as int256.
     // Negative ticks have all high bytes set to 0xFF — u128::from_str_radix
@@ -220,7 +220,7 @@ pub async fn quote_exact_input_single(
         anyhow::bail!("QuoterV2 returned empty/short result — pool may not exist or fee tier mismatch");
     }
     // amountOut is the first 32 bytes of the return
-    let amount_out = u128::from_str_radix(&raw[0..64], 16).unwrap_or(0);
+    let amount_out = decode_u256_from_hex(&raw[0..64]);
     Ok(amount_out)
 }
 


### PR DESCRIPTION
## Summary

- **EVM-006** (`add-liquidity`): `sleep(5s)` after token0 and token1 approve → `wait_and_check_receipt()` receipt polling. Fixes user-reported `STF` revert caused by approve not yet mined when mint tx was submitted.
- **EVM-006** (`remove-liquidity`): `sleep(5s)` after `decreaseLiquidity` → `wait_and_check_receipt()`. Prevents `collect` submitting before decrease confirmed.
- **EVM-012** (`swap`): allowance check `unwrap_or(0)` → `unwrap_or_else` with stderr warn. Avoids silent RPC failure masking as zero allowance → unnecessary approve.
- **EVM-003** (`rpc`): `sqrtPriceX96` and `amountOut` decoded via `decode_u256_from_hex()` instead of `u128::from_str_radix()`. Fixes silent `0` on large uint256 values that exceed u128 range.

## Root cause

`extract_tx_hash()` returns `"pending"` when onchainos response omits `txHash`. The original `sleep(5s)` then passed this string directly to the next tx submission — no confirmation, no real hash. `wait_and_check_receipt("pending", ...)` now bails immediately with a clear error instead of silently proceeding.

## Test plan

- [x] `cargo build` — compiles clean (v1.0.3)
- [x] `quote` — 1 USDC → 0.999548 USDT on Arbitrum
- [x] `pools --token0 USDC --token1 USDT --chain 42161` — 3 pools listed
- [x] `positions --owner <addr> --chain 42161` — 2 positions shown
- [x] `swap --dry-run` — correct calldata, no sleep
- [x] `add-liquidity --dry-run` — 3-step preview, no sleep
- [x] `remove-liquidity --dry-run` — 2-step preview, no sleep

🤖 Generated with [Claude Code](https://claude.ai/claude-code)