### PR TITLE
docs(morpho): add ## Quickstart section pointing to quickstart command

### DIFF
--- a/skills/morpho-plugin/SKILL.md
+++ b/skills/morpho-plugin/SKILL.md
@@ -177,6 +177,32 @@ Morpho is a permissionless lending protocol with over $5B TVL operating on two l
 
 ---
 
+## Quickstart
+
+Run the built-in onboarding command to check your wallet state and receive step-by-step guidance:
+
+```bash
+morpho-plugin quickstart
+```
+
+This checks your ETH, USDC, and WETH balances plus any open Blue and vault positions in parallel,
+then returns a `status` and a suggested `next_command` tailored to your situation:
+
+| Status | Meaning | Suggested next step |
+|--------|---------|-------------------|
+| `active` | Open positions exist — review them | `morpho-plugin positions` |
+| `ready` | Funded, no positions yet | `morpho-plugin supply --asset USDC --amount 100` |
+| `needs_gas` | Has tokens but no ETH for gas | Top up ETH on Ethereum mainnet |
+| `needs_funds` | Has gas but no USDC/WETH to supply | Bridge or buy USDC/WETH |
+| `no_funds` | Nothing found — new wallet | Fund the wallet address shown in output |
+
+**Base chain:**
+```bash
+morpho-plugin --chain 8453 quickstart
+```
+
+---
+
 ## Pre-flight Checks
 
 Before executing any command, verify:


### PR DESCRIPTION
## Summary

- Adds a `## Quickstart` section before `## Pre-flight Checks`
- Directs agents to use the built-in `morpho-plugin quickstart` command as the first step
- Includes a status table (active / ready / needs_gas / needs_funds / no_funds) with the recommended next action for each state
- Notes Base chain variant (`--chain 8453`)
- Complements the existing `### quickstart` command reference under `## Commands`; the new section is agent-visible upfront

## Files Changed

| File | Change |
|------|--------|
| `skills/morpho-plugin/SKILL.md` | Added `## Quickstart` section (26 lines) |

## Checklist

- [x] Points to the existing `quickstart` binary command — no new behaviour invented
- [x] Status table covers all 5 documented states from the quickstart command output
- [x] No binary changes — documentation only