### PR TITLE
feat(kamino-liquidity): add quickstart command + GEN-001 structured errors (v0.1.3)

### DIFF
--- a/skills/kamino-liquidity-plugin/.claude-plugin/plugin.json
+++ b/skills/kamino-liquidity-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kamino-liquidity",
   "description": "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn yield, withdraw shares, and track positions.",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/kamino-liquidity-plugin/Cargo.lock
+++ b/skills/kamino-liquidity-plugin/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,32 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,21 +175,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -222,43 +187,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -285,12 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,56 +241,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -421,7 +316,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -446,22 +340,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -482,11 +361,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -572,12 +449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,18 +467,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -651,8 +510,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "kamino-liquidity"
-version = "0.1.0"
+name = "kamino-liquidity-plugin"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -665,22 +524,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -704,16 +551,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -727,23 +574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,50 +584,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -835,12 +621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,13 +630,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "proc-macro2",
- "syn",
+ "zerocopy",
 ]
 
 [[package]]
@@ -866,6 +645,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -879,9 +713,38 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "6.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -900,29 +763,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -930,6 +790,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -947,17 +808,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.4"
+name = "rustc-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
@@ -966,6 +820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -978,6 +833,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1005,48 +861,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1191,37 +1009,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
+ "thiserror-impl",
 ]
 
 [[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1278,35 +1082,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -1387,12 +1168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,12 +1198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,15 +1217,6 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1517,40 +1277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,39 +1287,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1682,88 +1398,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -1792,6 +1426,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/skills/kamino-liquidity-plugin/Cargo.toml
+++ b/skills/kamino-liquidity-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kamino-liquidity-plugin"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [[bin]]

--- a/skills/kamino-liquidity-plugin/SKILL.md
+++ b/skills/kamino-liquidity-plugin/SKILL.md
@@ -4,8 +4,8 @@ description: "Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to e
 license: MIT
 metadata:
   author: GeoGu360
-  version: "0.1.2"
-version: "0.1.2"
+  version: "0.1.3"
+version: "0.1.3"
 author: GeoGu360
 ---
 
@@ -22,7 +22,7 @@ author: GeoGu360
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/kamino-liquidity-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.1.2"
+LOCAL_VER="0.1.3"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -95,7 +95,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/kamino-liquidity-plugin@0.1.2/kamino-liquidity-plugin-${TARGET}${EXT}" -o ~/.local/bin/.kamino-liquidity-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/kamino-liquidity-plugin@0.1.3/kamino-liquidity-plugin-${TARGET}${EXT}" -o ~/.local/bin/.kamino-liquidity-plugin-core${EXT}
 chmod +x ~/.local/bin/.kamino-liquidity-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -103,7 +103,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/kamino-liquidity-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.1.2" > "$HOME/.plugin-store/managed/kamino-liquidity-plugin"
+echo "0.1.3" > "$HOME/.plugin-store/managed/kamino-liquidity-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -123,7 +123,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"kamino-liquidity-plugin","version":"0.1.2"}' >/dev/null 2>&1 || true
+    -d '{"name":"kamino-liquidity-plugin","version":"0.1.3"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -166,6 +166,53 @@ Before running any command:
 
 > **Write operations require `--confirm`**: Run the command first without `--confirm` to preview
 > the transaction details. Add `--confirm` to broadcast.
+
+### quickstart — Wallet status and first command suggestion
+
+Shows wallet balances, active KVault positions, and suggests the best next action.
+
+**Usage:**
+```
+kamino-liquidity quickstart [--wallet <address>]
+```
+
+**Arguments:**
+- `--wallet` — Solana wallet address (optional; resolved from onchainos if omitted)
+
+**Trigger phrases:**
+- "Get started with Kamino"
+- "What should I do first on Kamino?"
+- "Check my Kamino status"
+- "Kamino quickstart"
+
+**Output fields:** `ok`, `about`, `wallet`, `assets` (sol_balance, usdc_balance, all_tokens), `kvault_positions`, `status` (active/ready/needs_gas/needs_funds/no_funds), `suggestion`, `next_command`, `onboarding_steps` (array of 5 steps, only when status != active)
+
+**Example output:**
+```json
+{
+  "ok": true,
+  "about": "Kamino KVaults are automated yield-optimization vaults on Solana...",
+  "wallet": "DTEqFXyFM9aMSGu9sw3PpRsZce6xqqmaUbGkFjmeieGE",
+  "assets": {
+    "sol_balance": "1.234567",
+    "usdc_balance": "50.000000",
+    "all_tokens": [{"symbol": "SOL", "balance": "1.234567"}, {"symbol": "USDC", "balance": "50.000000"}]
+  },
+  "kvault_positions": 0,
+  "status": "ready",
+  "suggestion": "Wallet is funded. You can deposit USDC into a KVault to start earning yield.",
+  "next_command": "kamino-liquidity vaults --token USDC",
+  "onboarding_steps": [
+    {"step": 1, "title": "Check available vaults", "command": "kamino-liquidity vaults --token USDC"},
+    {"step": 2, "title": "Preview a deposit", "command": "kamino-liquidity deposit --vault <VAULT_ADDRESS> --amount <AMOUNT> --dry-run"},
+    {"step": 3, "title": "Execute deposit", "command": "kamino-liquidity deposit --vault <VAULT_ADDRESS> --amount <AMOUNT> --confirm"},
+    {"step": 4, "title": "Check positions", "command": "kamino-liquidity positions"},
+    {"step": 5, "title": "Withdraw when ready", "command": "kamino-liquidity withdraw --vault <VAULT_ADDRESS> --amount <SHARES> --confirm"}
+  ]
+}
+```
+
+---
 
 ### vaults — List KVaults
 
@@ -264,6 +311,7 @@ kamino-liquidity deposit --vault <address> --amount <amount> [--chain 501] [--wa
 - `--chain` — Chain ID (must be 501, default: 501)
 - `--wallet` — Solana wallet address (optional; resolved from onchainos if omitted)
 - `--dry-run` — Preview transaction without broadcasting
+- `--confirm` — Broadcast the transaction (required for on-chain execution)
 
 **Trigger phrases:**
 - "Deposit 0.001 SOL into Kamino vault GEodMs..."
@@ -306,6 +354,7 @@ kamino-liquidity withdraw --vault <address> --amount <shares> [--chain 501] [--w
 - `--chain` — Chain ID (must be 501, default: 501)
 - `--wallet` — Solana wallet address (optional; resolved from onchainos if omitted)
 - `--dry-run` — Preview transaction without broadcasting
+- `--confirm` — Broadcast the transaction (required for on-chain execution)
 
 **Trigger phrases:**
 - "Withdraw from Kamino vault GEodMs..."

--- a/skills/kamino-liquidity-plugin/plugin.yaml
+++ b/skills/kamino-liquidity-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: kamino-liquidity-plugin
-version: "0.1.2"
+version: "0.1.3"
 description: Kamino Liquidity KVault earn vaults on Solana. Deposit tokens to earn
   yield, withdraw shares, and track positions.
 author:

--- a/skills/kamino-liquidity-plugin/src/commands/deposit.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/deposit.rs
@@ -32,62 +32,120 @@ pub struct DepositArgs {
 
 pub async fn run(args: DepositArgs) -> anyhow::Result<()> {
     if args.chain != 501 {
-        anyhow::bail!("kamino-liquidity only supports Solana (chain 501)");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "kamino-liquidity only supports Solana (chain 501)",
+                "error_code": "UNSUPPORTED_CHAIN",
+                "suggestion": "Use --chain 501 or omit --chain (defaults to 501)."
+            }))?
+        );
+        return Ok(());
     }
 
     // Dry-run early return — before wallet resolution
     if args.dry_run {
-        // Still call the API to verify it accepts our parameters
         let dummy_wallet = "DTEqFXyFM9aMSGu9sw3PpRsZce6xqqmaUbGkFjmeieGE";
         let wallet = args.wallet.as_deref().unwrap_or(dummy_wallet);
-        let tx_b64 = api::build_deposit_tx(&args.vault, wallet, &args.amount).await?;
-        let output = serde_json::json!({
-            "ok": true,
-            "dry_run": true,
-            "vault": args.vault,
-            "amount": args.amount,
-            "serialized_tx": tx_b64,
-            "data": { "txHash": "" }
-        });
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        let tx_b64 = match api::build_deposit_tx(&args.vault, wallet, &args.amount).await {
+            Ok(tx) => tx,
+            Err(e) => {
+                println!("{}", super::error_response(&e, Some(&args.vault)));
+                return Ok(());
+            }
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "dry_run": true,
+                "vault": args.vault,
+                "amount": args.amount,
+                "serialized_tx": tx_b64,
+                "data": { "txHash": "" }
+            }))?
+        );
         return Ok(());
     }
 
     // Resolve wallet (after dry-run guard)
     let wallet = match args.wallet {
         Some(w) => w,
-        None => onchainos::resolve_wallet_solana()?,
+        None => match onchainos::resolve_wallet_solana() {
+            Ok(w) => w,
+            Err(e) => {
+                println!("{}", super::error_response(&e, Some(&args.vault)));
+                return Ok(());
+            }
+        },
     };
 
     if wallet.is_empty() {
-        anyhow::bail!("Could not resolve wallet address. Pass --wallet <address> or ensure onchainos is logged in.");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "Cannot resolve wallet address.",
+                "error_code": "WALLET_NOT_FOUND",
+                "suggestion": "Pass --wallet <address> or run `onchainos wallet balance --chain 501` to verify login."
+            }))?
+        );
+        return Ok(());
     }
 
     // Build deposit transaction from Kamino API
