### PR TITLE
fix(etherfi-plugin): fix weETHBalance=0 race condition, WARNING in preview mode, extract NFT token ID from receipt (v0.2.9)

### DIFF
--- a/skills/etherfi-plugin/.claude-plugin/plugin.json
+++ b/skills/etherfi-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "etherfi",
   "description": "Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap eETH to weETH (ERC-4626), and check positions with APY",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/etherfi-plugin/Cargo.lock
+++ b/skills/etherfi-plugin/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "etherfi-plugin"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/etherfi-plugin/Cargo.toml
+++ b/skills/etherfi-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etherfi-plugin"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 
 [[bin]]

--- a/skills/etherfi-plugin/SKILL.md
+++ b/skills/etherfi-plugin/SKILL.md
@@ -268,7 +268,7 @@ etherfi unstake --amount 1.0 --dry-run
 
 **Output:**
 ```json
-{"ok":true,"txHash":"0xabc...","action":"unstake_request","eETHUnstaked":"1.0","eETHWei":"1000000000000000000","eETHBalance":"0.5","nftTokenId":12345,"note":"WithdrawRequestNFT #12345 minted. Withdrawals typically take 1-7 days. Track at https://app.ether.fi/portfolio — then run: etherfi unstake --claim --token-id 12345 --confirm"}
+{"ok":true,"txHash":"0xabc...","action":"unstake_request","eETHUnstaked":"1.0","eETHWei":"1000000000000000000","eETHBalance":"0.5","nftTokenId":12345,"note":"WithdrawRequestNFT #12345 minted. Withdrawals typically take 1-7 days. Check the ether.fi app to track status — then run: etherfi unstake --claim --token-id 12345 --confirm"}
 ```
 
 **Output fields:** `txHash`, `eETHUnstaked`, `eETHBalance` (post-confirmation balance), `nftTokenId` (auto-extracted from receipt; `null` if extraction fails), `note` (next step with token ID pre-filled when available).
@@ -310,7 +310,7 @@ etherfi unstake --claim --token-id 12345 --dry-run
 4. **Requires `--confirm`** to broadcast
 5. Call `WithdrawRequestNFT.claimWithdraw(tokenId)` (selector `0xb13acedd`) — burns NFT, sends ETH
 
-**Important:** If finalization check returns false, the plugin aborts with an error including a wait-time estimate (typically 1-7 days) and a link to `https://app.ether.fi/portfolio` to track status.
+**Important:** If finalization check returns false, the plugin aborts with an error including a wait-time estimate (typically 1-7 days) and a reminder to check the ether.fi app to track status.
 
 ---
 

--- a/skills/etherfi-plugin/SKILL.md
+++ b/skills/etherfi-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Liquid restaking on Ethereum. Deposit ETH into ether.fi LiquidityPool to receive eETH,
   wrap eETH into weETH (ERC-4626 yield-bearing token) to earn staking + EigenLayer
   restaking rewards, unstake eETH back to ETH, check balances, and view current APY.
-version: "0.2.8"
+version: "0.2.9"
 author: GeoGu360
 tags:
   - liquid-staking
@@ -29,7 +29,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/etherfi-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.8"
+LOCAL_VER="0.2.9"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -102,7 +102,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/etherfi-plugin@0.2.8/etherfi-plugin-${TARGET}${EXT}" -o ~/.local/bin/.etherfi-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/etherfi-plugin@0.2.9/etherfi-plugin-${TARGET}${EXT}" -o ~/.local/bin/.etherfi-plugin-core${EXT}
 chmod +x ~/.local/bin/.etherfi-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -110,7 +110,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/etherfi-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.8" > "$HOME/.plugin-store/managed/etherfi-plugin"
+echo "0.2.9" > "$HOME/.plugin-store/managed/etherfi-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -130,7 +130,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"etherfi-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
+    -d '{"name":"etherfi-plugin","version":"0.2.9"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -268,19 +268,20 @@ etherfi unstake --amount 1.0 --dry-run
 
 **Output:**
 ```json
-{"ok":true,"txHash":"0xabc...","action":"unstake_request","eETHUnstaked":"1.0","eETHWei":"1000000000000000000","eETHBalance":"0.5","note":"Find your WithdrawRequestNFT token ID in the tx receipt, then run: etherfi unstake --claim --token-id <id> --confirm"}
+{"ok":true,"txHash":"0xabc...","action":"unstake_request","eETHUnstaked":"1.0","eETHWei":"1000000000000000000","eETHBalance":"0.5","nftTokenId":12345,"note":"WithdrawRequestNFT #12345 minted. Withdrawals typically take 1-7 days. Track at https://app.ether.fi/portfolio — then run: etherfi unstake --claim --token-id 12345 --confirm"}
 ```
 
