### PR TITLE
docs(velodrome-v2): add ## Quickstart section with swap and liquidity flows

### DIFF
--- a/skills/velodrome-v2-plugin/SKILL.md
+++ b/skills/velodrome-v2-plugin/SKILL.md
@@ -139,6 +139,45 @@ fi
 ---
 
 
+## Quickstart
+
+**New to Velodrome V2?** Run these steps in order:
+
+1. **Get a swap quote** (read-only, no wallet needed)
+   ```bash
+   velodrome-v2 quote --token-in WETH --token-out USDC --amount-in 0.01
+   ```
+
+2. **Preview a swap** (no transaction sent)
+   ```bash
+   velodrome-v2 swap --token-in WETH --token-out USDC --amount-in 0.01 --slippage 0.5
+   ```
+   Review the output — add `--confirm` only after checking the amounts.
+
+3. **Execute the swap**
+   ```bash
+   velodrome-v2 swap --token-in WETH --token-out USDC --amount-in 0.01 --slippage 0.5 --confirm
+   ```
+
+**Liquidity flow:**
+```bash
+# Check existing LP positions
+velodrome-v2 positions
+
+# Preview adding liquidity (volatile pool)
+velodrome-v2 add-liquidity --token-a WETH --token-b USDC --amount-a 0.01 --slippage 0.5
+
+# Add liquidity
+velodrome-v2 add-liquidity --token-a WETH --token-b USDC --amount-a 0.01 --slippage 0.5 --confirm
+
+# Claim VELO gauge rewards
+velodrome-v2 claim-rewards --pool <POOL_ADDRESS> --confirm
+```
+
+> Velodrome V2 is Optimism only (chain ID 10). Use `--stable true` for stable pairs (USDC/DAI, USDC/USDT).
+
+---
+
 ## Pool Types
 
 | Type | stable flag | Formula | Best for |


### PR DESCRIPTION
## Summary

- Adds a `## Quickstart` section before `## Pool Types`
- Covers the 3-step swap flow: quote (read-only) → preview → confirm
- Documents the liquidity flow: positions → add-liquidity preview → confirm → claim-rewards
- Notes Optimism-only chain and `--stable true` for stable pairs

## Files Changed

| File | Change |
|------|--------|
| `skills/velodrome-v2-plugin/SKILL.md` | Added `## Quickstart` section (39 lines) |

## Checklist

- [x] Starts with read-only command (no funds moved)
- [x] Preview-then-confirm pattern shown for all write operations
- [x] No binary changes — documentation only