-    // NOTE: amount is in UI units (0.001 SOL = 0.001, not 1000000 lamports)
-    let tx_b64 = api::build_deposit_tx(&args.vault, &wallet, &args.amount).await?;
+    let tx_b64 = match api::build_deposit_tx(&args.vault, &wallet, &args.amount).await {
+        Ok(tx) => tx,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
 
-    // Submit via onchainos (base64→base58 conversion done internally)
-    // Solana blockhash expires ~60s — must submit immediately
-    // ── Preview mode: show TX details without broadcasting ──────────────────
+    // Preview mode
     if !args.confirm && !args.dry_run {
         println!("=== Transaction Preview (NOT broadcast) ===");
         println!("Add --confirm to execute this transaction.");
         return Ok(());
     }
-    let result = onchainos::wallet_contract_call_solana(KVAULT_PROGRAM_ID, &tx_b64, false).await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result);
-    let output = serde_json::json!({
-        "ok": true,
-        "vault": args.vault,
-        "wallet": wallet,
-        "amount": args.amount,
-        "data": {
-            "txHash": tx_hash
-        },
-        "explorer": format!("https://solscan.io/tx/{}", tx_hash)
-    });
-    println!("{}", serde_json::to_string_pretty(&output)?);
+    // Submit via onchainos (base64→base58 conversion done internally)
+    // Solana blockhash expires ~60s — must submit immediately
+    let result = match onchainos::wallet_contract_call_solana(KVAULT_PROGRAM_ID, &tx_b64, false).await {
+        Ok(r) => r,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
+
+    let tx_hash = match onchainos::extract_tx_hash(&result) {
+        Ok(h) => h,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
+
+    if let Err(e) = onchainos::wait_for_tx_solana(&tx_hash, &wallet).await {
+        println!("{}", super::error_response(&e, Some(&args.vault)));
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "vault": args.vault,
+            "wallet": wallet,
+            "amount": args.amount,
+            "action": "deposit",
+            "data": {
+                "txHash": tx_hash
+            },
+            "explorer": format!("https://solscan.io/tx/{}", tx_hash)
+        }))?
+    );
     Ok(())
 }

