### PR TITLE
fix(aave-v3-plugin): bail on pending approve, EVM-012 fixes, per-asset positions (v0.2.6)

### DIFF
--- a/skills/aave-v3-plugin/.claude-plugin/plugin.json
+++ b/skills/aave-v3-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "aave-v3-plugin",
   "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/skills/aave-v3-plugin/Cargo.lock
+++ b/skills/aave-v3-plugin/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aave-v3-plugin"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/aave-v3-plugin/Cargo.toml
+++ b/skills/aave-v3-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aave-v3-plugin"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [[bin]]

--- a/skills/aave-v3-plugin/SKILL.md
+++ b/skills/aave-v3-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aave-v3-plugin
 description: "Aave V3 lending and borrowing. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
-version: "0.2.5"
+version: "0.2.6"
 author: "skylavis-sky"
 tags:
   - lending
@@ -324,7 +324,7 @@ aave-v3-plugin --chain 42161 --confirm borrow --asset 0x82aF49447D8a07e3bd95BD0d
 ```
 
 **Key parameters:**
-- `--asset` — ERC-20 contract address (checksummed). Borrow and repay require the address, not symbol.
+- `--asset` — token symbol (e.g. USDC, WETH) or ERC-20 contract address
 - `--amount` — human-readable amount in token units (0.5 WETH = `0.5`)
 
 **Notes:**
@@ -459,7 +459,9 @@ aave-v3-plugin --chain 8453 reserves --asset 0x833589fCD6eDb6E08f4c7C32D4f71b54b
 
 **Trigger phrases:** "my aave positions", "aave portfolio", "我的Aave仓位", "Aave持仓"
 
-**Data source:** On-chain only — calls `Pool.getUserAccountData(address)` directly via public RPC. Returns aggregate totals. Per-asset supply/borrow breakdown is not included; use `aave-v3-plugin reserves` to see available markets.
+**Data source:** Two sources combined:
+- On-chain `Pool.getUserAccountData`: aggregate health factor, LTV, liquidation threshold
+- `onchainos defi position-detail` (Aave V3 platform 10): per-asset SUPPLY / BORROW breakdown
 
 **Usage:**
 ```bash
@@ -483,8 +485,14 @@ aave-v3-plugin --chain 1 positions --from 0xSomeAddress
   "availableBorrowsUSD": "2000.00",
   "currentLiquidationThreshold": "82.50%",
   "loanToValue": "75.00%",
