### PR TITLE
feat(hyperliquid): add quickstart command with guided onboarding (v0.3.6)

### DIFF
--- a/skills/hyperliquid-plugin/.claude-plugin/plugin.json
+++ b/skills/hyperliquid-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperliquid",
   "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/hyperliquid-plugin/Cargo.lock
+++ b/skills/hyperliquid-plugin/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "hyperliquid-plugin"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/hyperliquid-plugin/Cargo.toml
+++ b/skills/hyperliquid-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperliquid-plugin"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [[bin]]

--- a/skills/hyperliquid-plugin/SKILL.md
+++ b/skills/hyperliquid-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyperliquid-plugin
 description: Hyperliquid DEX — trade perps & spot, deposit from Arbitrum, withdraw to Arbitrum, transfer between perp and spot accounts, manage gas on HyperEVM.
-version: "0.3.5"
+version: "0.3.6"
 author: GeoGu360
 tags:
   - perps
@@ -26,7 +26,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/hyperliquid-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.3.5"
+LOCAL_VER="0.3.6"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -99,7 +99,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.5/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.6/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
 chmod +x ~/.local/bin/.hyperliquid-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -107,7 +107,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/hyperliquid-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.3.5" > "$HOME/.plugin-store/managed/hyperliquid-plugin"
+echo "0.3.6" > "$HOME/.plugin-store/managed/hyperliquid-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -127,7 +127,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"hyperliquid-plugin","version":"0.3.5"}' >/dev/null 2>&1 || true
+    -d '{"name":"hyperliquid-plugin","version":"0.3.6"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -227,6 +227,60 @@ The binary `hyperliquid` must be in your PATH.
 ## Commands
 
 > **Write operations require `--confirm`**: Run the command without `--confirm` first to preview the action. Add `--confirm` to sign and broadcast.