--- a/skills/kamino-liquidity-plugin/src/commands/mod.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/mod.rs
@@ -1,4 +1,55 @@
 pub mod deposit;
 pub mod positions;
+pub mod quickstart;
 pub mod vaults;
 pub mod withdraw;
+
+/// Format a business error as a structured JSON string for stdout.
+pub fn error_response(err: &anyhow::Error, vault: Option<&str>) -> String {
+    let msg = format!("{:#}", err);
+    let (error_code, suggestion) = classify_error(&msg, vault);
+    serde_json::to_string_pretty(&serde_json::json!({
+        "ok": false,
+        "error": msg,
+        "error_code": error_code,
+        "suggestion": suggestion,
+    }))
+    .unwrap_or_else(|_| format!(r#"{{"ok":false,"error":{:?}}}"#, msg))
+}
+
+fn classify_error(msg: &str, vault: Option<&str>) -> (&'static str, String) {
+    let vault_hint = vault.unwrap_or("this vault");
+    if msg.contains("WALLET_NOT_FOUND") || msg.contains("resolve wallet") || msg.contains("resolve Solana wallet") {
+        return ("WALLET_NOT_FOUND",
+            "Run `onchainos wallet balance --chain 501` to verify login, or pass --wallet <address>.".into());
+    }
+    if msg.contains("base64") || msg.contains("base58") {
+        return ("TX_ENCODING_ERROR",
+            "Transaction encoding failed. The API transaction may have expired — retry.".into());
+    }
+    if msg.contains("contract-call failed") || msg.contains("contract-call returned error") {
+        return ("TX_BROADCAST_ERROR",
+            format!("Transaction broadcast failed for {}. Check wallet balance and try again.", vault_hint));
+    }
+    if msg.contains("Timeout") || msg.contains("timeout") {
+        return ("TX_TIMEOUT",
+            "Transaction did not confirm within 60s. Check Solscan for the tx hash.".into());
+    }
+    if msg.contains("failed on-chain") {
+        return ("TX_FAILED_ON_CHAIN",
+            "Transaction was included in a block but execution failed. See failReason for details.".into());
+    }
+    if msg.contains("insufficient") || msg.contains("Insufficient") {
+        return ("INSUFFICIENT_BALANCE",
+            format!("Insufficient token balance to deposit into {}.", vault_hint));
+    }
+    if msg.contains("fewer than 32 characters") || msg.contains("kvault must") || msg.contains("vault must") {
+        return ("INVALID_VAULT_ADDRESS",
+            format!("'{}' is not a valid vault address. Use `kamino-liquidity vaults` to list valid vault addresses.", vault_hint));
+    }
+    if msg.contains("Kamino API") {
+        return ("KAMINO_API_ERROR",
+            "Kamino API returned an error. Check vault address and amount, then retry.".into());
+    }
+    ("UNKNOWN_ERROR", "See error field for details.".into())
+}

--- a/skills/kamino-liquidity-plugin/src/commands/positions.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/positions.rs
@@ -17,23 +17,80 @@ pub struct PositionsArgs {
 
 pub async fn run(args: PositionsArgs) -> anyhow::Result<()> {
     if args.chain != 501 {
-        anyhow::bail!("kamino-liquidity only supports Solana (chain 501)");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "kamino-liquidity only supports Solana (chain 501)",
+                "error_code": "UNSUPPORTED_CHAIN",
+                "suggestion": "Use --chain 501 or omit --chain (defaults to 501)."
+            }))?
+        );
+        return Ok(());
     }
 
     let wallet = match args.wallet {
         Some(w) => w,
-        None => onchainos::resolve_wallet_solana()?,
+        None => match onchainos::resolve_wallet_solana() {
+            Ok(w) => w,
+            Err(e) => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": false,
+                        "error": format!("{:#}", e),
+                        "error_code": "WALLET_NOT_FOUND",
+                        "suggestion": "Run `onchainos wallet balance --chain 501` to verify login, or pass --wallet <address>."
+                    }))?
+                );
+                return Ok(());
+            }
+        },
     };
 
     if wallet.is_empty() {
-        anyhow::bail!("Could not resolve wallet address. Pass --wallet <address> or ensure onchainos is logged in.");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "Cannot resolve wallet address.",
+                "error_code": "WALLET_NOT_FOUND",
+                "suggestion": "Pass --wallet <address> or run `onchainos wallet balance --chain 501` to verify login."
+            }))?
+        );
+        return Ok(());
     }
 
