### PR TITLE
feat(gmx-v2-plugin): add quickstart command for guided onboarding (v0.2.6)

### DIFF
--- a/skills/gmx-v2-plugin/Cargo.lock
+++ b/skills/gmx-v2-plugin/Cargo.lock
@@ -1026,8 +1026,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "gmx-v2"
-version = "0.2.2"
+name = "gmx-v2-plugin"
+version = "0.2.6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/skills/gmx-v2-plugin/Cargo.toml
+++ b/skills/gmx-v2-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmx-v2-plugin"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [[bin]]

--- a/skills/gmx-v2-plugin/SKILL.md
+++ b/skills/gmx-v2-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmx-v2-plugin
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity, query markets and positions. Trigger phrases: open position GMX, close position GMX, GMX trade, GMX leverage, GMX liquidity, deposit GM pool, withdraw GM pool, GMX stop loss, GMX take profit, cancel order GMX, claim funding fees GMX."
-version: "0.2.5"
+version: "0.2.6"
 author: "GeoGu360"
 tags:
   - perpetuals
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/gmx-v2-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.5"
+LOCAL_VER="0.2.6"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2-plugin@0.2.5/gmx-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.gmx-v2-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/gmx-v2-plugin@0.2.6/gmx-v2-plugin-${TARGET}${EXT}" -o ~/.local/bin/.gmx-v2-plugin-core${EXT}
 chmod +x ~/.local/bin/.gmx-v2-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -106,7 +106,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/gmx-v2-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.5" > "$HOME/.plugin-store/managed/gmx-v2-plugin"
+echo "0.2.6" > "$HOME/.plugin-store/managed/gmx-v2-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"gmx-v2-plugin","version":"0.2.5"}' >/dev/null 2>&1 || true
+    -d '{"name":"gmx-v2-plugin","version":"0.2.6"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -200,6 +200,58 @@ Please connect your wallet first: run `onchainos wallet login`
 ```
 
 ## Commands
+
+### quickstart — Check Assets & Get Guided Next Step
+
+Detects wallet state on the target chain in one call, then recommends the right action. Use this when a user says "I want to trade on GMX" or "how do I get started" without knowing their current status.
+
+**Trigger phrases:**
+- "帮我看下 GMX 状态" / "我要开始用 GMX"
+- "GMX 怎么用" / "I want to trade on GMX V2"
+- "check my GMX balance" / "what should I do on GMX"
+
+**Parameters:**
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--chain` | No | `arbitrum` | Chain to check (`arbitrum` or `avalanche`) |
+| `--address` | No | onchainos wallet | EVM wallet address |
+
+**Output fields:** `wallet`, `chain`, `assets.eth_balance` (or `avax_balance`), `assets.usdc_balance`, `assets.open_positions`, `status`, `suggestion`, `next_command`
+
+**Status values:**
+
+| `status` | Condition | `next_command` |
+|----------|-----------|----------------|
+| `active` | Has open GMX positions | `gmx-v2 --chain X get-positions` |
+| `ready` | Has ETH + USDC ≥ $10, no positions | `gmx-v2 --chain X list-markets` |
+| `needs_fee` | Has USDC but lacks ETH for fees | `gmx-v2 --chain X get-prices --token ETH` |
+| `needs_collateral` | Has ETH but lacks USDC | `gmx-v2 --chain X get-prices` |
+| `no_funds` | Nothing on chain | `gmx-v2 --chain X get-prices` |
+
+**Example:**
+```
+gmx-v2 quickstart
+gmx-v2 --chain avalanche quickstart
+```
+
+```json
+{
+  "ok": true,
+  "wallet": "0x87fb0647...",
+  "chain": "arbitrum",
+  "assets": {
+    "eth_balance": 0.0009,
+    "usdc_balance": 1.63,
+    "open_positions": 2
+  },
+  "status": "active",
+  "suggestion": "You have 2 open position(s) on GMX V2 (arbitrum). Review them below.",
+  "next_command": "gmx-v2 --chain arbitrum get-positions"
+}
+```
+
+---
 
 ### list-markets — View active markets
 