-**Display:** `txHash` (abbreviated), `eETHUnstaked`, `eETHBalance` (updated balance), `note` (next step instructions).
+**Output fields:** `txHash`, `eETHUnstaked`, `eETHBalance` (post-confirmation balance), `nftTokenId` (auto-extracted from receipt; `null` if extraction fails), `note` (next step with token ID pre-filled when available).
 
 **Flow:**
 1. Parse eETH amount to wei (18 decimals)
 2. Resolve wallet address via `onchainos wallet addresses`
 3. Validate eETH balance is sufficient
-4. Check eETH allowance for LiquidityPool; if insufficient, approve `u128::MAX` first — **waits for on-chain confirmation before proceeding** (polls `onchainos wallet history`, up to 90s)
+4. Check eETH allowance for LiquidityPool; if insufficient, prints `NOTE` in preview mode or approves `u128::MAX` with WARNING in confirm mode — **waits for on-chain confirmation before proceeding** (polls `onchainos wallet history`, up to 90s)
 5. **Requires `--confirm`** — without it, prints preview JSON and exits
 6. Call `LiquidityPool.requestWithdraw(recipient, amountOfEEth)` (selector `0x397a1b28`)
-7. WithdrawRequestNFT is minted — token ID is in the tx receipt (check Etherscan)
+7. Waits for requestWithdraw tx confirmation, then queries updated eETH balance
+8. Extracts `WithdrawRequestNFT` token ID from tx receipt logs (ERC-721 Transfer mint event); surfaces as `nftTokenId` in output
 
 #### Step 2 — Claim ETH (after finalization)
 
@@ -309,7 +310,7 @@ etherfi unstake --claim --token-id 12345 --dry-run
 4. **Requires `--confirm`** to broadcast
 5. Call `WithdrawRequestNFT.claimWithdraw(tokenId)` (selector `0xb13acedd`) — burns NFT, sends ETH
 
-**Important:** If finalization check returns false, the transaction will revert on-chain. Always confirm the status before claiming.
+**Important:** If finalization check returns false, the plugin aborts with an error including a wait-time estimate (typically 1-7 days) and a link to `https://app.ether.fi/portfolio` to track status.
 
 ---
 
@@ -340,9 +341,10 @@ etherfi wrap --amount 1.0 --dry-run
 1. Parse eETH amount to wei
 2. Fetch `weETH.getRate()` and compute `weETHExpected = eETH / rate` — shown in preview before confirm
 3. Resolve wallet; check eETH balance is sufficient
-4. Check eETH allowance for weETH contract; approve `u128::MAX` if needed — **waits for on-chain confirmation before proceeding** (polls `onchainos wallet history`, up to 90s)
+4. Check eETH allowance for weETH contract; if insufficient, prints `NOTE` in preview mode or approves `u128::MAX` with WARNING in confirm mode — **waits for on-chain confirmation before proceeding** (polls `onchainos wallet history`, up to 90s)
 5. **Requires `--confirm`** for each step (approve + wrap)
 6. Call `weETH.wrap(uint256)` via `onchainos wallet contract-call` (selector `0xea598cb0`)
+7. Waits for wrap tx confirmation, then queries updated weETH balance
 
 ---
 

--- a/skills/etherfi-plugin/plugin.yaml
+++ b/skills/etherfi-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: etherfi-plugin
-version: "0.2.8"
+version: "0.2.9"
 description: Liquid restaking on Ethereum — deposit ETH to receive eETH, wrap/unwrap eETH/weETH (ERC-4626), unstake eETH back to ETH, and check positions with APY
 author:
   name: GeoGu360

--- a/skills/etherfi-plugin/src/commands/unstake.rs
+++ b/skills/etherfi-plugin/src/commands/unstake.rs
@@ -5,7 +5,7 @@ use crate::config::{
     parse_units, rpc_url, withdraw_request_nft_address, CHAIN_ID,
 };
 use crate::onchainos::{extract_tx_hash, resolve_wallet, wait_for_tx, wallet_contract_call};