-    let data = api::get_user_positions(&wallet).await?;
+    let data = match api::get_user_positions(&wallet).await {
+        Ok(d) => d,
+        Err(e) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("{:#}", e),
+                    "error_code": "KAMINO_API_ERROR",
+                    "suggestion": "Failed to fetch positions from Kamino API. Check your connection and retry."
+                }))?
+            );
+            return Ok(());
+        }
+    };
 
     let positions = match data.as_array() {
         Some(arr) => arr,
-        None => anyhow::bail!("Unexpected positions response: {}", data),
+        None => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("Unexpected positions response: {}", data),
+                    "error_code": "KAMINO_API_ERROR",
+                    "suggestion": "Kamino API returned an unexpected format. Retry or check api.kamino.finance status."
+                }))?
+            );
+            return Ok(());
+        }
     };
 
     let mut results: Vec<serde_json::Map<String, Value>> = Vec::new();

--- a/skills/kamino-liquidity-plugin/src/commands/quickstart.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/quickstart.rs
@@ -1,0 +1,152 @@
+/// `kamino-liquidity quickstart` — wallet status, balances, and suggested first command.
+
+use clap::Args;
+use anyhow::Result;
+
+use crate::{api, onchainos};
+
+const ABOUT: &str = "Kamino KVaults are automated yield-optimization vaults on Solana — \
+    deposit tokens (USDC, SOL, and more) to earn yield from Kamino lending markets \
+    without manually managing positions.";
+
+const MIN_SOL_GAS: f64 = 0.01;
+const MIN_USDC: f64 = 1.0;
+
+/// USDC mint on Solana mainnet
+const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+#[derive(Args, Debug)]
+pub struct QuickstartArgs {
+    /// Wallet address (base58). If omitted, resolved from onchainos.
+    #[arg(long)]
+    pub wallet: Option<String>,
+}
+
+pub async fn run(args: QuickstartArgs) -> Result<()> {
+    // Resolve wallet
+    let wallet = match args.wallet {
+        Some(w) => w,
+        None => match onchainos::resolve_wallet_solana() {
+            Ok(w) => w,
+            Err(e) => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "ok": false,
+                        "error": format!("{:#}", e),
+                        "error_code": "WALLET_NOT_FOUND",
+                        "suggestion": "Run `onchainos wallet balance --chain 501` to verify login, or pass --wallet <address>."
+                    }))?
+                );
+                return Ok(());
+            }
+        },
+    };
+
+    // Fetch balances and positions concurrently
+    let balances = onchainos::get_all_token_balances();
+    let positions = api::get_user_positions(&wallet).await.unwrap_or_default();
+
+    let sol_balance = onchainos::get_sol_balance();
+    let usdc_balance = balances
+        .iter()
+        .find(|(_, _, mint)| mint == USDC_MINT)
+        .map(|(_, bal, _)| *bal)
+        .unwrap_or(0.0);
+
+    let position_count = positions.as_array().map(|a| a.len()).unwrap_or(0);
+
+    // Determine status
+    let (status, suggestion, next_command) = if position_count > 0 {
+        (
+            "active",
+            format!("You have {} active KVault position(s). Check your earnings or deposit more.", position_count),
+            "kamino-liquidity positions".to_string(),
+        )
+    } else if sol_balance >= MIN_SOL_GAS && usdc_balance >= MIN_USDC {
+        (
+            "ready",
+            "Wallet is funded. You can deposit USDC into a KVault to start earning yield.".to_string(),
+            "kamino-liquidity vaults --token USDC".to_string(),
+        )
+    } else if usdc_balance >= MIN_USDC && sol_balance < MIN_SOL_GAS {
+        (
+            "needs_gas",
+            format!("You have {:.2} USDC but need at least {} SOL for transaction fees.", usdc_balance, MIN_SOL_GAS),
+            "onchainos wallet balance --chain 501".to_string(),
+        )
+    } else if sol_balance >= MIN_SOL_GAS {
+        (
+            "needs_funds",
+            "You have SOL for gas but no USDC yet. Deposit USDC or another supported token to start earning.".to_string(),
+            "kamino-liquidity vaults".to_string(),
+        )
+    } else {
+        (
+            "no_funds",
+            "Wallet has no SOL or USDC. Fund your wallet first to use Kamino KVaults.".to_string(),
+            "onchainos wallet balance --chain 501".to_string(),
+        )
+    };
+
+    // Build asset summary
+    let asset_list: Vec<serde_json::Value> = balances
+        .iter()
+        .take(8)
+        .map(|(sym, bal, _)| serde_json::json!({ "symbol": sym, "balance": format!("{:.6}", bal) }))
+        .collect();
+
+    // Build onboarding steps when not active
+    let mut output = serde_json::json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "assets": {
+            "sol_balance": format!("{:.6}", sol_balance),
+            "usdc_balance": format!("{:.6}", usdc_balance),
+            "all_tokens": asset_list
+        },
+        "kvault_positions": position_count,
+        "status": status,
+        "suggestion": suggestion,
+        "next_command": next_command
+    });
+
+    if status != "active" {
+        output["onboarding_steps"] = serde_json::json!([
+            {
+                "step": 1,
+                "title": "Check available vaults",
+                "command": "kamino-liquidity vaults --token USDC",
+                "description": "List all USDC earn vaults with allocation strategies and fees."
+            },
+            {
+                "step": 2,
+                "title": "Preview a deposit",
+                "command": "kamino-liquidity deposit --vault <VAULT_ADDRESS> --amount <AMOUNT> --dry-run",
+                "description": "Dry-run a deposit to verify the transaction before broadcasting."
+            },
+            {
+                "step": 3,
+                "title": "Execute deposit",
+                "command": "kamino-liquidity deposit --vault <VAULT_ADDRESS> --amount <AMOUNT> --confirm",
+                "description": "Deposit tokens into the vault. Returns ok:true only after on-chain confirmation."
+            },
+            {
+                "step": 4,
+                "title": "Check positions",
+                "command": "kamino-liquidity positions",
+                "description": "View your share balances across all KVaults."
+            },
+            {
+                "step": 5,
+                "title": "Withdraw when ready",
+                "command": "kamino-liquidity withdraw --vault <VAULT_ADDRESS> --amount <SHARES> --confirm",
+                "description": "Redeem shares back to tokens. Amount is in shares, not token units."
+            }
+        ]);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}