+
+---
+
+### 0. `quickstart` — Check Assets & Get Guided Next Step
+
+Detects wallet state across Arbitrum and Hyperliquid in one call, then recommends the right next action. Use this when a user says "I want to start trading on Hyperliquid" or "what should I do first" without knowing their current status.
+
+**Trigger phrases:**
+- "帮我看下 Hyperliquid 状态" / "我要开始用 Hyperliquid"
+- "我有多少资产在 HL" / "quickstart hyperliquid"
+- "Hyperliquid 怎么用" / "I want to trade on Hyperliquid"
+- "check my hyperliquid balance" / "what should I do on HL"
+
+**Parameters:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--address` | No | EVM wallet address (defaults to onchainos wallet) |
+
+**Output fields:** `wallet`, `assets.arb_usdc_balance`, `assets.hl_account_value_usd`, `assets.hl_withdrawable_usd`, `assets.hl_open_positions`, `positions[]`, `status`, `suggestion`, `next_command`
+
+**Status values and flow:**
+
+| `status` | Condition | `next_command` |
+|----------|-----------|----------------|
+| `active` | Has open HL positions | `hyperliquid positions` |
+| `ready` | HL account ≥ $1, no positions | `hyperliquid order ...` |
+| `needs_deposit` | Arbitrum USDC ≥ $5, HL empty | `hyperliquid deposit --amount X --confirm` |
+| `low_balance` | Arbitrum USDC < $5 | `hyperliquid address` |
+| `no_funds` | No USDC anywhere | `hyperliquid address` |
+
+**Example:**
+```
+hyperliquid quickstart
+```
+
+```json
+{
+  "ok": true,
+  "wallet": "0x87fb0647...",
+  "assets": {
+    "arb_usdc_balance": 1.63,
+    "hl_account_value_usd": 9.89,
+    "hl_withdrawable_usd": 8.77,
+    "hl_open_positions": 1
+  },
+  "positions": [
+    { "coin": "BTC", "side": "long", "size": "0.00015", "entryPrice": "74633.0", "unrealizedPnl": "0.0015" }
+  ],
+  "status": "active",
+  "suggestion": "You have open positions on Hyperliquid. Review them below.",
+  "next_command": "hyperliquid positions"
+}
+```
 
 ---
 
@@ -903,6 +957,10 @@ All data returned by `hyperliquid positions`, `hyperliquid prices`, and exchange
 ---
 
 ## Changelog
+
+### v0.3.6 (2026-04-17)
+
+- **feat**: `quickstart` — new command; checks Arbitrum USDC balance + Hyperliquid account value + open positions in parallel via onchainos, returns structured JSON with `status` and `next_command` to guide first-time users from zero to first trade
 
 ### v0.3.2 (2026-04-13)
 

--- a/skills/hyperliquid-plugin/plugin.yaml
+++ b/skills/hyperliquid-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: hyperliquid-plugin
-version: "0.3.5"
+version: "0.3.6"
 description: "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC"
 author:
   name: GeoGu360

--- a/skills/hyperliquid-plugin/src/commands/mod.rs
+++ b/skills/hyperliquid-plugin/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod spot_prices;
 pub mod tpsl;
 pub mod transfer;
 pub mod withdraw;
+pub mod quickstart;

--- a/skills/hyperliquid-plugin/src/commands/quickstart.rs
+++ b/skills/hyperliquid-plugin/src/commands/quickstart.rs
@@ -1,0 +1,187 @@
+use clap::Args;
+use crate::api::get_clearinghouse_state;
+use crate::config::{info_url, ARBITRUM_CHAIN_ID, USDC_ARBITRUM};
+use crate::onchainos::resolve_wallet;
+use crate::rpc::{ARBITRUM_RPC, erc20_balance};
+
+const ABOUT: &str = "Hyperliquid is a high-performance on-chain perpetuals DEX — trade BTC, ETH and 100+ assets with up to 50x leverage at CEX speed, with full on-chain transparency and no KYC.";
+
+#[derive(Args)]
+pub struct QuickstartArgs {
+    /// Wallet address to query. Defaults to the connected onchainos wallet.
+    #[arg(long)]
+    pub address: Option<String>,
+}
+
+pub async fn run(args: QuickstartArgs) -> anyhow::Result<()> {
+    // 1. Resolve wallet (EVM address shared by Arbitrum + Hyperliquid)
+    let wallet = match args.address {
+        Some(addr) => addr,
+        None => resolve_wallet(ARBITRUM_CHAIN_ID)?,
+    };
+
+    eprintln!("Checking assets for {}...", &wallet[..std::cmp::min(10, wallet.len())]);
+
+    // 2. Fetch in parallel: Arbitrum USDC balance + HL perp clearinghouse state
+    let url = info_url();
+    let (arb_result, hl_result) = tokio::join!(
+        erc20_balance(USDC_ARBITRUM, &wallet, ARBITRUM_RPC),
+        get_clearinghouse_state(url, &wallet),
+    );
+
+    let arb_usdc_units = arb_result.unwrap_or(0);
+    let arb_usdc = arb_usdc_units as f64 / 1_000_000.0;
+
+    // Parse HL clearinghouse state
+    let (hl_account_value, hl_withdrawable, open_positions, positions_detail) = match hl_result {
+        Ok(ref state) => {
+            let margin = &state["marginSummary"];
+            let account_value: f64 = margin["accountValue"]
+                .as_str()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
+            let withdrawable: f64 = state["withdrawable"]
+                .as_str()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
+            let empty = vec![];
+            let asset_positions = state["assetPositions"].as_array().unwrap_or(&empty);
+            let coins: Vec<String> = asset_positions
+                .iter()
+                .filter_map(|p| p["position"]["coin"].as_str().map(|s| s.to_string()))
+                .collect();
+            let detail: Vec<serde_json::Value> = asset_positions
+                .iter()
+                .map(|p| {
+                    let pos = &p["position"];
+                    let szi = pos["szi"].as_str().unwrap_or("0");
+                    serde_json::json!({
+                        "coin":         pos["coin"].as_str().unwrap_or("?"),
+                        "side":         if szi.starts_with('-') { "short" } else { "long" },
+                        "size":         szi,
+                        "entryPrice":   pos["entryPx"].as_str().unwrap_or("0"),
+                        "unrealizedPnl": pos["unrealizedPnl"].as_str().unwrap_or("0"),
+                    })
+                })
+                .collect();
+            (account_value, withdrawable, coins, detail)
+        }
+        Err(_) => (0.0, 0.0, vec![], vec![]),
+    };
+
+    // 3. Build guidance based on account state
+    let (status, suggestion, onboarding_steps, next_command) =
+        build_suggestion(&wallet, arb_usdc, hl_account_value, &open_positions);
+
+    let mut out = serde_json::json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "assets": {
+            "arb_usdc_balance":     arb_usdc,
+            "hl_account_value_usd": hl_account_value,
+            "hl_withdrawable_usd":  hl_withdrawable,
+            "hl_open_positions":    open_positions.len(),
+        },
+        "positions": positions_detail,
+        "status":       status,
+        "suggestion":   suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = serde_json::json!(onboarding_steps);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&out)?);
+
+    Ok(())
+}
+
+/// Returns (status, human-readable suggestion, onboarding_steps, ready-to-run command).
+fn build_suggestion(
+    wallet: &str,
+    arb_usdc: f64,
+    hl_account_value: f64,
+    open_positions: &[String],
+) -> (&'static str, &'static str, Vec<String>, String) {
+    // Case 1: active trader — has open positions
+    if !open_positions.is_empty() {
+        return (
+            "active",
+            "You have open positions on Hyperliquid. Review them below.",
+            vec![],
+            "hyperliquid positions".to_string(),
+        );
+    }
+
+    // Case 2: funded and ready — USDC on HL, no positions yet
+    if hl_account_value >= 1.0 {
+        return (
+            "ready",
+            "Your Hyperliquid perp account is funded. Place your first trade.",
+            vec![
+                "1. Check available markets:  hyperliquid prices".to_string(),
+                "2. Preview a trade (no --confirm = preview only):".to_string(),
+                "   hyperliquid order --coin BTC --side long --size 10 --leverage 5".to_string(),
+                "3. When ready, add --confirm to execute on-chain:".to_string(),
+                "   hyperliquid order --coin BTC --side long --size 10 --leverage 5 --confirm".to_string(),
+            ],
+            "hyperliquid order --coin BTC --side long --size 10 --leverage 5".to_string(),
+        );
+    }
+
+    // Case 3: has enough Arbitrum USDC to deposit (minimum $5)
+    if arb_usdc >= 5.0 {
+        let suggest = ((arb_usdc * 0.9 * 100.0).floor() / 100.0).max(5.0);
+        let suggest = suggest.min(arb_usdc);
+        return (
+            "needs_deposit",
+            "You have USDC on Arbitrum. Deposit to Hyperliquid to start trading perps (minimum $5).",
+            vec![
+                format!("1. Deposit USDC from Arbitrum to Hyperliquid (minimum $5):"),
+                format!("   hyperliquid deposit --amount {:.2} --confirm", suggest),
+                "2. Run quickstart again to confirm your HL account is funded:".to_string(),
+                "   hyperliquid quickstart".to_string(),
+                "3. Check available markets:  hyperliquid prices".to_string(),
+                "4. Place your first trade:".to_string(),
+                "   hyperliquid order --coin BTC --side long --size 10 --leverage 5 --confirm".to_string(),
+            ],
+            format!("hyperliquid deposit --amount {:.2} --confirm", suggest),
+        );
+    }
+
+    // Case 4: some Arbitrum USDC but below $5 minimum
+    if arb_usdc > 0.0 {
+        return (
+            "low_balance",
+            "You have some USDC on Arbitrum but below the $5 deposit minimum. Add more USDC to your Arbitrum wallet.",
+            vec![
+                format!("1. Send at least $5 USDC to your Arbitrum wallet:"),
+                format!("   {}", wallet),
+                "2. Run quickstart again to check your balance:".to_string(),
+                "   hyperliquid quickstart".to_string(),
+                "3. Then deposit to Hyperliquid:".to_string(),
+                "   hyperliquid deposit --amount 5 --confirm".to_string(),
+            ],
+            "hyperliquid address".to_string(),
+        );
+    }
+
+    // Case 5: new user — no funds anywhere
+    (
+        "no_funds",
+        "No USDC found on Arbitrum or Hyperliquid. Transfer USDC to your Arbitrum wallet, then deposit (minimum $5).",
+        vec![
+            "1. Send USDC to your Arbitrum wallet (minimum $5):".to_string(),
+            format!("   {}", wallet),
+            "2. Run quickstart again to confirm your balance:".to_string(),
+            "   hyperliquid quickstart".to_string(),
+            "3. Deposit USDC to Hyperliquid:".to_string(),
+            "   hyperliquid deposit --amount <amount> --confirm".to_string(),
+            "4. Place your first trade:".to_string(),
+            "   hyperliquid order --coin BTC --side long --size 10 --leverage 5 --confirm".to_string(),
+        ],
+        "hyperliquid address".to_string(),
+    )
+}

--- a/skills/hyperliquid-plugin/src/main.rs
+++ b/skills/hyperliquid-plugin/src/main.rs
@@ -25,6 +25,7 @@ use commands::{
     tpsl::TpslArgs,
     transfer::TransferArgs,
     withdraw::WithdrawArgs,
+    quickstart::QuickstartArgs,
 };
 
 #[derive(Parser)]
@@ -76,6 +77,8 @@ enum Commands {
     SpotOrder(SpotOrderArgs),
     /// Cancel an open spot order by order ID or cancel all for a token (requires --confirm)
     SpotCancel(SpotCancelArgs),
+    /// Check wallet assets and get a recommended next step for Hyperliquid
+    Quickstart(QuickstartArgs),
 }
 
 #[tokio::main]
@@ -100,5 +103,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::SpotPrices(args) => commands::spot_prices::run(args).await,
         Commands::SpotOrder(args) => commands::spot_order::run(args).await,
         Commands::SpotCancel(args) => commands::spot_cancel::run(args).await,
+        Commands::Quickstart(args) => commands::quickstart::run(args).await,
     }
 }


### PR DESCRIPTION
## Summary

- New \`quickstart\` subcommand — checks Arbitrum USDC balance + Hyperliquid perp account in parallel, then guides user to their next action
- Detects 5 states: \`active\` / \`ready\` / \`needs_deposit\` / \`low_balance\` / \`no_funds\`
- Emits \`about\` field (one-liner description of Hyperliquid) and \`onboarding_steps[]\` with the user's wallet address embedded for new-user cases

## Example output (new user, no funds)

\`\`\`json
{
  "about": "Hyperliquid is a high-performance on-chain perpetuals DEX...",
  "wallet": "0xabc...123",
  "status": "no_funds",
  "suggestion": "No USDC found. Transfer USDC to your Arbitrum wallet, then deposit.",
  "onboarding_steps": [
    "1. Send USDC to your Arbitrum wallet (minimum $5):",
    "   0xabc...123",
    "2. Run quickstart again: hyperliquid quickstart",
    "3. Deposit: hyperliquid deposit --amount <amount> --confirm",
    "4. Place your first trade: hyperliquid order --coin BTC --side long ..."
  ],
  "next_command": "hyperliquid address"
}
\`\`\`

## Test plan

- [ ] \`hyperliquid quickstart\` with funded HL account → status: active/ready
- [ ] \`hyperliquid quickstart\` with ARB USDC → status: needs_deposit, deposit command in next_command
- [ ] \`hyperliquid quickstart\` with no funds → status: no_funds, wallet address in onboarding_steps
- [ ] \`about\` present in all cases; \`onboarding_steps\` omitted for active case

🤖 Generated with [Claude Code](https://claude.com/claude-code)