-use crate::rpc::{get_allowance, get_balance, is_withdrawal_finalized};
+use crate::rpc::{get_allowance, get_balance, get_nft_token_id_from_mint, is_withdrawal_finalized};
 
 #[derive(Args)]
 pub struct UnstakeArgs {
@@ -86,7 +86,6 @@ async fn run_request(args: UnstakeArgs) -> anyhow::Result<()> {
     if !args.dry_run {
         let allowance = get_allowance(eeth, &wallet, pool, rpc).await?;
         if allowance < eeth_wei {
-            eprintln!("WARNING: Approving LiquidityPool to spend eETH (unlimited allowance, u128::MAX). To revoke later, call approve(LiquidityPool, 0).");
             let approve_data = build_approve_calldata(pool, u128::MAX);
             let approve_result = wallet_contract_call(
                 CHAIN_ID,
@@ -99,12 +98,14 @@ async fn run_request(args: UnstakeArgs) -> anyhow::Result<()> {
             .await?;
 
             if approve_result["preview"].as_bool() == Some(true) {
+                eprintln!("NOTE: eETH approval needed. Re-run with --confirm to approve + requestWithdraw.");
                 println!("{}", serde_json::to_string_pretty(&approve_result)?);
-                eprintln!("Re-run with --confirm to execute approve + requestWithdraw.");
                 return Ok(());
             }
 
+            // Only reached when --confirm is passed and tx is actually broadcast
             let approve_tx = extract_tx_hash(&approve_result).to_string();
+            eprintln!("WARNING: Granting LiquidityPool unlimited (u128::MAX) eETH allowance. To revoke later: approve(LiquidityPool, 0).");
             eprintln!("Approve tx: {} — waiting for confirmation...", approve_tx);
             wait_for_tx(approve_tx, wallet.clone()).await
                 .map_err(|e| anyhow::anyhow!("Approve tx did not confirm: {}", e))?;
@@ -132,7 +133,16 @@ async fn run_request(args: UnstakeArgs) -> anyhow::Result<()> {
 
     let tx_hash = extract_tx_hash(&result);
 
-    // Fetch updated eETH balance after request
+    // Wait for requestWithdraw tx to confirm before querying balance / receipt
+    // (fix: was querying before confirmation, showing stale pre-tx balance)
+    if !args.dry_run && args.confirm {
+        eprintln!("RequestWithdraw tx: {} — waiting for confirmation...", tx_hash);
+        wait_for_tx(tx_hash.to_string(), wallet.clone()).await
+            .map_err(|e| anyhow::anyhow!("RequestWithdraw tx did not confirm: {}", e))?;
+        eprintln!("RequestWithdraw confirmed.");
+    }
+
+    // Fetch updated eETH balance after confirmation
     let eeth_balance_str = if !args.dry_run && args.confirm {
         match get_balance(eeth, &wallet, rpc).await {
             Ok(bal) => format_units(bal, 18),
@@ -142,9 +152,37 @@ async fn run_request(args: UnstakeArgs) -> anyhow::Result<()> {
         "N/A".to_string()
     };
 
+    // Extract NFT token ID from tx receipt
+    let nft = withdraw_request_nft_address();
+    let nft_token_id: Option<u64> = if !args.dry_run && args.confirm {
+        get_nft_token_id_from_mint(tx_hash, nft, &wallet, rpc).await.unwrap_or(None)
+    } else {
+        None
+    };
+
+    let note = match nft_token_id {
+        Some(id) => format!(
+            "WithdrawRequestNFT #{id} minted. Withdrawals typically take 1-7 days. \
+            Track at https://app.ether.fi/portfolio — \
+            then run: etherfi unstake --claim --token-id {id} --confirm"
+        ),
+        None => "Find your WithdrawRequestNFT token ID in the tx receipt, \
+            then run: etherfi unstake --claim --token-id <id> --confirm. \
+            Withdrawals typically take 1-7 days; track at https://app.ether.fi/portfolio".to_string(),
+    };
+
     println!(
-        "{{\"ok\":true,\"txHash\":\"{}\",\"action\":\"unstake_request\",\"eETHUnstaked\":\"{}\",\"eETHWei\":\"{}\",\"eETHBalance\":\"{}\",\"note\":\"Find your WithdrawRequestNFT token ID in the tx receipt, then run: etherfi unstake --claim --token-id <id> --confirm\"}}",
-        tx_hash, amount_str, eeth_wei, eeth_balance_str
+        "{}",
+        serde_json::json!({
+            "ok": true,
+            "txHash": tx_hash,
+            "action": "unstake_request",
+            "eETHUnstaked": amount_str,
+            "eETHWei": eeth_wei.to_string(),
+            "eETHBalance": eeth_balance_str,
+            "nftTokenId": nft_token_id,
+            "note": note,
+        })
     );
 
     Ok(())
@@ -175,13 +213,15 @@ async fn run_claim(args: UnstakeArgs) -> anyhow::Result<()> {
     if !finalized && !args.dry_run {
         eprintln!(
             "Warning: WithdrawRequestNFT #{} is not yet finalized. \
-            Claiming before finalization will fail on-chain. \
-            Check the ether.fi UI or try again later.",
-            token_id
+            Withdrawals typically take 1-7 days depending on the exit queue. \
+            Track your request at https://app.ether.fi/portfolio — \
+            run `etherfi unstake --claim --token-id {} --confirm` once finalized.",
+            token_id, token_id
         );
         if args.confirm {
             anyhow::bail!(
-                "Withdrawal request #{} is not finalized. Cannot claim yet.",
+                "Withdrawal request #{} is not finalized. Cannot claim yet. \
+                Typically takes 1-7 days — check https://app.ether.fi/portfolio for status.",
                 token_id
             );
         }

--- a/skills/etherfi-plugin/src/commands/wrap.rs
+++ b/skills/etherfi-plugin/src/commands/wrap.rs
@@ -69,8 +69,6 @@ pub async fn run(args: WrapArgs) -> anyhow::Result<()> {
     if !args.dry_run {
         let allowance = get_allowance(eeth, &wallet, weeth, rpc).await?;
         if allowance < eeth_wei {
-            eprintln!("WARNING: This approval grants the weETH contract unlimited (u128::MAX) spending access to your eETH. To revoke later, call approve(weETH, 0).");
-            eprintln!("Approving weETH contract to spend eETH (unlimited allowance)...");
             let approve_data = build_approve_calldata(weeth, u128::MAX);
             let approve_result = wallet_contract_call(
                 CHAIN_ID,
@@ -83,12 +81,14 @@ pub async fn run(args: WrapArgs) -> anyhow::Result<()> {
             .await?;
 
             if approve_result["preview"].as_bool() == Some(true) {
+                eprintln!("NOTE: eETH approval needed. Re-run with --confirm to approve + wrap.");
                 println!("{}", serde_json::to_string_pretty(&approve_result)?);
-                eprintln!("Re-run with --confirm to execute approve + wrap.");
                 return Ok(());
             }
 
+            // Only reached when --confirm is passed and tx is actually broadcast
             let approve_tx = extract_tx_hash(&approve_result).to_string();
+            eprintln!("WARNING: Granting weETH contract unlimited (u128::MAX) eETH allowance. To revoke later: approve(weETH, 0).");
             eprintln!("Approve tx: {} — waiting for confirmation...", approve_tx);
             wait_for_tx(approve_tx, wallet.clone()).await
                 .map_err(|e| anyhow::anyhow!("Approve tx did not confirm: {}", e))?;
@@ -116,7 +116,15 @@ pub async fn run(args: WrapArgs) -> anyhow::Result<()> {
 
     let tx_hash = extract_tx_hash(&result);
 
-    // Fetch updated weETH balance if live transaction
+    // Wait for wrap tx to confirm before querying balance (fix: was querying before confirmation)
+    if !args.dry_run && args.confirm {
+        eprintln!("Wrap tx: {} — waiting for confirmation...", tx_hash);
+        wait_for_tx(tx_hash.to_string(), wallet.clone()).await
+            .map_err(|e| anyhow::anyhow!("Wrap tx did not confirm: {}", e))?;
+        eprintln!("Wrap confirmed.");
+    }
+
+    // Fetch updated weETH balance after confirmation
     let weeth_balance_str = if !args.dry_run && args.confirm {
         match get_balance(weeth, &wallet, rpc).await {
             Ok(bal) => format_units(bal, 18),

--- a/skills/etherfi-plugin/src/rpc.rs
+++ b/skills/etherfi-plugin/src/rpc.rs
@@ -85,6 +85,64 @@ pub async fn weeth_get_rate(weeth: &str, rpc_url: &str) -> anyhow::Result<f64> {
     Ok(raw as f64 / 1e18)
 }
 
+/// Get transaction receipt and extract the WithdrawRequestNFT token ID from the mint event.
+/// ERC-721 Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+/// Selector: 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
+/// Minting: from == 0x000...000, to == recipient
+pub async fn get_nft_token_id_from_mint(
+    tx_hash: &str,
+    nft_address: &str,
+    recipient: &str,
+    rpc_url: &str,
+) -> anyhow::Result<Option<u64>> {
+    let client = reqwest::Client::new();
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getTransactionReceipt",
+        "params": [tx_hash],
+        "id": 1
+    });
+    let resp: Value = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .context("eth_getTransactionReceipt HTTP request failed")?
+        .json()
+        .await
+        .context("eth_getTransactionReceipt JSON parse failed")?;
+    if let Some(err) = resp.get("error") {
+        anyhow::bail!("eth_getTransactionReceipt error: {}", err);
+    }
+    let logs = match resp["result"]["logs"].as_array() {
+        Some(l) => l,
+        None => return Ok(None),
+    };
+    let transfer_sig = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    let zero_topic = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    let recipient_topic = format!(
+        "0x000000000000000000000000{}",
+        recipient.trim_start_matches("0x").to_lowercase()
+    );
+    let nft_lower = nft_address.to_lowercase();
+    for log in logs {
+        let addr = log["address"].as_str().unwrap_or("").to_lowercase();
+        if addr != nft_lower { continue; }
+        let topics = match log["topics"].as_array() {
+            Some(t) if t.len() >= 4 => t,
+            _ => continue,
+        };
+        if topics[0].as_str().unwrap_or("").to_lowercase() != transfer_sig { continue; }
+        if topics[1].as_str().unwrap_or("") != zero_topic { continue; }
+        if topics[2].as_str().unwrap_or("").to_lowercase() != recipient_topic { continue; }
+        let id_hex = topics[3].as_str().unwrap_or("").trim_start_matches("0x");
+        if let Ok(id) = u64::from_str_radix(id_hex, 16) {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
 /// WithdrawRequestNFT.isFinalized(uint256 tokenId) -> bool
 /// Returns true if the withdrawal request has been finalized and ETH is ready to claim.
 /// Selector: 0x33727c4d (keccak256("isFinalized(uint256)")[0..4])


### PR DESCRIPTION
## Summary

- **weETHBalance=0 / eETHBalance stale (race condition)**: `wrap` and `unstake` were querying balances immediately after tx submission without waiting for on-chain confirmation. Added `wait_for_tx` after the main tx in both commands before querying the updated balance.
- **Misleading WARNING in preview mode**: `wrap` and `unstake` were printing `WARNING: ...unlimited allowance...` and `Approving...` before the preview check, making users think an approval had been sent when nothing was broadcast. Moved WARNING to after the preview check; preview path now shows a `NOTE` instead.
- **NFT token ID not surfaced**: `unstake` step 1 required users to manually look up the `WithdrawRequestNFT` token ID from Etherscan. Now parses `eth_getTransactionReceipt` logs for the ERC-721 Transfer mint event and surfaces the ID as `nftTokenId` in the output with a pre-filled claim command in `note`.
- **Unfinalized claim error message**: Improved error to include "typically 1-7 days" wait estimate and `https://app.ether.fi/portfolio` tracking link.

## Files Changed

- `src/rpc.rs` — new `get_nft_token_id_from_mint` via `eth_getTransactionReceipt`
- `src/commands/wrap.rs` — `wait_for_tx` after wrap tx; WARNING moved after preview check
- `src/commands/unstake.rs` — `wait_for_tx` after requestWithdraw tx; NFT token ID extraction; improved messages
- `SKILL.md` — updated output fields, flow steps, unfinalized error description

## Test plan

- [ ] `etherfi wrap --amount <x>` (preview, no --confirm): should show `NOTE` only, no WARNING
- [ ] `etherfi wrap --amount <x> --confirm`: WARNING shown at approve time; `weETHBalance` shows correct post-confirmation value (not 0)
- [ ] `etherfi unstake --amount <x> --confirm`: `eETHBalance` shows post-confirmation value; `nftTokenId` populated in output
- [ ] `etherfi unstake --claim --token-id <unfinalized>`: error includes "1-7 days" and ether.fi portfolio link

🤖 Generated with [Claude Code](https://claude.ai/claude-code)