--- a/skills/kamino-liquidity-plugin/src/commands/vaults.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/vaults.rs
@@ -20,13 +20,48 @@ pub struct VaultsArgs {
 
 pub async fn run(args: VaultsArgs) -> anyhow::Result<()> {
     if args.chain != 501 {
-        anyhow::bail!("kamino-liquidity only supports Solana (chain 501)");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "kamino-liquidity only supports Solana (chain 501)",
+                "error_code": "UNSUPPORTED_CHAIN",
+                "suggestion": "Use --chain 501 or omit --chain (defaults to 501)."
+            }))?
+        );
+        return Ok(());
     }
 
-    let raw = api::get_vaults().await?;
+    let raw = match api::get_vaults().await {
+        Ok(r) => r,
+        Err(e) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("{:#}", e),
+                    "error_code": "KAMINO_API_ERROR",
+                    "suggestion": "Kamino API request failed. Check your connection and retry."
+                }))?
+            );
+            return Ok(());
+        }
+    };
+
     let vaults = match raw.as_array() {
         Some(v) => v,
-        None => anyhow::bail!("Unexpected response from Kamino API: {}", raw),
+        None => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": false,
+                    "error": format!("Unexpected response from Kamino API: {}", raw),
+                    "error_code": "KAMINO_API_ERROR",
+                    "suggestion": "Kamino API returned an unexpected format. Retry or check api.kamino.finance status."
+                }))?
+            );
+            return Ok(());
+        }
     };
 
     let mut results: Vec<serde_json::Map<String, Value>> = Vec::new();