-  "dataSource": "on-chain — Pool.getUserAccountData (aggregate totals only)",
-  "note": "Per-asset supply/borrow breakdown requires querying Pool.getUserReserveData for each reserve. Use `aave-v3-plugin reserves` to see available markets."
+  "positions": {
+    "supply": [
+      { "asset": "USDC", "tokenAddress": "0x833589...", "amount": "1000.00", "valueUSD": "1000.00", "marketId": "0xa238dd..." }
+    ],
+    "borrow": [
+      { "asset": "WETH", "tokenAddress": "0x4200000...", "amount": "0.25", "valueUSD": "500.00", "marketId": "0xa238dd..." }
+    ]
+  }
 }
 ```
 </external-content>
@@ -544,7 +552,7 @@ aave-v3-plugin --chain 8453 --confirm claim-rewards
 
 ## Asset Address Reference
 
-For borrow and repay, you need ERC-20 contract addresses. Common addresses:
+Symbols (e.g. USDC, WETH) are accepted for all commands. Common addresses for reference:
 
 ### Base (8453)
 | Symbol | Address |

--- a/skills/aave-v3-plugin/plugin.yaml
+++ b/skills/aave-v3-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: aave-v3-plugin
-version: "0.2.5"
+version: "0.2.6"
 description: "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards."
 author:
   name: skylavis-sky

--- a/skills/aave-v3-plugin/src/commands/positions.rs
+++ b/skills/aave-v3-plugin/src/commands/positions.rs
@@ -7,11 +7,9 @@ use crate::rpc;
 
 /// View current Aave V3 positions.
 ///
-/// Data source: on-chain only via Pool.getUserAccountData (eth_call to public RPC).
-/// Returns aggregate totals (totalCollateralUSD, totalDebtUSD, healthFactor).
-/// Per-asset supply/borrow breakdown is NOT included — that would require iterating
-/// all reserve addresses and calling getUserReserveData for each, which is
-/// available via the Aave V3 UI or PoolDataProvider contract directly.
+/// Data sources:
+/// - on-chain Pool.getUserAccountData: aggregate health factor, LTV, liquidation threshold
+/// - onchainos defi position-detail (platform 10): per-asset SUPPLY / BORROW breakdown
 pub async fn run(chain_id: u64, from: Option<&str>) -> anyhow::Result<Value> {
     let cfg = get_chain_config(chain_id)?;
 
@@ -34,6 +32,9 @@ pub async fn run(chain_id: u64, from: Option<&str>) -> anyhow::Result<Value> {
         .await
         .context("Failed to fetch user account data from on-chain Aave Pool")?;
 
+    // Fetch per-asset SUPPLY / BORROW breakdown via onchainos
+    let per_asset = fetch_per_asset_positions(chain_id, &user_addr);
+
     Ok(json!({
         "ok": true,
         "chain": cfg.name,
@@ -47,7 +48,87 @@ pub async fn run(chain_id: u64, from: Option<&str>) -> anyhow::Result<Value> {
         "availableBorrowsUSD": format!("{:.2}", account_data.available_borrows_usd()),
         "currentLiquidationThreshold": format!("{:.2}%", account_data.current_liquidation_threshold as f64 / 100.0),
         "loanToValue": format!("{:.2}%", account_data.ltv as f64 / 100.0),
-        "dataSource": "on-chain — Pool.getUserAccountData (aggregate totals only)",
-        "note": "Per-asset supply/borrow breakdown requires querying Pool.getUserReserveData for each reserve. Use `aave-v3-plugin reserves` to see available markets."
+        "positions": per_asset
     }))
+}
+
+/// Parse onchainos defi position-detail response into clean SUPPLY/BORROW lists.
+/// Returns null if no Aave positions found or onchainos call fails.
+fn fetch_per_asset_positions(chain_id: u64, user_addr: &str) -> Value {
+    let raw = match onchainos::defi_position_detail(chain_id, user_addr) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[positions] onchainos position-detail failed: {}", e);
+            return json!(null);
+        }
+    };
+
+    let chain_idx = chain_id.to_string();
+    let empty = vec![];
+
+    // Navigate: data[0].walletIdPlatformDetailList[0].networkHoldVoList
+    let networks = raw["data"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|p| p["walletIdPlatformDetailList"].as_array())
+        .and_then(|a| a.first())
+        .and_then(|w| w["networkHoldVoList"].as_array())
+        .unwrap_or(&empty);
+
+    // Find the network entry matching this chain
+    let network = networks.iter().find(|n| {
+        n["chainIndex"].as_str() == Some(&chain_idx)
+    });
+
+    let Some(network) = network else {
+        return json!({"supply": [], "borrow": []});
+    };
+
+    let markets = network["investMarketTokenBalanceVoList"]
+        .as_array()
+        .unwrap_or(&empty);
+
+    let mut supply: Vec<Value> = Vec::new();
+    let mut borrow: Vec<Value> = Vec::new();
+
+    for market in markets {
+        let asset_map = &market["assetMap"];
+
+        if let Some(supply_list) = asset_map["SUPPLY"].as_array() {
+            for item in supply_list {
+                let token = item["assetsTokenList"].as_array()
+                    .and_then(|a| a.first())
+                    .cloned()
+                    .unwrap_or(json!({}));
+                supply.push(json!({
+                    "asset": item["investmentName"].as_str().unwrap_or("?"),
+                    "tokenAddress": token["tokenAddress"].as_str().unwrap_or("?"),
+                    "amount": token["coinAmount"].as_str().unwrap_or("0"),
+                    "valueUSD": item["totalValue"].as_str().unwrap_or("0"),
+                    "marketId": item["marketId"].as_str().unwrap_or("?")
+                }));
+            }
+        }
+
+        if let Some(borrow_list) = asset_map["BORROW"].as_array() {
+            for item in borrow_list {
+                let token = item["assetsTokenList"].as_array()
+                    .and_then(|a| a.first())
+                    .cloned()
+                    .unwrap_or(json!({}));
+                // totalValue is negative for borrows; strip the sign for amount display
+                let value_str = item["totalValue"].as_str().unwrap_or("0");
+                let value_abs = value_str.trim_start_matches('-');
+                borrow.push(json!({
+                    "asset": item["investmentName"].as_str().unwrap_or("?"),
+                    "tokenAddress": token["tokenAddress"].as_str().unwrap_or("?"),
+                    "amount": token["coinAmount"].as_str().unwrap_or("0"),
+                    "valueUSD": value_abs,
+                    "marketId": item["marketId"].as_str().unwrap_or("?")
+                }));
+            }
+        }
+    }
+
+    json!({"supply": supply, "borrow": borrow})
 }

--- a/skills/aave-v3-plugin/src/commands/repay.rs
+++ b/skills/aave-v3-plugin/src/commands/repay.rs
@@ -78,7 +78,7 @@ pub async fn run(
     } else {
         let allowance = rpc::get_allowance(&token_addr, &from_addr, &pool_addr, cfg.rpc_url)
             .await
-            .unwrap_or(0);
+            .context("Failed to fetch token allowance")?;
         allowance < amount_minimal
     };
 
@@ -95,17 +95,23 @@ pub async fn run(
             dry_run,
         )
         .context("ERC-20 approve failed")?;
-        // Wait for approve tx to be mined before submitting repay
+        // Wait for approve tx to be mined before submitting repay.
+        // Bail early if approve was not broadcast — proceeding with a "pending" hash
+        // would submit repay before allowance is on-chain, causing STF revert.
         if !dry_run {
             let approve_tx = approve_res["data"]["txHash"]
                 .as_str()
                 .or_else(|| approve_res["txHash"].as_str())
                 .unwrap_or("");
-            if !approve_tx.is_empty() && approve_tx.starts_with("0x") {
-                rpc::wait_for_tx(cfg.rpc_url, approve_tx)
-                    .await
-                    .context("Approve tx did not confirm in time")?;
+            if approve_tx.is_empty() || !approve_tx.starts_with("0x") {
+                anyhow::bail!(
+                    "Approve tx was not broadcast (tx hash: '{}'). Check wallet connection and retry.",
+                    approve_tx
+                );
             }
+            rpc::wait_for_tx(cfg.rpc_url, approve_tx)
+                .await
+                .context("Approve tx did not confirm in time")?;
         }
         approval_result = Some(approve_res);
     }

--- a/skills/aave-v3-plugin/src/commands/supply.rs
+++ b/skills/aave-v3-plugin/src/commands/supply.rs
@@ -44,12 +44,12 @@ pub async fn run(
     if is_weth {
         let weth_balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
             .await
-            .unwrap_or(0);
+            .context("Failed to fetch WETH balance")?;
         if weth_balance < amount_minimal {
             let needed = amount_minimal - weth_balance;
             let eth_balance = rpc::get_eth_balance(&from_addr, cfg.rpc_url)
                 .await
-                .unwrap_or(0);
+                .context("Failed to fetch ETH balance")?;
             if eth_balance < needed {
                 anyhow::bail!(
                     "Insufficient balance: need {:.6} WETH to supply, have {:.6} WETH and {:.6} ETH. \
@@ -82,11 +82,15 @@ pub async fn run(
                     .or_else(|| wrap_result["hash"].as_str())
                     .unwrap_or("pending")
                     .to_string();
-                if tx != "pending" && tx.starts_with("0x") {
-                    rpc::wait_for_tx(cfg.rpc_url, &tx)
-                        .await
-                        .context("WETH wrap tx did not confirm in time")?;
+                if tx == "pending" || !tx.starts_with("0x") {
+                    anyhow::bail!(
+                        "WETH wrap tx was not broadcast (tx hash: '{}'). Check wallet connection and retry.",
+                        tx
+                    );
                 }
+                rpc::wait_for_tx(cfg.rpc_url, &tx)
+                    .await
+                    .context("WETH wrap tx did not confirm in time")?;
                 wrap_tx = Some(tx);
             }
         }
@@ -94,7 +98,7 @@ pub async fn run(
         // Non-WETH: check ERC-20 balance before attempting supply
         let token_balance = rpc::get_erc20_balance(&token_addr, &from_addr, cfg.rpc_url)
             .await
-            .unwrap_or(0);
+            .context("Failed to fetch token balance")?;
         if token_balance < amount_minimal && !dry_run {
             anyhow::bail!(
                 "Insufficient {} balance: need {:.6}, have {:.6}. Add funds to your wallet before supplying.",
@@ -154,12 +158,18 @@ pub async fn run(
         .unwrap_or("pending")
         .to_string();
 
-    // Wait for approve tx to be mined before submitting supply
-    if approve_tx != "pending" && approve_tx.starts_with("0x") {
-        rpc::wait_for_tx(cfg.rpc_url, &approve_tx)
-            .await
-            .context("Approve tx did not confirm in time")?;
+    // Wait for approve tx to be mined before submitting supply.
+    // Bail early if approve was not broadcast — proceeding with a "pending" hash
+    // would submit supply before allowance is on-chain, causing STF revert.
+    if approve_tx == "pending" || !approve_tx.starts_with("0x") {
+        anyhow::bail!(
+            "Approve tx was not broadcast (tx hash: '{}'). Check wallet connection and retry.",
+            approve_tx
+        );
     }
+    rpc::wait_for_tx(cfg.rpc_url, &approve_tx)
+        .await
+        .context("Approve tx did not confirm in time")?;
 
     // Step 2: supply
     let supply_calldata = calldata::encode_supply(&token_addr, amount_minimal, &from_addr)

--- a/skills/aave-v3-plugin/src/main.rs
+++ b/skills/aave-v3-plugin/src/main.rs
@@ -52,7 +52,7 @@ enum Commands {
     },
     /// Borrow an asset against posted collateral
     Borrow {
-        /// Asset ERC-20 address (must be checksummed address)
+        /// Asset ERC-20 address or symbol (e.g. USDC, WETH)
         #[arg(long)]
         asset: String,
         /// Human-readable amount (e.g. 0.5 for 0.5 WETH)
@@ -61,7 +61,7 @@ enum Commands {
     },
     /// Repay borrowed debt (partial or full)
     Repay {
-        /// Asset ERC-20 address (must be checksummed address)
+        /// Asset ERC-20 address or symbol (e.g. USDC, WETH)
         #[arg(long)]
         asset: String,
         /// Human-readable amount to repay (omit if using --all)

--- a/skills/aave-v3-plugin/src/onchainos.rs
+++ b/skills/aave-v3-plugin/src/onchainos.rs
@@ -90,6 +90,24 @@ pub fn defi_collect(
     run_cmd(cmd)
 }
 
+/// Get per-asset Aave V3 holdings (SUPPLY/BORROW) for a wallet via onchainos.
+/// platform_id 10 = Aave V3 across all supported chains.
+pub fn defi_position_detail(chain_id: u64, wallet_addr: &str) -> anyhow::Result<Value> {
+    let chain_name = chain_id_to_name(chain_id);
+    let mut cmd = base_cmd();
+    cmd.args([
+        "defi",
+        "position-detail",
+        "--address",
+        wallet_addr,
+        "--chain",
+        chain_name,
+        "--platform-id",
+        "10",
+    ]);
+    run_cmd(cmd)
+}
+
 /// Get DeFi positions for a wallet address on a given chain.
 /// Requires --address and --chains (comma-separated chain names).
 pub fn defi_positions(chain_id: u64, wallet_addr: &str) -> anyhow::Result<Value> {


### PR DESCRIPTION
## Summary

- **EVM-006** (`supply`): WETH wrap and approve tx — `if tx != "pending"` guard silently skipped receipt wait → now bails immediately if tx hash is `"pending"`, preventing `supply` from submitting before allowance is on-chain.
- **EVM-006** (`repay`): approve tx — `if !empty && starts_with("0x")` guard had same issue → now bails on pending hash.
- **EVM-012** (`supply`): 3× `unwrap_or(0)` on `get_erc20_balance` / `get_eth_balance` → `.context()` propagates RPC errors instead of silent zero balance.
- **EVM-012** (`repay`): allowance `unwrap_or(0)` → `.context("Failed to fetch token allowance")`.
- **positions command**: rewritten to combine `Pool.getUserAccountData` (aggregate healthFactor / LTV / netAPY) with `onchainos defi position-detail --platform-id 10` (per-asset SUPPLY/BORROW breakdown). Previously only aggregate totals were returned.
- **Docs**: `--asset` docstring corrected to accept symbol or address; `SKILL.md` `positions` output fields updated.

## Root cause (EVM-006)

Both `supply` and `repay` had an `if` guard that skipped the receipt wait when the approve tx hash was `"pending"`. This is the same class of bug as a `sleep(N)` — when onchainos doesn't return a real txHash, the main tx gets submitted immediately without allowance being on-chain, causing STF revert.

## Test plan

- [x] `cargo build` — compiles clean (v0.2.6)
- [x] `positions --chain 1 --from <addr>` — returns aggregate + per-asset supply/borrow breakdown
- [x] `supply --dry-run` — correct calldata preview, ERC-20 and WETH paths
- [x] `repay --dry-run` — correct calldata preview
- [x] `borrow --dry-run` — correct calldata preview

🤖 Generated with [Claude Code](https://claude.ai/claude-code)