### PR TITLE
fix(morpho-plugin): pre-flight balance check + auto-wrap ETH→WETH + EVM-012 silent zeros (v0.2.5)

### DIFF
--- a/skills/morpho-plugin/Cargo.lock
+++ b/skills/morpho-plugin/Cargo.lock
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "morpho-plugin"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/morpho-plugin/plugin.yaml
+++ b/skills/morpho-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: morpho-plugin
-version: "0.2.4"
+version: "0.2.5"
 description: "Supply, borrow and earn yield on Morpho — a permissionless lending protocol"
 author:
   name: GeoGu360

--- a/skills/morpho-plugin/src/commands/repay.rs
+++ b/skills/morpho-plugin/src/commands/repay.rs
@@ -50,11 +50,13 @@ pub async fn run(
             .context("No position found for this market. Nothing to repay.")?;
 
         let borrow_shares_str = pos.state.borrow_shares.as_deref().unwrap_or("0");
-        repay_shares = borrow_shares_str.parse().unwrap_or(0);
+        repay_shares = borrow_shares_str.parse()
+            .with_context(|| format!("Failed to parse borrow shares: '{}'", borrow_shares_str))?;
         repay_assets = 0; // Use shares mode for full repay
 
         let borrow_assets_str = pos.state.borrow_assets.as_deref().unwrap_or("0");
-        borrow_assets = borrow_assets_str.parse().unwrap_or(0);
+        borrow_assets = borrow_assets_str.parse()
+            .with_context(|| format!("Failed to parse borrow assets: '{}'", borrow_assets_str))?;
         display_amount = calldata::format_amount(borrow_assets, decimals);
 
         eprintln!("[morpho] Repaying all debt ({} {}) using {} shares...", display_amount, symbol, repay_shares);

--- a/skills/morpho-plugin/src/commands/supply.rs
+++ b/skills/morpho-plugin/src/commands/supply.rs
@@ -28,6 +28,65 @@ pub async fn run(
     // Resolve the caller's wallet address (used as receiver in deposit)
     let wallet_addr = onchainos::resolve_wallet(from, chain_id).await?;
 
+    // Pre-flight: balance check and auto-wrap ETH→WETH if needed
+    let is_weth = weth_address(chain_id)
+        .map_or(false, |w| w.eq_ignore_ascii_case(&asset_addr));
+    let mut wrap_tx: Option<String> = None;
+
+    if !dry_run {
+        if is_weth {
+            let weth_balance = rpc::erc20_balance_of(&asset_addr, &wallet_addr, cfg.rpc_url)
+                .await
+                .context("Failed to fetch WETH balance")?;
+            if weth_balance < raw_amount {
+                let needed = raw_amount - weth_balance;
+                let eth_bal = rpc::eth_balance(&wallet_addr, cfg.rpc_url)
+                    .await
+                    .context("Failed to fetch ETH balance")?;
+                if eth_bal < needed {
+                    anyhow::bail!(
+                        "Insufficient balance: need {:.6} WETH to deposit, \
+                         have {:.6} WETH and {:.6} ETH. \
+                         Add more ETH or WETH to your wallet.",
+                        raw_amount as f64 / 1e18,
+                        weth_balance as f64 / 1e18,
+                        eth_bal as f64 / 1e18,
+                    );
+                }
+                // Auto-wrap ETH → WETH using WETH.deposit()
+                eprintln!("[morpho] Wrapping {:.6} ETH → WETH (WETH balance insufficient)...",
+                    needed as f64 / 1e18);
+                let wrap_result = onchainos::wallet_contract_call(
+                    chain_id,
+                    &asset_addr,
+                    "0xd0e30db0", // WETH.deposit() selector
+                    Some(wallet_addr.as_str()),
+                    Some(needed),
+                    false,
+                    false,
+                ).await?;
+                let wrap_hash = onchainos::extract_tx_hash_or_err(&wrap_result)?;
+                eprintln!("[morpho] Wrap tx: {} — waiting for confirmation...", wrap_hash);
+                onchainos::wait_for_tx(&wrap_hash, cfg.rpc_url, chain_id).await
+                    .context("WETH wrap tx did not confirm in time")?;
+                wrap_tx = Some(wrap_hash);
+            }
+        } else {
+            // Non-WETH: check ERC-20 balance before proceeding
+            let token_balance = rpc::erc20_balance_of(&asset_addr, &wallet_addr, cfg.rpc_url)
+                .await
+                .context("Failed to fetch token balance")?;
+            if token_balance < raw_amount {
+                anyhow::bail!(
+                    "Insufficient {} balance: need {}, have {}. Add funds to your wallet.",
+                    symbol,
+                    calldata::format_amount(raw_amount, decimals),
+                    calldata::format_amount(token_balance, decimals),
+                );
+            }
+        }
+    }
+
     // Build calldatas (needed for both preview and execution)
     let approve_calldata = calldata::encode_approve(vault, raw_amount);
     let deposit_calldata = calldata::encode_vault_deposit(raw_amount, &wallet_addr);
@@ -49,14 +108,15 @@ pub async fn run(
                 {"step": 1, "description": format!("Approve {} to spend {} {}", vault, amount, symbol), "to": asset_addr},
                 {"step": 2, "description": format!("Deposit {} {} into vault {}", amount, symbol, vault), "to": vault},
             ],
-            "note": "Re-run with --confirm to execute these transactions on-chain."
+            "note": "Re-run with --confirm to execute these transactions on-chain. If depositing WETH and wallet only holds ETH, a wrap step will be added automatically."
         });
         println!("{}", serde_json::to_string_pretty(&preview)?);
         return Ok(());
     }
 
     // Step 1: Approve vault to spend asset