--- a/skills/kamino-liquidity-plugin/src/commands/withdraw.rs
+++ b/skills/kamino-liquidity-plugin/src/commands/withdraw.rs
@@ -32,61 +32,120 @@ pub struct WithdrawArgs {
 
 pub async fn run(args: WithdrawArgs) -> anyhow::Result<()> {
     if args.chain != 501 {
-        anyhow::bail!("kamino-liquidity only supports Solana (chain 501)");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "kamino-liquidity only supports Solana (chain 501)",
+                "error_code": "UNSUPPORTED_CHAIN",
+                "suggestion": "Use --chain 501 or omit --chain (defaults to 501)."
+            }))?
+        );
+        return Ok(());
     }
 
     // Dry-run early return — before wallet resolution
     if args.dry_run {
         let dummy_wallet = "DTEqFXyFM9aMSGu9sw3PpRsZce6xqqmaUbGkFjmeieGE";
         let wallet = args.wallet.as_deref().unwrap_or(dummy_wallet);
-        let tx_b64 = api::build_withdraw_tx(&args.vault, wallet, &args.amount).await?;
-        let output = serde_json::json!({
-            "ok": true,
-            "dry_run": true,
-            "vault": args.vault,
-            "amount": args.amount,
-            "serialized_tx": tx_b64,
-            "data": { "txHash": "" }
-        });
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        let tx_b64 = match api::build_withdraw_tx(&args.vault, wallet, &args.amount).await {
+            Ok(tx) => tx,
+            Err(e) => {
+                println!("{}", super::error_response(&e, Some(&args.vault)));
+                return Ok(());
+            }
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "dry_run": true,
+                "vault": args.vault,
+                "amount": args.amount,
+                "serialized_tx": tx_b64,
+                "data": { "txHash": "" }
+            }))?
+        );
         return Ok(());
     }
 
     // Resolve wallet (after dry-run guard)
     let wallet = match args.wallet {
         Some(w) => w,
-        None => onchainos::resolve_wallet_solana()?,
+        None => match onchainos::resolve_wallet_solana() {
+            Ok(w) => w,
+            Err(e) => {
+                println!("{}", super::error_response(&e, Some(&args.vault)));
+                return Ok(());
+            }
+        },
     };
 
     if wallet.is_empty() {
-        anyhow::bail!("Could not resolve wallet address. Pass --wallet <address> or ensure onchainos is logged in.");
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "Cannot resolve wallet address.",
+                "error_code": "WALLET_NOT_FOUND",
+                "suggestion": "Pass --wallet <address> or run `onchainos wallet balance --chain 501` to verify login."
+            }))?
+        );
+        return Ok(());
     }
 
     // Build withdraw transaction from Kamino API
-    // NOTE: amount = shares in UI units (not token amount)
-    let tx_b64 = api::build_withdraw_tx(&args.vault, &wallet, &args.amount).await?;
+    let tx_b64 = match api::build_withdraw_tx(&args.vault, &wallet, &args.amount).await {
+        Ok(tx) => tx,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
 
-    // Submit via onchainos (base64→base58 conversion done internally)
-    // Solana blockhash expires ~60s — must submit immediately
-    // ── Preview mode: show TX details without broadcasting ──────────────────
+    // Preview mode
     if !args.confirm && !args.dry_run {
         println!("=== Transaction Preview (NOT broadcast) ===");
         println!("Add --confirm to execute this transaction.");
         return Ok(());
     }
-    let result = onchainos::wallet_contract_call_solana(KVAULT_PROGRAM_ID, &tx_b64, false).await?;
 
-    let tx_hash = onchainos::extract_tx_hash(&result);
-    let output = serde_json::json!({
-        "ok": true,
-        "vault": args.vault,
-        "wallet": wallet,
-        "shares_redeemed": args.amount,
-        "data": {
-            "txHash": tx_hash
-        },
-        "explorer": format!("https://solscan.io/tx/{}", tx_hash)
-    });
-    println!("{}", serde_json::to_string_pretty(&output)?);
+    // Submit via onchainos (base64→base58 conversion done internally)
+    // Solana blockhash expires ~60s — must submit immediately
+    let result = match onchainos::wallet_contract_call_solana(KVAULT_PROGRAM_ID, &tx_b64, false).await {
+        Ok(r) => r,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
+
+    let tx_hash = match onchainos::extract_tx_hash(&result) {
+        Ok(h) => h,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some(&args.vault)));
+            return Ok(());
+        }
+    };
+
+    if let Err(e) = onchainos::wait_for_tx_solana(&tx_hash, &wallet).await {
+        println!("{}", super::error_response(&e, Some(&args.vault)));
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "ok": true,
+            "vault": args.vault,
+            "wallet": wallet,
+            "shares_redeemed": args.amount,
+            "action": "withdraw",
+            "data": {
+                "txHash": tx_hash
+            },
+            "explorer": format!("https://solscan.io/tx/{}", tx_hash)
+        }))?
+    );
     Ok(())
 }