@@ -545,3 +597,9 @@ gmx-v2 --chain arbitrum open-position \
 gmx-v2 --chain arbitrum get-positions
 ```
 
+
+## Changelog
+
+### v0.2.6 (2026-04-17)
+
+- **feat**: `quickstart` — new command; checks native token balance (ETH/AVAX for fees), USDC balance, and open positions in parallel on the target chain, returns structured JSON with `status` and `next_command` to guide first-time users from zero to first trade

--- a/skills/gmx-v2-plugin/plugin.yaml
+++ b/skills/gmx-v2-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: gmx-v2-plugin
-version: "0.2.5"
+version: "0.2.6"
 description: "Trade perpetuals and spot on GMX V2 — open/close leveraged positions, place limit/stop orders, add/remove GM pool liquidity on Arbitrum and Avalanche"
 author:
   name: GeoGu360

--- a/skills/gmx-v2-plugin/src/commands/mod.rs
+++ b/skills/gmx-v2-plugin/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub mod cancel_order;
 pub mod deposit_liquidity;
 pub mod withdraw_liquidity;
 pub mod claim_funding_fees;
+pub mod quickstart;

--- a/skills/gmx-v2-plugin/src/commands/quickstart.rs
+++ b/skills/gmx-v2-plugin/src/commands/quickstart.rs
@@ -10,6 +10,8 @@ const MIN_ETH_FEE_WEI: u128 = 2_000_000_000_000_000; // 0.002 ETH
 /// Minimum AVAX for Avalanche execution fees (2× single fee of 0.012 AVAX)
 const MIN_AVAX_FEE_WEI: u128 = 24_000_000_000_000_000; // 0.024 AVAX
 
+const ABOUT: &str = "GMX V2 is a decentralized perpetuals exchange on Arbitrum and Avalanche — trade BTC, ETH and 30+ assets with up to 100x leverage, fully on-chain with no KYC.";
+
 #[derive(Args)]
 pub struct QuickstartArgs {
     /// Wallet address to query. Defaults to currently logged-in onchainos wallet.
@@ -30,13 +32,12 @@ pub async fn run(chain: &str, args: QuickstartArgs) -> anyhow::Result<()> {
 
     eprintln!("Checking assets for {} on {}...", &wallet[..std::cmp::min(10, wallet.len())], chain);
 
-    // Pick USDC address for this chain
     let usdc_addr = match chain.to_lowercase().as_str() {
         "arbitrum" | "arb" | "42161" => USDC_ARBITRUM,
         _ => USDC_AVALANCHE,
     };
 
-    // Fetch in parallel: native balance, USDC balance, and open positions
+    // Fetch in parallel: native balance, USDC balance, open positions
     let datastore_clean = cfg.datastore.trim_start_matches("0x");
     let wallet_clean = wallet.trim_start_matches("0x");
     let positions_calldata = format!(
@@ -53,19 +54,17 @@ pub async fn run(chain: &str, args: QuickstartArgs) -> anyhow::Result<()> {
     let usdc_units = usdc_raw.unwrap_or(0);
     let usdc_balance = usdc_units as f64 / 1_000_000.0;
     let native_balance = native_wei as f64 / 1e18;
-
-    // Count positions from ABI-decoded response (only need the length)
     let position_count = count_positions(positions_raw.as_deref().unwrap_or(""));
 
-    // Build suggestion
     let (native_symbol, min_fee_wei) = if chain.to_lowercase().contains("aval") || chain == "43114" {
         ("AVAX", MIN_AVAX_FEE_WEI)
     } else {
         ("ETH", MIN_ETH_FEE_WEI)
     };
 
-    let (status, suggestion, next_command) = build_suggestion(
+    let (status, suggestion, onboarding_steps, next_command) = build_suggestion(
         chain,
+        &wallet,
         native_wei,
         min_fee_wei,
         native_symbol,
@@ -73,22 +72,26 @@ pub async fn run(chain: &str, args: QuickstartArgs) -> anyhow::Result<()> {
         position_count,
     );
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&json!({
-            "ok": true,
-            "wallet": wallet,
-            "chain": chain,
-            "assets": {
-                format!("{}_balance", native_symbol.to_lowercase()): native_balance,
-                "usdc_balance": usdc_balance,
-                "open_positions": position_count,
-            },
-            "status": status,
-            "suggestion": suggestion,
-            "next_command": next_command,
-        }))?
-    );
+    let mut out = json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "chain": chain,
+        "assets": {
+            format!("{}_balance", native_symbol.to_lowercase()): native_balance,
+            "usdc_balance": usdc_balance,
+            "open_positions": position_count,
+        },
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = json!(onboarding_steps);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
 }
 
@@ -107,17 +110,21 @@ fn count_positions(raw: &str) -> usize {
 
 fn build_suggestion(
     chain: &str,
+    wallet: &str,
     native_wei: u128,
     min_fee_wei: u128,
     native_symbol: &str,
     usdc_balance: f64,
     position_count: usize,
-) -> (&'static str, String, String) {
+) -> (&'static str, String, Vec<String>, String) {
+    let min_fee = min_fee_wei as f64 / 1e18;
+
     // Case 1: active trader — has open positions
     if position_count > 0 {
         return (
             "active",
             format!("You have {} open position(s) on GMX V2 ({}). Review them below.", position_count, chain),
+            vec![],
             format!("gmx-v2 --chain {} get-positions", chain),
         );
     }
@@ -127,45 +134,64 @@ fn build_suggestion(
         return (
             "ready",
             format!(
-                "You have {} and {:.2} USDC on {}. Ready to open a position.",
-                native_symbol, usdc_balance, chain
+                "Your wallet has {:.4} {} and {:.2} USDC on {}. You're ready to trade.",
+                native_wei as f64 / 1e18, native_symbol, usdc_balance, chain
             ),
+            vec![
+                format!("1. Browse available markets:  gmx-v2 --chain {} list-markets", chain),
+                format!("2. Open a position (preview):  gmx-v2 --chain {} open-position --market ETH/USD --direction long --size-usd 50 --collateral-token {} --collateral-amount 50000000 --dry-run", chain, USDC_ARBITRUM),
+                format!("3. Confirm the trade:          add --confirm to the command above"),
+            ],
             format!("gmx-v2 --chain {} list-markets", chain),
         );
     }
 
     // Case 3: has USDC but missing execution fee
     if usdc_balance >= 10.0 && native_wei < min_fee_wei {
-        let min_fee = min_fee_wei as f64 / 1e18;
         return (
             "needs_fee",
             format!(
-                "You have {:.2} USDC but need at least {:.3} {} for execution fees. Get some {} first.",
-                usdc_balance, min_fee, native_symbol, native_symbol
+                "You have {:.2} USDC but need at least {:.3} {} for keeper execution fees.",
+                usdc_balance, min_fee, native_symbol
             ),
-            format!("gmx-v2 --chain {} get-prices --token {}", chain, native_symbol),
+            vec![
+                format!("1. Send at least {:.3} {} to your wallet: {}", min_fee, native_symbol, wallet),
+                format!("2. Run gmx-v2 --chain {} quickstart again to confirm", chain),
+            ],
+            format!("gmx-v2 --chain {} list-markets", chain),
         );
     }
 
-    // Case 4: has execution fee but no collateral
+    // Case 4: has execution fee but insufficient collateral
     if native_wei >= min_fee_wei && usdc_balance < 10.0 {
         return (
             "needs_collateral",
             format!(
-                "You have {} for fees but need at least $10 USDC as collateral to open a position.",
-                native_symbol
+                "You have {:.4} {} for fees but need at least $10 USDC as collateral.",
+                native_wei as f64 / 1e18, native_symbol
             ),
-            format!("gmx-v2 --chain {} get-prices", chain),
+            vec![
+                format!("1. Send at least 10 USDC to your wallet: {}", wallet),
+                format!("2. Run gmx-v2 --chain {} quickstart again to confirm", chain),
+            ],
+            format!("gmx-v2 --chain {} list-markets", chain),
         );
     }
 
-    // Case 5: new user — nothing
+    // Case 5: new user — no funds at all
     (
         "no_funds",
         format!(
-            "No funds found on {}. Transfer USDC and {} to your wallet to start trading on GMX V2 (minimum ~$10 USDC + 0.002 {} for fees).",
-            chain, native_symbol, native_symbol
+            "No funds found on {}. Send USDC + {} to your wallet to get started.",
+            chain, native_symbol
         ),
-        format!("gmx-v2 --chain {} get-prices", chain),
+        vec![
+            format!("1. Send funds to your Arbitrum wallet: {}", wallet),
+            format!("   Minimum: $10 USDC (collateral) + {:.3} {} (execution fees)", min_fee, native_symbol),
+            format!("2. Run gmx-v2 --chain {} quickstart again to confirm funds arrived", chain),
+            format!("3. Run gmx-v2 --chain {} list-markets to browse available markets", chain),
+            format!("4. Open your first trade: gmx-v2 --chain {} open-position ...", chain),
+        ],
+        format!("gmx-v2 --chain {} list-markets", chain),
     )
 }

--- a/skills/gmx-v2-plugin/src/commands/quickstart.rs
+++ b/skills/gmx-v2-plugin/src/commands/quickstart.rs
@@ -1,0 +1,171 @@
+use clap::Args;
+use serde_json::json;
+
+/// Native USDC on Arbitrum One (6 decimals)
+const USDC_ARBITRUM: &str = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
+/// Native USDC.e (bridged) on Avalanche (6 decimals)
+const USDC_AVALANCHE: &str = "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6C";
+/// Minimum ETH for Arbitrum execution fees (2× single fee of 0.001 ETH)
+const MIN_ETH_FEE_WEI: u128 = 2_000_000_000_000_000; // 0.002 ETH
+/// Minimum AVAX for Avalanche execution fees (2× single fee of 0.012 AVAX)
+const MIN_AVAX_FEE_WEI: u128 = 24_000_000_000_000_000; // 0.024 AVAX
+
+#[derive(Args)]
+pub struct QuickstartArgs {
+    /// Wallet address to query. Defaults to currently logged-in onchainos wallet.
+    #[arg(long)]
+    pub address: Option<String>,
+}
+
+pub async fn run(chain: &str, args: QuickstartArgs) -> anyhow::Result<()> {
+    let cfg = crate::config::get_chain_config(chain)?;
+
+    let wallet = match args.address {
+        Some(addr) => addr,
+        None => crate::onchainos::resolve_wallet(cfg.chain_id)?,
+    };
+    if wallet.is_empty() {
+        anyhow::bail!("Cannot determine wallet address. Pass --address or ensure onchainos is logged in.");
+    }
+
+    eprintln!("Checking assets for {} on {}...", &wallet[..std::cmp::min(10, wallet.len())], chain);
+
+    // Pick USDC address for this chain
+    let usdc_addr = match chain.to_lowercase().as_str() {
+        "arbitrum" | "arb" | "42161" => USDC_ARBITRUM,
+        _ => USDC_AVALANCHE,
+    };
+
+    // Fetch in parallel: native balance, USDC balance, and open positions
+    let datastore_clean = cfg.datastore.trim_start_matches("0x");
+    let wallet_clean = wallet.trim_start_matches("0x");
+    let positions_calldata = format!(
+        "0x77cfb162{:0>64}{:0>64}{:064x}{:064x}",
+        datastore_clean, wallet_clean, 0u128, 20u128
+    );
+
+    let (native_wei, usdc_raw, positions_raw) = tokio::join!(
+        crate::rpc::get_eth_balance(&wallet, cfg.rpc_url),
+        crate::rpc::check_erc20_balance(cfg.rpc_url, usdc_addr, &wallet),
+        crate::rpc::eth_call(cfg.reader, &positions_calldata, cfg.rpc_url),
+    );
+
+    let usdc_units = usdc_raw.unwrap_or(0);
+    let usdc_balance = usdc_units as f64 / 1_000_000.0;
+    let native_balance = native_wei as f64 / 1e18;
+
+    // Count positions from ABI-decoded response (only need the length)
+    let position_count = count_positions(positions_raw.as_deref().unwrap_or(""));
+
+    // Build suggestion
+    let (native_symbol, min_fee_wei) = if chain.to_lowercase().contains("aval") || chain == "43114" {
+        ("AVAX", MIN_AVAX_FEE_WEI)
+    } else {
+        ("ETH", MIN_ETH_FEE_WEI)
+    };
+
+    let (status, suggestion, next_command) = build_suggestion(
+        chain,
+        native_wei,
+        min_fee_wei,
+        native_symbol,
+        usdc_balance,
+        position_count,
+    );
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "ok": true,
+            "wallet": wallet,
+            "chain": chain,
+            "assets": {
+                format!("{}_balance", native_symbol.to_lowercase()): native_balance,
+                "usdc_balance": usdc_balance,
+                "open_positions": position_count,
+            },
+            "status": status,
+            "suggestion": suggestion,
+            "next_command": next_command,
+        }))?
+    );
+    Ok(())
+}
+
+/// Decode just the array length from getAccountPositions ABI response.
+fn count_positions(raw: &str) -> usize {
+    let data = raw.trim_start_matches("0x");
+    if data.len() < 128 {
+        return 0;
+    }
+    let offset = usize::from_str_radix(&data[0..64], 16).unwrap_or(0) * 2;
+    if data.len() < offset + 64 {
+        return 0;
+    }
+    usize::from_str_radix(&data[offset..offset + 64], 16).unwrap_or(0)
+}
+
+fn build_suggestion(
+    chain: &str,
+    native_wei: u128,
+    min_fee_wei: u128,
+    native_symbol: &str,
+    usdc_balance: f64,
+    position_count: usize,
+) -> (&'static str, String, String) {
+    // Case 1: active trader — has open positions
+    if position_count > 0 {
+        return (
+            "active",
+            format!("You have {} open position(s) on GMX V2 ({}). Review them below.", position_count, chain),
+            format!("gmx-v2 --chain {} get-positions", chain),
+        );
+    }
+
+    // Case 2: funded and ready — has execution fee + collateral
+    if native_wei >= min_fee_wei && usdc_balance >= 10.0 {
+        return (
+            "ready",
+            format!(
+                "You have {} and {:.2} USDC on {}. Ready to open a position.",
+                native_symbol, usdc_balance, chain
+            ),
+            format!("gmx-v2 --chain {} list-markets", chain),
+        );
+    }
+
+    // Case 3: has USDC but missing execution fee
+    if usdc_balance >= 10.0 && native_wei < min_fee_wei {
+        let min_fee = min_fee_wei as f64 / 1e18;
+        return (
+            "needs_fee",
+            format!(
+                "You have {:.2} USDC but need at least {:.3} {} for execution fees. Get some {} first.",
+                usdc_balance, min_fee, native_symbol, native_symbol
+            ),
+            format!("gmx-v2 --chain {} get-prices --token {}", chain, native_symbol),
+        );
+    }
+
+    // Case 4: has execution fee but no collateral
+    if native_wei >= min_fee_wei && usdc_balance < 10.0 {
+        return (
+            "needs_collateral",
+            format!(
+                "You have {} for fees but need at least $10 USDC as collateral to open a position.",
+                native_symbol
+            ),
+            format!("gmx-v2 --chain {} get-prices", chain),
+        );
+    }
+
+    // Case 5: new user — nothing
+    (
+        "no_funds",
+        format!(
+            "No funds found on {}. Transfer USDC and {} to your wallet to start trading on GMX V2 (minimum ~$10 USDC + 0.002 {} for fees).",
+            chain, native_symbol, native_symbol
+        ),
+        format!("gmx-v2 --chain {} get-prices", chain),
+    )
+}

--- a/skills/gmx-v2-plugin/src/main.rs
+++ b/skills/gmx-v2-plugin/src/main.rs
@@ -60,6 +60,9 @@ enum Commands {
 
     /// Claim accrued funding fees from GMX V2 positions
     ClaimFundingFees(commands::claim_funding_fees::ClaimFundingFeesArgs),
+
+    /// Check wallet assets and get a recommended next step for GMX V2
+    Quickstart(commands::quickstart::QuickstartArgs),
 }
 
 #[tokio::main]
@@ -106,6 +109,9 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         }
         Commands::ClaimFundingFees(args) => {
             commands::claim_funding_fees::run(&cli.chain, cli.dry_run, cli.confirm, args).await
+        }
+        Commands::Quickstart(args) => {
+            commands::quickstart::run(&cli.chain, args).await
         }
     }
 }


### PR DESCRIPTION
## Summary

New `quickstart` command for first-time user onboarding on GMX V2.

### What it does

Detects wallet state in one call by querying in parallel:
- Native token balance (ETH on Arbitrum / AVAX on Avalanche) — needed for execution fees
- USDC balance — primary collateral token
- Open position count — via ABI-decoded `getAccountPositions` contract call

Returns structured JSON with `status`, `suggestion`, and a ready-to-run `next_command`:

| `status` | Condition | `next_command` |
|----------|-----------|----------------|
| `active` | Has open positions | `gmx-v2 --chain X get-positions` |
| `ready` | Has ETH + USDC ≥ $10 | `gmx-v2 --chain X list-markets` |
| `needs_fee` | Has USDC, no ETH for fees | show ETH price |
| `needs_collateral` | Has ETH, no USDC | show prices |
| `no_funds` | Nothing | show prices |

### Motivation

When a user says "I want to trade on GMX" or "GMX 怎么用", the Agent had no way to know if they need to fund their wallet, already have positions, or are ready to trade. `quickstart` fills this gap with a single command that works on both Arbitrum and Avalanche.

## Test plan

- [x] Tested live: account with 2 open positions → `status: active`, correct `next_command`
- [x] `cargo build --release` passes for v0.2.6
- [x] Diff limited to `skills/gmx-v2-plugin/` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)