### PR TITLE
fix(raydium-plugin): surface RPC errors in balance check + fix SKILL.md bool flag docs (v0.1.6)

### DIFF
--- a/skills/raydium-plugin/.claude-plugin/plugin.json
+++ b/skills/raydium-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "raydium",
   "description": "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium.",
-  "version": "0.1.3"
+  "version": "0.1.6"
 }

--- a/skills/raydium-plugin/Cargo.lock
+++ b/skills/raydium-plugin/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "raydium-plugin"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/raydium-plugin/Cargo.toml
+++ b/skills/raydium-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raydium-plugin"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [[bin]]

--- a/skills/raydium-plugin/SKILL.md
+++ b/skills/raydium-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Raydium AMM plugin for token swaps, price queries, and pool info o
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.1.5"
+  version: "0.1.6"
 ---
 
 
@@ -236,9 +236,7 @@ raydium swap \
   --input-mint So11111111111111111111111111111111111111112 \
   --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
   --amount 0.1 \
-  --slippage-bps 50 \
-  --wrap-sol true \
-  --unwrap-sol true
+  --slippage-bps 50
 ```
 
 **Output fields:** `ok`, `inputMint`, `outputMint`, `amount`, `amountDisplay` (2 decimal places), `rawAmount`, `outputAmount`, `priceImpactPct`, `transactions` (array of `txHash`)

--- a/skills/raydium-plugin/plugin.yaml
+++ b/skills/raydium-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: raydium-plugin
-version: "0.1.5"
+version: "0.1.6"
 description: "Raydium AMM plugin for token swaps, price queries, and pool info on Solana mainnet. Trigger phrases: swap on raydium, raydium swap, raydium price, raydium pool, get swap quote raydium, raydium dex, swap solana raydium."
 author:
   name: skylavis-sky

--- a/skills/raydium-plugin/src/commands/swap.rs
+++ b/skills/raydium-plugin/src/commands/swap.rs
@@ -134,7 +134,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
     if args.input_mint == SOL_NATIVE_MINT {
         let lamports = onchainos::get_sol_balance(&wallet, SOLANA_RPC_URL)
             .await
-            .unwrap_or(0);
+            .map_err(|e| anyhow::anyhow!("Failed to fetch SOL balance: {}", e))?;
         if lamports < raw_amount {
             anyhow::bail!(
                 "Insufficient SOL balance: need {:.9} SOL, have {:.9} SOL. \
@@ -146,7 +146,7 @@ pub async fn execute(args: &SwapArgs, dry_run: bool) -> Result<()> {
     } else {
         let token_balance = onchainos::get_spl_token_balance(&wallet, &args.input_mint, SOLANA_RPC_URL)
             .await
-            .unwrap_or(0);
+            .map_err(|e| anyhow::anyhow!("Failed to fetch token balance for mint {}: {}", args.input_mint, e))?;
         if token_balance < raw_amount {
             anyhow::bail!(
                 "Insufficient token balance: need {} units, have {} units for mint {}. \


### PR DESCRIPTION
## Summary

- **EVM-012 — Misleading balance error on RPC failure**: `swap` pre-flight checks used `unwrap_or(0)` on `get_sol_balance` and `get_spl_token_balance`. When the Solana RPC is unreachable or rate-limits the request, balance silently becomes 0 and the user sees \"Insufficient SOL/token balance\" instead of the actual RPC error. Fixed with `map_err()?` to propagate the real error message.
- **SKILL.md doc bug**: `swap` example included `--wrap-sol true` and `--unwrap-sol true`. These are presence-only boolean flags in clap (`default_value_t = true`) — passing a value causes `unexpected argument 'true' found`. Since both default to true, removed them from the example entirely.

## Test plan

- [x] Compiled: `cargo build` passes (`raydium-plugin v0.1.6`)
- [x] User confirmed live swap tests pass: USDC→SOL and SOL→USDC on mainnet
- [x] `--wrap-sol` / `--unwrap-sol` verified as presence-only flags via `swap --help`
- [x] Version consistency: all 4 files at `0.1.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)