--- a/skills/kamino-liquidity-plugin/src/main.rs
+++ b/skills/kamino-liquidity-plugin/src/main.rs
@@ -18,6 +18,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Show wallet status, balances, and suggested first command
+    Quickstart(commands::quickstart::QuickstartArgs),
     /// List all Kamino KVault earn vaults
     Vaults(commands::vaults::VaultsArgs),
     /// Query your Kamino KVault positions (share balances)
@@ -32,6 +34,7 @@ enum Commands {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
+        Commands::Quickstart(args) => commands::quickstart::run(args).await,
         Commands::Vaults(args) => commands::vaults::run(args).await,
         Commands::Positions(args) => commands::positions::run(args).await,
         Commands::Deposit(args) => commands::deposit::run(args).await,

--- a/skills/kamino-liquidity-plugin/src/onchainos.rs
+++ b/skills/kamino-liquidity-plugin/src/onchainos.rs
@@ -1,6 +1,68 @@
 use std::process::Command;
 use serde_json::Value;
 
+/// Native SOL mint sentinel used by onchainos for native SOL.
+const NATIVE_SOL_MINT: &str = "11111111111111111111111111111111";
+
+/// Return native SOL balance in UI units (e.g. 1.5 = 1.5 SOL). Returns 0.0 on failure.
+pub fn get_sol_balance() -> f64 {
+    let output = Command::new("onchainos")
+        .args(["wallet", "balance", "--chain", "501"])
+        .output()
+        .ok();
+    let stdout = output
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or_default();
+    let json: Value = serde_json::from_str(&stdout).unwrap_or(Value::Null);
+    if let Some(assets) = json["data"]["details"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|d| d["tokenAssets"].as_array())
+    {
+        for asset in assets {
+            let addr = asset["tokenAddress"].as_str().unwrap_or("");
+            if addr.is_empty() || addr == NATIVE_SOL_MINT {
+                return asset["balance"]
+                    .as_str()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .unwrap_or(0.0);
+            }
+        }
+    }
+    0.0
+}
+
+/// Return all token balances (SOL + SPL) as (symbol, balance_ui, mint_address).
+pub fn get_all_token_balances() -> Vec<(String, f64, String)> {
+    let output = Command::new("onchainos")
+        .args(["wallet", "balance", "--chain", "501"])
+        .output()
+        .ok();
+    let stdout = output
+        .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+        .unwrap_or_default();
+    let json: Value = serde_json::from_str(&stdout).unwrap_or(Value::Null);
+    let mut result = Vec::new();
+    if let Some(assets) = json["data"]["details"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|d| d["tokenAssets"].as_array())
+    {
+        for asset in assets {
+            let symbol = asset["symbol"].as_str().unwrap_or("UNKNOWN").to_string();
+            let balance = asset["balance"]
+                .as_str()
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
+            let mint = asset["tokenAddress"].as_str().unwrap_or("").to_string();
+            if balance > 0.0 {
+                result.push((symbol, balance, mint));
+            }
+        }
+    }
+    result
+}
+
 /// Resolve the current Solana wallet address from onchainos.
 /// NOTE: Solana does NOT support --output json; wallet balance returns JSON directly.
 /// Address path: data.details[0].tokenAssets[0].address
@@ -67,22 +129,95 @@ pub async fn wallet_contract_call_solana(
             "--to",
             to,
             "--unsigned-tx",
-            &tx_base58
+            &tx_base58,
+            "--force",
         ])
         .output()?;
+
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "onchainos contract-call failed (exit code {:?}).\nstdout: {}\nstderr: {}",
+            output.status.code(),
+            stdout,
+            stderr
+        );
+    }
+
     let result: Value = serde_json::from_str(&stdout)