-    eprintln!("[morpho] Step 1/2: Approving {} to spend {} {}...", vault, amount, symbol);
+    let step = if wrap_tx.is_some() { "2/3" } else { "1/2" };
+    eprintln!("[morpho] Step {}: Approving {} to spend {} {}...", step, vault, amount, symbol);
     if dry_run {
         eprintln!("[morpho] [dry-run] Would approve: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, asset_addr, approve_calldata);
     }
@@ -65,7 +125,8 @@ pub async fn run(
     onchainos::wait_for_tx(&approve_tx, cfg.rpc_url, chain_id).await?;
 
     // Step 2: Deposit to vault
-    eprintln!("[morpho] Step 2/2: Depositing {} {} into vault {}...", amount, symbol, vault);
+    let step = if wrap_tx.is_some() { "3/3" } else { "2/2" };
+    eprintln!("[morpho] Step {}: Depositing {} {} into vault {}...", step, amount, symbol, vault);
     if dry_run {
         eprintln!("[morpho] [dry-run] Would deposit: onchainos wallet contract-call --chain {} --to {} --input-data {}", chain_id, vault, deposit_calldata);
     }
@@ -82,11 +143,23 @@ pub async fn run(
         "rawAmount": raw_amount.to_string(),
         "chainId": chain_id,
         "dryRun": dry_run,
+        "wrapTxHash": wrap_tx,
         "approveTxHash": approve_tx,
         "supplyTxHash": deposit_tx,
     });
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
+}
+
+/// Return the WETH contract address for known chains, or None.
+fn weth_address(chain_id: u64) -> Option<&'static str> {
+    match chain_id {
+        1     => Some("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+        8453  => Some("0x4200000000000000000000000000000000000006"),
+        42161 => Some("0x82af49447d8a07e3bd95bd0d56f35241523fbab1"), // Arbitrum
+        10    => Some("0x4200000000000000000000000000000000000006"), // Optimism
+        _ => None,
+    }
 }
 
 /// Resolve asset symbol or address to a checksummed address.

--- a/skills/morpho-plugin/src/commands/withdraw_collateral.rs
+++ b/skills/morpho-plugin/src/commands/withdraw_collateral.rs
@@ -40,7 +40,8 @@ pub async fn run(
             .context("No position found for this market. Nothing to withdraw.")?;
 
         let collateral_str = pos.state.collateral.as_deref().unwrap_or("0");
-        raw_amount = collateral_str.parse().unwrap_or(0);
+        raw_amount = collateral_str.parse()
+            .with_context(|| format!("Failed to parse collateral amount: '{}'", collateral_str))?;
         display_amount = calldata::format_amount(raw_amount, decimals);
         eprintln!("[morpho] Withdrawing all collateral ({} {}) from market {}...", display_amount, symbol, market_id);
     } else {

--- a/skills/morpho-plugin/src/rpc.rs
+++ b/skills/morpho-plugin/src/rpc.rs
@@ -102,6 +102,40 @@ pub async fn erc20_symbol(token: &str, rpc_url: &str) -> anyhow::Result<String> 
     Ok(String::from_utf8_lossy(&bytes).to_string())
 }
 
+/// Read native ETH balance of `owner`.
+pub async fn eth_balance(owner: &str, rpc_url: &str) -> anyhow::Result<u128> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [owner, "latest"],
+        "id": 1
+    });
+    let resp: serde_json::Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("RPC request failed")?
+        .json()
+        .await
+        .context("RPC response parse failed")?;
+
+    if let Some(err) = resp.get("error") {
+        anyhow::bail!("eth_getBalance error: {}", err);
+    }
+    let hex = resp["result"]
+        .as_str()
+        .context("Missing result field in eth_getBalance response")?;
+    let hex_clean = hex.trim_start_matches("0x");
+    if hex_clean.is_empty() {
+        return Ok(0);
+    }
+    let padded = format!("{:0>32}", hex_clean);
+    let val = u128::from_str_radix(&padded[padded.len().saturating_sub(32)..], 16).unwrap_or(0);
+    Ok(val)
+}
+
 /// Read vault share balance (ERC-20 balanceOf, same encoding).
 pub async fn vault_share_balance(
     vault: &str,


### PR DESCRIPTION
## Summary

- **EVM-001 — Missing pre-flight balance check in `supply`**: Before approve+deposit, now checks WETH/token balance. If depositing into a WETH vault and the wallet has ETH but insufficient WETH, automatically wraps the needed ETH→WETH via `WETH.deposit()` (selector `0xd0e30db0`), waits for confirmation, then proceeds with approve+deposit. Fixes Noah Chen's reported \"execution reverted\" on Base: user had ETH but no WETH, approve succeeded but vault `transferFrom` reverted.
- **EVM-012 — Silent zero on API parse failure in `repay --all`**: `borrow_shares` and `borrow_assets` parse errors now bail with context instead of silently returning 0.
- **EVM-012 — Silent zero on API parse failure in `withdraw-collateral --all`**: `collateral` parse errors now bail with context instead of silently returning 0.
- **`rpc.rs`**: Added `eth_balance()` via `eth_getBalance` to support the pre-flight ETH check.

## Test plan

- [x] Compiled: `cargo build` passes with no errors
- [x] `morpho-plugin supply --vault 0xf56Fc94C8E43AfD4209c9Ca9ED95190C83F7A424 --asset WETH --amount 0.0001 --chain 8453 --confirm` executed on-chain — approve + deposit both confirmed (wallet had sufficient WETH, wrap step correctly skipped, `wrapTxHash: null`)
- [x] `morpho-plugin positions --chain 8453` shows 0.0001 WETH deposited into SageFlow Flagship ETH vault ✅
- [x] Version consistency: all 4 files at `0.2.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)