-        .map_err(|e| anyhow::anyhow!("Failed to parse onchainos response: {}\nRaw: {}", e, stdout))?;
+        .map_err(|e| anyhow::anyhow!(
+            "Failed to parse onchainos response: {}\nstdout: {}\nstderr: {}",
+            e, stdout, stderr
+        ))?;
+
+    if result.get("ok").and_then(|v| v.as_bool()) == Some(false) {
+        let msg = result["error"].as_str()
+            .or_else(|| result["message"].as_str())
+            .unwrap_or("unknown error");
+        anyhow::bail!("onchainos contract-call returned error: {}", msg);
+    }
+
     Ok(result)
 }
 
+/// Poll onchainos wallet history until the tx reaches SUCCESS or FAILED, or 60s timeout.
+/// Returns Ok(()) on SUCCESS, Err on FAILED or timeout.
+pub async fn wait_for_tx_solana(tx_hash: &str, wallet: &str) -> anyhow::Result<()> {
+    let tx = tx_hash.to_string();
+    let wlt = wallet.to_string();
+    tokio::task::spawn_blocking(move || wait_for_tx_solana_sync(&tx, &wlt))
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking error: {}", e))?
+}
+
+fn wait_for_tx_solana_sync(tx_hash: &str, wallet: &str) -> anyhow::Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        if std::time::Instant::now() > deadline {
+            anyhow::bail!("Timeout (60s) waiting for tx {} to confirm on-chain", tx_hash);
+        }
+        let output = Command::new("onchainos")
+            .args([
+                "wallet", "history",
+                "--tx-hash", tx_hash,
+                "--address", wallet,
+                "--chain", "501",
+            ])
+            .output();
+        if let Ok(out) = output {
+            let text = String::from_utf8_lossy(&out.stdout);
+            if let Ok(v) = serde_json::from_str::<Value>(&text) {
+                let entry = v["data"]
+                    .as_array()
+                    .and_then(|a| a.first())
+                    .cloned()
+                    .unwrap_or_else(|| v["data"].clone());
+                match entry["txStatus"].as_str() {
+                    Some("SUCCESS") => return Ok(()),
+                    Some("FAILED") => {
+                        let reason = entry["failReason"].as_str().unwrap_or("unknown");
+                        anyhow::bail!("tx {} failed on-chain: {}", tx_hash, reason);
+                    }
+                    _ => {} // PENDING or not yet indexed — keep polling
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    }
+}
+
 /// Extract txHash from onchainos response.
-/// Checks data.txHash and data.swapTxHash (for DEX operations).
-pub fn extract_tx_hash(result: &Value) -> String {
+/// Returns an error if no txHash is found.
+pub fn extract_tx_hash(result: &Value) -> anyhow::Result<String> {
     result["data"]["swapTxHash"]
         .as_str()
         .or_else(|| result["data"]["txHash"].as_str())
         .or_else(|| result["txHash"].as_str())
-        .unwrap_or("pending")
-        .to_string()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!(
+            "onchainos did not return a transaction hash. Response: {}",
+            serde_json::to_string(result).unwrap_or_default()
+        ))
 }


### PR DESCRIPTION
## Summary

- **Add `quickstart` command**: shows wallet balances (SOL + USDC), active KVault positions, status (`active`/`ready`/`needs_gas`/`needs_funds`/`no_funds`), and `onboarding_steps` array when no active positions
- **GEN-001 fix**: all 5 commands (`quickstart`, `vaults`, `positions`, `deposit`, `withdraw`) now output `{"ok":false,"error_code":"...","suggestion":"..."}` to stdout on failure — never exit non-zero for business logic errors
- **Add `wait_for_tx_solana`**: deposit and withdraw return `ok:true` only after on-chain `txStatus:SUCCESS` (60s timeout with 2s polling)
- **Fix `extract_tx_hash`** return type: `anyhow::Result<String>` — was silently returning `"pending"` on missing hash
- **Add `--force` flag** to `onchainos wallet contract-call` for reliable Solana tx broadcasting
- **Add helpers** `get_sol_balance()` and `get_all_token_balances()` for quickstart balance display

## Checklist

- [x] `cargo build --release` compiles clean
- [x] All 5 commands return structured JSON on error (GEN-001)
- [x] SKILL.md updated: `quickstart` docs, `--confirm` in deposit/withdraw args
- [x] Version bumped: 0.1.2 → 0.1.3
- [x] All 4 version files consistent (plugin.yaml, SKILL.md, Cargo.toml, plugin.json)
- [x] `api_calls` in plugin.yaml covers all external domains
- [x] Diff only affects `skills/kamino-liquidity-plugin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)