### PR TITLE
fix(hyperliquid-plugin): price precision, configurable slippage, structured errors (v0.3.7)

### DIFF
--- a/skills/hyperliquid-plugin/.claude-plugin/plugin.json
+++ b/skills/hyperliquid-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperliquid",
   "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "author": {
     "name": "GeoGu360",
     "github": "GeoGu360"

--- a/skills/hyperliquid-plugin/Cargo.lock
+++ b/skills/hyperliquid-plugin/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "hyperliquid-plugin"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/hyperliquid-plugin/Cargo.toml
+++ b/skills/hyperliquid-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperliquid-plugin"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [[bin]]

--- a/skills/hyperliquid-plugin/SKILL.md
+++ b/skills/hyperliquid-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyperliquid-plugin
 description: Hyperliquid DEX — trade perps & spot, deposit from Arbitrum, withdraw to Arbitrum, transfer between perp and spot accounts, manage gas on HyperEVM.
-version: "0.3.6"
+version: "0.3.7"
 author: GeoGu360
 tags:
   - perps
@@ -26,7 +26,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/hyperliquid-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.3.6"
+LOCAL_VER="0.3.7"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -99,7 +99,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.6/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/hyperliquid-plugin@0.3.7/hyperliquid-plugin-${TARGET}${EXT}" -o ~/.local/bin/.hyperliquid-plugin-core${EXT}
 chmod +x ~/.local/bin/.hyperliquid-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -107,7 +107,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/hyperliquid-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.3.6" > "$HOME/.plugin-store/managed/hyperliquid-plugin"
+echo "0.3.7" > "$HOME/.plugin-store/managed/hyperliquid-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -127,7 +127,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"hyperliquid-plugin","version":"0.3.6"}' >/dev/null 2>&1 || true
+    -d '{"name":"hyperliquid-plugin","version":"0.3.7"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \

--- a/skills/hyperliquid-plugin/plugin.yaml
+++ b/skills/hyperliquid-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: hyperliquid-plugin
-version: "0.3.6"
+version: "0.3.7"
 description: "Trade perpetuals on Hyperliquid — check positions, get prices, place market/limit orders with TP/SL brackets, close positions, deposit USDC"
 author:
   name: GeoGu360

--- a/skills/hyperliquid-plugin/src/commands/cancel.rs
+++ b/skills/hyperliquid-plugin/src/commands/cancel.rs
@@ -34,18 +34,32 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
     let exchange = exchange_url();
     let nonce = now_ms();
 
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // ── Determine which orders to cancel ──────────────────────────────────────
 
     // Case 1: single order by ID
     if let Some(oid) = args.order_id {
-        let coin = args
-            .coin
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("--coin is required when using --order-id"))?;
-        let coin = normalize_coin(coin);
-        let asset_idx = get_asset_index(info, &coin).await?;
+        let coin = match args.coin.as_deref() {
+            Some(c) => normalize_coin(c),
+            None => {
+                println!("{}", super::error_response("--coin is required when using --order-id", "INVALID_ARGUMENT", "Provide --coin <SYMBOL> alongside --order-id."));
+                return Ok(());
+            }
+        };
+        let asset_idx = match get_asset_index(info, &coin).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+                return Ok(());
+            }
+        };
         let action = build_cancel_action(asset_idx, oid);
 
         println!(
@@ -71,8 +85,20 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-        let result = submit_exchange_request(exchange, signed).await?;
+        let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+                return Ok(());
+            }
+        };
+        let result = match submit_exchange_request(exchange, signed).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+                return Ok(());
+            }
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -87,7 +113,13 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
     }
 
     // Case 2: batch by coin or --all — fetch open orders first
-    let open_orders = get_open_orders(info, &wallet).await?;
+    let open_orders = match get_open_orders(info, &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let empty_vec = vec![];
     let all_orders = open_orders.as_array().unwrap_or(&empty_vec);
 
@@ -127,10 +159,20 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
     }
 
     // Build asset index map from meta (one call instead of N)
-    let meta = get_meta(info).await?;
-    let universe = meta["universe"]
-        .as_array()
-        .ok_or_else(|| anyhow::anyhow!("meta.universe missing"))?;
+    let meta = match get_meta(info).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
+    let universe = match meta["universe"].as_array() {
+        Some(v) => v,
+        None => {
+            println!("{}", super::error_response("meta.universe missing", "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     let get_asset_idx = |coin_name: &str| -> Option<usize> {
         let upper = coin_name.to_uppercase();
@@ -153,8 +195,13 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
         let limit_px = o["limitPx"].as_str().unwrap_or("?");
         let sz = o["sz"].as_str().unwrap_or("?");
 
-        let asset_idx = get_asset_idx(coin_name)
-            .ok_or_else(|| anyhow::anyhow!("Coin '{}' not found in universe", coin_name))?;
+        let asset_idx = match get_asset_idx(coin_name) {
+            Some(i) => i,
+            None => {
+                println!("{}", super::error_response(&format!("Coin '{}' not found in universe", coin_name), "INVALID_ARGUMENT", "Check the coin symbol and retry."));
+                return Ok(());
+            }
+        };
 
         batch.push((asset_idx, oid));
         preview_list.push(serde_json::json!({
@@ -195,8 +242,20 @@ pub async fn run(args: CancelArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!(
         "{}",

--- a/skills/hyperliquid-plugin/src/commands/close.rs
+++ b/skills/hyperliquid-plugin/src/commands/close.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use crate::api::{get_asset_meta, get_all_mids, get_clearinghouse_state};
 use crate::config::{info_url, exchange_url, normalize_coin, now_ms, CHAIN_ID, ARBITRUM_CHAIN_ID};
 use crate::onchainos::{onchainos_hl_sign, resolve_wallet};
-use crate::signing::{build_close_action, market_slippage_px, submit_exchange_request};
+use crate::signing::{build_close_action, round_px, submit_exchange_request};
 
 #[derive(Args)]
 pub struct CloseArgs {
@@ -13,6 +13,10 @@ pub struct CloseArgs {
     /// Close only this many base units instead of the entire position
     #[arg(long)]
     pub size: Option<String>,
+
+    /// Slippage tolerance for the market close order, in percent (default 5.0 = 5%)
+    #[arg(long, default_value = "5.0")]
+    pub slippage: f64,
 
     /// Dry run — show payload without signing or submitting
     #[arg(long)]
@@ -31,13 +35,31 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     let nonce = now_ms();
 
     // Look up asset index and sz_decimals for price rounding
-    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
+    let (asset_idx, sz_decimals) = match get_asset_meta(info, &coin).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     // Resolve wallet
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // Fetch current position to determine direction and full size
-    let state = get_clearinghouse_state(info, &wallet).await?;
+    let state = match get_clearinghouse_state(info, &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let empty_vec = vec![];
     let positions = state["assetPositions"].as_array().unwrap_or(&empty_vec);
 
@@ -52,12 +74,25 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
         }
     }
 
-    let szi = position_szi.ok_or_else(|| {
-        anyhow::anyhow!("No open {} position found. Use `hyperliquid positions` to check.", coin)
-    })?;
+    let szi = match position_szi {
+        Some(v) => v,
+        None => {
+            println!("{}", super::error_response(
+                &format!("No open {} position found.", coin),
+                "POSITION_NOT_FOUND",
+                "Run positions to see open positions."
+            ));
+            return Ok(());
+        }
+    };
 
     if szi == 0.0 {
-        anyhow::bail!("No open {} position (size is 0).", coin);
+        println!("{}", super::error_response(
+            &format!("No open {} position (size is 0).", coin),
+            "POSITION_NOT_FOUND",
+            "Run positions to see open positions."
+        ));
+        return Ok(());
     }
 
     let position_is_long = szi > 0.0;
@@ -67,18 +102,24 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     // Determine close size
     let close_size = match &args.size {
         Some(s) => {
-            let v: f64 = s.parse().map_err(|_| {
-                anyhow::anyhow!("Invalid size '{}' — must be a number", s)
-            })?;
+            let v: f64 = match s.parse() {
+                Ok(v) => v,
+                Err(_) => {
+                    println!("{}", super::error_response(&format!("Invalid size '{}' — must be a number", s), "INVALID_ARGUMENT", "Provide a numeric size value, e.g. --size 0.01"));
+                    return Ok(());
+                }
+            };
             if v <= 0.0 {
-                anyhow::bail!("Close size must be positive");
+                println!("{}", super::error_response("Close size must be positive", "INVALID_ARGUMENT", "Provide a positive close size value."));
+                return Ok(());
             }
             if v > position_size {
-                anyhow::bail!(
-                    "Close size {} exceeds position size {}",
-                    v,
-                    position_size
-                );
+                println!("{}", super::error_response(
+                    &format!("Close size {} exceeds position size {}", v, position_size),
+                    "INVALID_ARGUMENT",
+                    &format!("Maximum close size is {}.", position_size)
+                ));
+                return Ok(());
             }
             s.clone()
         }
@@ -86,7 +127,13 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     };
 
     // Fetch current price for display
-    let mids = get_all_mids(info).await?;
+    let mids = match get_all_mids(info).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let current_price = mids
         .get(&coin)
         .and_then(|v| v.as_str())
@@ -95,7 +142,8 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
     let closing_side = if position_is_long { "sell" } else { "buy" };
     let close_is_buy = !position_is_long;
     let mid_f = current_price.parse::<f64>().unwrap_or(0.0);
-    let slippage_px_str = market_slippage_px(mid_f, close_is_buy, sz_decimals);
+    let slippage_multiplier = if close_is_buy { 1.0 + args.slippage / 100.0 } else { 1.0 - args.slippage / 100.0 };
+    let slippage_px_str = round_px(mid_f * slippage_multiplier, sz_decimals);
 
     let action = build_close_action(asset_idx, position_is_long, &close_size, &slippage_px_str);
 
@@ -110,6 +158,8 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
                 "closingSide": closing_side,
                 "currentMidPrice": current_price,
                 "type": "market",
+                "slippagePct": args.slippage,
+                "worstFillPrice": slippage_px_str,
                 "reduceOnly": true,
                 "nonce": nonce
             },
@@ -128,8 +178,20 @@ pub async fn run(args: CloseArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!(
         "{}",

--- a/skills/hyperliquid-plugin/src/commands/deposit.rs
+++ b/skills/hyperliquid-plugin/src/commands/deposit.rs
@@ -76,7 +76,8 @@ fn build_batched_deposit_calldata(
 
 pub async fn run(args: DepositArgs) -> anyhow::Result<()> {
     if args.amount <= 0.0 {
-        anyhow::bail!("Amount must be greater than 0");
+        println!("{}", super::error_response("Amount must be greater than 0", "INVALID_ARGUMENT", "Provide a positive USDC amount with --amount."));
+        return Ok(());
     }
     if args.amount < 5.0 {
         eprintln!("WARNING: Minimum recommended deposit is $5 USDC. Amounts below $5 may not arrive.");
@@ -86,10 +87,22 @@ pub async fn run(args: DepositArgs) -> anyhow::Result<()> {
     let usdc_units = (args.amount * 1_000_000.0).round() as u64;
     let usdc_u128 = usdc_units as u128;
 
-    let wallet = resolve_wallet(ARBITRUM_CHAIN_ID)?;
+    let wallet = match resolve_wallet(ARBITRUM_CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // Permit deadline: now + 1 hour
-    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let now = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_secs(),
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let deadline = now + 3600;
 
     if args.dry_run {
@@ -109,18 +122,31 @@ pub async fn run(args: DepositArgs) -> anyhow::Result<()> {
     }
 
     // Check USDC balance on Arbitrum
-    let balance = erc20_balance(USDC_ARBITRUM, &wallet, ARBITRUM_RPC).await?;
+    let balance = match erc20_balance(USDC_ARBITRUM, &wallet, ARBITRUM_RPC).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let balance_usd = balance as f64 / 1_000_000.0;
     if balance < usdc_u128 {
-        anyhow::bail!(
-            "Insufficient USDC on Arbitrum: have {:.6} USDC, need {:.6} USDC",
-            balance_usd,
-            args.amount
-        );
+        println!("{}", super::error_response(
+            &format!("Insufficient USDC on Arbitrum: have {:.6} USDC, need {:.6} USDC", balance_usd, args.amount),
+            "INSUFFICIENT_BALANCE",
+            "Add USDC to your Arbitrum wallet before depositing."
+        ));
+        return Ok(());
     }
 
     // Get USDC permit nonce
-    let permit_nonce = usdc_permit_nonce(USDC_ARBITRUM, &wallet, ARBITRUM_RPC).await?;
+    let permit_nonce = match usdc_permit_nonce(USDC_ARBITRUM, &wallet, ARBITRUM_RPC).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     if !args.confirm {
         println!("{}", serde_json::json!({
@@ -174,29 +200,52 @@ pub async fn run(args: DepositArgs) -> anyhow::Result<()> {
 
     // Step 2: Sign the permit via onchainos
     eprintln!("Signing USDC permit for {} USDC...", args.amount);
-    let sig_hex = onchainos_sign_eip712(&permit_typed_data, &wallet)?;
+    let sig_hex = match onchainos_sign_eip712(&permit_typed_data, &wallet) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     // Parse r, s, v from the 65-byte hex signature
     let sig_hex = sig_hex.trim_start_matches("0x");
     if sig_hex.len() != 130 {
-        anyhow::bail!("Expected 130-char hex signature, got {}", sig_hex.len());
+        println!("{}", super::error_response(
+            &format!("Expected 130-char hex signature, got {}", sig_hex.len()),
+            "SIGNING_FAILED",
+            "Retry the command. If the issue persists, check onchainos status."
+        ));
+        return Ok(());
     }
     let r = &sig_hex[0..64];
     let s = &sig_hex[64..128];
-    let v = u8::from_str_radix(&sig_hex[128..130], 16)?;
+    let v = match u8::from_str_radix(&sig_hex[128..130], 16) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("Failed to parse signature v byte: {:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     // Step 3: Build batchedDepositWithPermit calldata
     let calldata = build_batched_deposit_calldata(&wallet, usdc_units, deadline, r, s, v);
 
     // Step 4: Submit the transaction
     eprintln!("Depositing {:.6} USDC to Hyperliquid via Arbitrum bridge...", args.amount);
-    let deposit_result = wallet_contract_call(
+    let deposit_result = match wallet_contract_call(
         ARBITRUM_CHAIN_ID,
         HL_BRIDGE_ARBITRUM,
         &calldata,
         None,
         false,
-    )?;
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     let deposit_tx_hash = deposit_result["data"]["txHash"]
         .as_str()

--- a/skills/hyperliquid-plugin/src/commands/evm_send.rs
+++ b/skills/hyperliquid-plugin/src/commands/evm_send.rs
@@ -102,25 +102,40 @@ fn core_writer_calldata(action_id: u32, abi_params: &[u8]) -> String {
 
 pub async fn run(args: EvmSendArgs) -> anyhow::Result<()> {
     if args.amount <= 0.0 {
-        anyhow::bail!("--amount must be positive");
+        println!("{}", super::error_response("--amount must be positive", "INVALID_ARGUMENT", "Provide a positive USDC amount with --amount."));
+        return Ok(());
     }
 
     let usdc_units = (args.amount * 1_000_000.0).round() as u64;
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
     let destination = args.to.clone().unwrap_or_else(|| wallet.clone());
 
     // Check HyperCore perp withdrawable balance
-    let state = get_clearinghouse_state(info_url(), &wallet).await?;
+    let state = match get_clearinghouse_state(info_url(), &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let withdrawable: f64 = state["withdrawable"]
         .as_str()
         .and_then(|s| s.parse().ok())
         .unwrap_or(0.0);
 
     if args.amount > withdrawable {
-        anyhow::bail!(
-            "Insufficient perp balance: requested {:.4} USDC, withdrawable {:.4} USDC",
-            args.amount, withdrawable
-        );
+        println!("{}", super::error_response(
+            &format!("Insufficient perp balance: requested {:.4} USDC, withdrawable {:.4} USDC", args.amount, withdrawable),
+            "INSUFFICIENT_BALANCE",
+            "Ensure you have enough USDC in your perp account before sending to HyperEVM."
+        ));
+        return Ok(());
     }
 
     // ── Build calldata ────────────────────────────────────────────────────
@@ -172,7 +187,13 @@ pub async fn run(args: EvmSendArgs) -> anyhow::Result<()> {
 
     // Step 1: Move perp → spot
     eprintln!("Step 1/2  Transferring {} USDC from perp → spot via CoreWriter...", args.amount);
-    let result1 = wallet_contract_call(CHAIN_ID, CORE_WRITER, &calldata_perp_to_spot, None, false)?;
+    let result1 = match wallet_contract_call(CHAIN_ID, CORE_WRITER, &calldata_perp_to_spot, None, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     // Wait for step 1 to be mined before submitting step 2 (HyperCore needs the tx on-chain)
     eprintln!("  Waiting for HyperCore to process...");
@@ -186,7 +207,13 @@ pub async fn run(args: EvmSendArgs) -> anyhow::Result<()> {
 
     // Step 2: Spot → HyperEVM address
     eprintln!("Step 2/2  Sending {} USDC from spot → HyperEVM {}...", args.amount, &destination[..10]);
-    wallet_contract_call(CHAIN_ID, CORE_WRITER, &calldata_spot_to_evm, None, false)?;
+    match wallet_contract_call(CHAIN_ID, CORE_WRITER, &calldata_spot_to_evm, None, false) {
+        Ok(_) => {}
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!("{}", serde_json::json!({
         "ok": true,

--- a/skills/hyperliquid-plugin/src/commands/mod.rs
+++ b/skills/hyperliquid-plugin/src/commands/mod.rs
@@ -17,3 +17,15 @@ pub mod tpsl;
 pub mod transfer;
 pub mod withdraw;
 pub mod quickstart;
+
+/// Render a structured error JSON string for stdout output.
+/// All command failures must use this instead of anyhow::bail! or ?.
+pub fn error_response(msg: &str, code: &str, suggestion: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "ok": false,
+        "error": msg,
+        "error_code": code,
+        "suggestion": suggestion,
+    }))
+    .unwrap_or_else(|_| format!(r#"{{"ok":false,"error":{:?}}}"#, msg))
+}

--- a/skills/hyperliquid-plugin/src/commands/order.rs
+++ b/skills/hyperliquid-plugin/src/commands/order.rs
@@ -6,7 +6,7 @@ use crate::rpc::{ARBITRUM_RPC, erc20_balance};
 use crate::signing::{
     build_bracketed_order_action, build_limit_order_action, build_market_order_action,
     build_update_leverage_action,
-    format_px, round_px, market_slippage_px, submit_exchange_request,
+    format_px, round_px, submit_exchange_request,
 };
 
 #[derive(Args)]
@@ -56,6 +56,16 @@ pub struct OrderArgs {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Slippage tolerance for market orders, in percent (default 5.0 = 5%)
+    /// The worst-fill price is mid × (1 ± slippage/100)
+    #[arg(long, default_value = "5.0")]
+    pub slippage: f64,
+
+    /// Worst-fill slippage when a TP/SL bracket trigger fires, in percent (default 10.0 = 10%).
+    /// Only applies when --sl-px or --tp-px is set
+    #[arg(long, default_value = "10.0")]
+    pub trigger_slippage: f64,
+
     /// Confirm and submit the order (without this flag, prints a preview)
     #[arg(long)]
     pub confirm: bool,
@@ -79,33 +89,69 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     let nonce = now_ms();
 
     // Validate size is a number
-    let size_f: f64 = args
-        .size
-        .parse()
-        .map_err(|_| anyhow::anyhow!("Invalid size '{}' — must be a number (e.g. 0.01)", args.size))?;
+    let size_f: f64 = match args.size.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            println!("{}", super::error_response(
+                &format!("Invalid size '{}' — must be a number (e.g. 0.01)", args.size),
+                "INVALID_ARGUMENT",
+                "Provide a numeric size value, e.g. --size 0.01"
+            ));
+            return Ok(());
+        }
+    };
 
     // Validate leverage range (Hyperliquid accepts 1–100)
     if let Some(lev) = args.leverage {
         if !(1..=100).contains(&lev) {
-            anyhow::bail!("--leverage must be between 1 and 100 (got {})", lev);
+            println!("{}", super::error_response(
+                &format!("--leverage must be between 1 and 100 (got {})", lev),
+                "INVALID_ARGUMENT",
+                "Provide a leverage value between 1 and 100, e.g. --leverage 10"
+            ));
+            return Ok(());
         }
     }
 
     // TP/SL bracket validation
     if let Some(sl) = args.sl_px {
         if is_buy && args.tp_px.map_or(false, |tp| tp <= sl) {
-            anyhow::bail!("Take-profit must be above stop-loss for a long position");
+            println!("{}", super::error_response(
+                "Take-profit must be above stop-loss for a long position",
+                "INVALID_ARGUMENT",
+                "For a long: SL below entry, TP above entry."
+            ));
+            return Ok(());
         }
         if !is_buy && args.tp_px.map_or(false, |tp| tp >= sl) {
-            anyhow::bail!("Take-profit must be below stop-loss for a short position");
+            println!("{}", super::error_response(
+                "Take-profit must be below stop-loss for a short position",
+                "INVALID_ARGUMENT",
+                "For a short: SL above entry, TP below entry."
+            ));
+            return Ok(());
         }
     }
 
     // ─── Fetch meta + prices concurrently ────────────────────────────────────
-    let ((asset_idx, sz_decimals), mids) = tokio::try_join!(
+    let (meta_res, mids_res) = tokio::join!(
         get_asset_meta(info, &coin),
         get_all_mids(info)
-    )?;
+    );
+    let (asset_idx, sz_decimals) = match meta_res {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
+    let mids = match mids_res {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     let current_price = mids
         .get(&coin)
@@ -135,7 +181,8 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     let notional = size_rounded * mid_f;
 
     // Slippage-protected price for market orders
-    let slippage_px_str = market_slippage_px(mid_f, is_buy, sz_decimals);
+    let slippage_multiplier = if is_buy { 1.0 + args.slippage / 100.0 } else { 1.0 - args.slippage / 100.0 };
+    let slippage_px_str = round_px(mid_f * slippage_multiplier, sz_decimals);
 
     // ─── SL/TP prices rounded to correct precision ────────────────────────────
     let sl_px_str = args.sl_px.map(|px| round_px(px, sz_decimals));
@@ -255,13 +302,17 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                 "t": { "limit": { "tif": "Ioc" } }
             }),
             "limit" => {
-                let price_str = args
-                    .price
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("--price is required for limit orders"))?;
-                let _: f64 = price_str
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("Invalid price '{}'", price_str))?;
+                let price_str = match args.price.as_deref() {
+                    Some(p) => p,
+                    None => {
+                        println!("{}", super::error_response("--price is required for limit orders", "INVALID_ARGUMENT", "Provide a limit price, e.g. --price 100000"));
+                        return Ok(());
+                    }
+                };
+                if price_str.parse::<f64>().is_err() {
+                    println!("{}", super::error_response(&format!("Invalid price '{}'", price_str), "INVALID_ARGUMENT", "Provide a numeric price value."));
+                    return Ok(());
+                }
                 serde_json::json!({
                     "a": asset_idx,
                     "b": is_buy,
@@ -271,7 +322,10 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
                     "t": { "limit": { "tif": "Gtc" } }
                 })
             }
-            _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
+            _ => {
+                println!("{}", super::error_response(&format!("Unknown order type '{}'", args.r#type), "INVALID_ARGUMENT", "Use --type market or --type limit."));
+                return Ok(());
+            }
         };
 
         build_bracketed_order_action(
@@ -282,21 +336,29 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             sl_px_str.as_deref(),
             tp_px_str.as_deref(),
             sz_decimals,
+            args.trigger_slippage,
         )
     } else {
         match args.r#type.as_str() {
             "market" => build_market_order_action(asset_idx, is_buy, &size_str, args.reduce_only, &slippage_px_str),
             "limit" => {
-                let price_str = args
-                    .price
-                    .as_deref()
-                    .ok_or_else(|| anyhow::anyhow!("--price is required for limit orders"))?;
-                let _: f64 = price_str
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("Invalid price '{}'", price_str))?;
+                let price_str = match args.price.as_deref() {
+                    Some(p) => p,
+                    None => {
+                        println!("{}", super::error_response("--price is required for limit orders", "INVALID_ARGUMENT", "Provide a limit price, e.g. --price 100000"));
+                        return Ok(());
+                    }
+                };
+                if price_str.parse::<f64>().is_err() {
+                    println!("{}", super::error_response(&format!("Invalid price '{}'", price_str), "INVALID_ARGUMENT", "Provide a numeric price value."));
+                    return Ok(());
+                }
                 build_limit_order_action(asset_idx, is_buy, price_str, &size_str, args.reduce_only, "Gtc")
             }
-            _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
+            _ => {
+                println!("{}", super::error_response(&format!("Unknown order type '{}'", args.r#type), "INVALID_ARGUMENT", "Use --type market or --type limit."));
+                return Ok(());
+            }
         }
     };
 
@@ -314,6 +376,8 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         "type": args.r#type,
         "price": args.price,
         "leverage": leverage_preview,
+        "slippagePct": args.slippage,
+        "worstFillPrice": if args.r#type == "market" { Some(slippage_px_str.clone()) } else { None },
         "stopLoss": sl_px_str,
         "takeProfit": tp_px_str,
         "reduceOnly": args.reduce_only,
@@ -346,22 +410,40 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
     }
 
     // ─── Submit ───────────────────────────────────────────────────────────────
-    let wallet = wallet_opt
-        .ok_or_else(|| anyhow::anyhow!("Cannot resolve wallet. Log in via onchainos."))?;
+    let wallet = match wallet_opt {
+        Some(w) => w,
+        None => {
+            println!("{}", super::error_response("Cannot resolve wallet. Log in via onchainos.", "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // Set leverage before placing the order if --leverage was provided
     if let Some(lev) = args.leverage {
         let is_cross = !args.isolated;
         let lev_action = build_update_leverage_action(asset_idx, is_cross, lev);
         let lev_nonce = now_ms();
-        let lev_signed = onchainos_hl_sign(&lev_action, lev_nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-        let lev_result = submit_exchange_request(exchange, lev_signed).await
-            .map_err(|e| anyhow::anyhow!("Leverage update failed: {}", e))?;
+        let lev_signed = match onchainos_hl_sign(&lev_action, lev_nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("Leverage update signing failed: {:#}", e), "SIGNING_FAILED", "Retry the command."));
+                return Ok(());
+            }
+        };
+        let lev_result = match submit_exchange_request(exchange, lev_signed).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("Leverage update failed: {:#}", e), "TX_SUBMIT_FAILED", "Retry the command."));
+                return Ok(());
+            }
+        };
         if lev_result["status"].as_str() == Some("err") {
-            anyhow::bail!(
-                "Leverage update rejected by Hyperliquid: {}",
-                lev_result["response"].as_str().unwrap_or("unknown error")
-            );
+            println!("{}", super::error_response(
+                &format!("Leverage update rejected: {}", lev_result["response"].as_str().unwrap_or("unknown error")),
+                "TX_SUBMIT_FAILED",
+                "Check your leverage settings and retry."
+            ));
+            return Ok(());
         }
         eprintln!(
             "Leverage set to {}x ({}) for {}",
@@ -369,8 +451,31 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
         );
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+
+    // Extract fill data for programmatic consumers (e.g. liquidation scripts)
+    let statuses = result["response"]["data"]["statuses"]
+        .as_array()
+        .and_then(|a| a.first())
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let avg_px = statuses["filled"]["avgPx"].as_str().map(|s| s.to_string());
+    let oid = statuses["filled"]["oid"]
+        .as_u64()
+        .or_else(|| statuses["resting"]["oid"].as_u64());
 
     println!(
         "{}",
@@ -383,6 +488,11 @@ pub async fn run(args: OrderArgs) -> anyhow::Result<()> {
             "type": args.r#type,
             "stopLoss": sl_px_str,
             "takeProfit": tp_px_str,
+            "data": {
+                "avg_px": avg_px,
+                "fill_px": avg_px,
+                "oid": oid,
+            },
             "result": result
         }))?
     );

--- a/skills/hyperliquid-plugin/src/commands/orders.rs
+++ b/skills/hyperliquid-plugin/src/commands/orders.rs
@@ -19,10 +19,22 @@ pub async fn run(args: OrdersArgs) -> anyhow::Result<()> {
 
     let address = match args.address {
         Some(addr) => addr,
-        None => resolve_wallet(CHAIN_ID)?,
+        None => match resolve_wallet(CHAIN_ID) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+                return Ok(());
+            }
+        },
     };
 
-    let orders = get_open_orders(url, &address).await?;
+    let orders = match get_open_orders(url, &address).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     let empty_vec = vec![];
     let all_orders = orders.as_array().unwrap_or(&empty_vec);

--- a/skills/hyperliquid-plugin/src/commands/positions.rs
+++ b/skills/hyperliquid-plugin/src/commands/positions.rs
@@ -18,12 +18,24 @@ pub async fn run(args: PositionsArgs) -> anyhow::Result<()> {
 
     let address = match args.address {
         Some(addr) => addr,
-        None => resolve_wallet(CHAIN_ID)?,
+        None => match resolve_wallet(CHAIN_ID) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+                return Ok(());
+            }
+        },
     };
 
     eprintln!("Fetching Hyperliquid positions for: {}", address);
 
-    let state = get_clearinghouse_state(url, &address).await?;
+    let state = match get_clearinghouse_state(url, &address).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     // Parse margin summary
     let margin = &state["marginSummary"];
@@ -84,7 +96,13 @@ pub async fn run(args: PositionsArgs) -> anyhow::Result<()> {
     });
 
     if args.show_orders {
-        let orders = get_open_orders(url, &address).await?;
+        let orders = match get_open_orders(url, &address).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+                return Ok(());
+            }
+        };
         out["openOrders"] = orders;
     }
 

--- a/skills/hyperliquid-plugin/src/commands/prices.rs
+++ b/skills/hyperliquid-plugin/src/commands/prices.rs
@@ -12,7 +12,13 @@ pub struct PricesArgs {
 
 pub async fn run(args: PricesArgs) -> anyhow::Result<()> {
     let url = info_url();
-    let mids = get_all_mids(url).await?;
+    let mids = match get_all_mids(url).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     match args.coin {
         Some(coin) => {
@@ -29,18 +35,23 @@ pub async fn run(args: PricesArgs) -> anyhow::Result<()> {
                     );
                 }
                 None => {
-                    anyhow::bail!(
-                        "Coin '{}' not found. Check spelling or run `hyperliquid prices` without --coin to list all coins.",
-                        coin_upper
-                    );
+                    println!("{}", super::error_response(
+                        &format!("Coin '{}' not found. Check spelling or run `hyperliquid prices` without --coin to list all coins.", coin_upper),
+                        "INVALID_ARGUMENT",
+                        "Check the coin symbol or run `hyperliquid prices` without --coin to list all available coins."
+                    ));
                 }
             }
         }
         None => {
             // Return all prices sorted alphabetically
-            let obj = mids
-                .as_object()
-                .ok_or_else(|| anyhow::anyhow!("Unexpected allMids response format"))?;
+            let obj = match mids.as_object() {
+                Some(v) => v,
+                None => {
+                    println!("{}", super::error_response("Unexpected allMids response format", "API_ERROR", "Check your connection and retry."));
+                    return Ok(());
+                }
+            };
 
             let mut sorted: Vec<(&String, &serde_json::Value)> = obj.iter().collect();
             sorted.sort_by_key(|(k, _)| k.as_str());

--- a/skills/hyperliquid-plugin/src/commands/register.rs
+++ b/skills/hyperliquid-plugin/src/commands/register.rs
@@ -23,7 +23,13 @@ pub struct RegisterArgs {
 }
 
 pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     if args.dry_run {
         println!(
@@ -47,11 +53,17 @@ pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
     let dummy_action = build_market_order_action(asset_idx, true, "0", false, "0");
 
     // Sign through onchainos (real signing required to get HL to reveal signer)
-    let signed = onchainos_hl_sign(&dummy_action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)
-        .map_err(|e| anyhow::anyhow!(
-            "onchainos signing failed: {}. Ensure onchainos is installed and a wallet is configured.",
-            e
-        ))?;
+    let signed = match onchainos_hl_sign(&dummy_action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(
+                &format!("onchainos signing failed: {}. Ensure onchainos is installed and a wallet is configured.", e),
+                "SIGNING_FAILED",
+                "Retry the command. If the issue persists, check onchainos status."
+            ));
+            return Ok(());
+        }
+    };
 
     // Submit to HL — expect an error response containing the recovered signer address
     let response = submit_exchange_request(exchange_url(), signed).await;
@@ -70,10 +82,12 @@ pub async fn run(args: RegisterArgs) -> anyhow::Result<()> {
             if response.as_ref().map(|v| v["status"].as_str() == Some("ok")).unwrap_or(false) {
                 wallet.clone()
             } else {
-                anyhow::bail!(
-                    "Could not detect signing address from HL response: {:?}",
-                    response
-                );
+                println!("{}", super::error_response(
+                    &format!("Could not detect signing address from HL response: {:?}", response),
+                    "API_ERROR",
+                    "Check your connection and retry."
+                ));
+                return Ok(());
             }
         }
     };

--- a/skills/hyperliquid-plugin/src/commands/spot_cancel.rs
+++ b/skills/hyperliquid-plugin/src/commands/spot_cancel.rs
@@ -34,17 +34,32 @@ pub async fn run(args: SpotCancelArgs) -> anyhow::Result<()> {
     let exchange = exchange_url();
     let nonce = now_ms();
 
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // ── Case 1: single order by ID ────────────────────────────────────────────
     if let Some(oid) = args.order_id {
-        let coin_str = args
-            .coin
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("--coin is required when using --order-id"))?;
+        let coin_str = match args.coin.as_deref() {
+            Some(c) => c,
+            None => {
+                println!("{}", super::error_response("--coin is required when using --order-id", "INVALID_ARGUMENT", "Provide --coin <SYMBOL> alongside --order-id."));
+                return Ok(());
+            }
+        };
         let coin = normalize_coin(coin_str);
 
-        let (asset_idx, market_idx, _) = get_spot_asset_meta(info, &coin).await?;
+        let (asset_idx, market_idx, _) = match get_spot_asset_meta(info, &coin).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+                return Ok(());
+            }
+        };
         let action = build_cancel_action(asset_idx, oid);
 
         println!(
@@ -72,8 +87,20 @@ pub async fn run(args: SpotCancelArgs) -> anyhow::Result<()> {
             return Ok(());
         }
 
-        let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-        let result = submit_exchange_request(exchange, signed).await?;
+        let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+                return Ok(());
+            }
+        };
+        let result = match submit_exchange_request(exchange, signed).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+                return Ok(());
+            }
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -93,13 +120,25 @@ pub async fn run(args: SpotCancelArgs) -> anyhow::Result<()> {
 
     let spot_coin_filter: Option<(String, usize, usize)> = if let Some(ref c) = args.coin {
         let coin = normalize_coin(c);
-        let (asset_idx, market_idx, _) = get_spot_asset_meta(info, &coin).await?;
+        let (asset_idx, market_idx, _) = match get_spot_asset_meta(info, &coin).await {
+            Ok(v) => v,
+            Err(e) => {
+                println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+                return Ok(());
+            }
+        };
         Some((coin, asset_idx, market_idx))
     } else {
         None
     };
 
-    let open_orders = get_open_orders(info, &wallet).await?;
+    let open_orders = match get_open_orders(info, &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let empty_vec = vec![];
     let all_orders = open_orders.as_array().unwrap_or(&empty_vec);
 
@@ -214,8 +253,20 @@ pub async fn run(args: SpotCancelArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!(
         "{}",

--- a/skills/hyperliquid-plugin/src/commands/spot_order.rs
+++ b/skills/hyperliquid-plugin/src/commands/spot_order.rs
@@ -57,16 +57,26 @@ pub async fn run(args: SpotOrderArgs) -> anyhow::Result<()> {
     let nonce = now_ms();
 
     // Validate inputs
-    let _size_check: f64 = args
-        .size
-        .parse()
-        .map_err(|_| anyhow::anyhow!("Invalid --size '{}' — must be a number (e.g. 100)", args.size))?;
+    if args.size.parse::<f64>().is_err() {
+        println!("{}", super::error_response(
+            &format!("Invalid --size '{}' — must be a number (e.g. 100)", args.size),
+            "INVALID_ARGUMENT",
+            "Provide a valid numeric size with --size."
+        ));
+        return Ok(());
+    }
 
     if args.post_only && args.r#type != "limit" {
-        anyhow::bail!("--post-only requires --type limit");
+        println!("{}", super::error_response("--post-only requires --type limit", "INVALID_ARGUMENT", "Use --type limit together with --post-only."));
+        return Ok(());
     }
     if args.slippage <= 0.0 || args.slippage > 100.0 {
-        anyhow::bail!("--slippage must be between 0 and 100 (got {})", args.slippage);
+        println!("{}", super::error_response(
+            &format!("--slippage must be between 0 and 100 (got {})", args.slippage),
+            "INVALID_ARGUMENT",
+            "Provide a slippage value between 0 and 100 (e.g. 1.0 for 1%)."
+        ));
+        return Ok(());
     }
 
     // Pre-flight: check notional value against HL's 10 USDC spot minimum
@@ -74,20 +84,37 @@ pub async fn run(args: SpotOrderArgs) -> anyhow::Result<()> {
         if let Ok(price_f) = price_str.parse::<f64>() {
             let notional = size_f * price_f;
             if notional < 10.0 {
-                anyhow::bail!(
-                    "Order value {:.4} USDC is below Hyperliquid's 10 USDC minimum for spot orders. \
-                     Increase --size or --price (current: {} × {} = {:.4} USDC).",
-                    notional, args.size, price_str, notional
-                );
+                println!("{}", super::error_response(
+                    &format!(
+                        "Order value {:.4} USDC is below Hyperliquid's 10 USDC minimum for spot orders. \
+                         Increase --size or --price (current: {} × {} = {:.4} USDC).",
+                        notional, args.size, price_str, notional
+                    ),
+                    "INVALID_ARGUMENT",
+                    "Increase --size or --price so the order value is at least 10 USDC."
+                ));
+                return Ok(());
             }
         }
     }
 
     // Look up spot asset — returns (order_asset_idx, raw_market_idx, sz_decimals)
-    let (asset_idx, market_idx, sz_decimals) = get_spot_asset_meta(info, &coin).await?;
+    let (asset_idx, market_idx, sz_decimals) = match get_spot_asset_meta(info, &coin).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     // Current mid price (keyed as "@{market_idx}" in allMids)
-    let mids = get_all_mids(info).await?;
+    let mids = match get_all_mids(info).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let price_key = format!("@{}", market_idx);
     let current_price = mids
         .get(&price_key)
@@ -103,17 +130,24 @@ pub async fn run(args: SpotOrderArgs) -> anyhow::Result<()> {
     let action = match args.r#type.as_str() {
         "market" => build_market_order_action(asset_idx, is_buy, &args.size, false, &slippage_px_str),
         "limit" => {
-            let price_str = args
-                .price
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("--price is required for limit orders"))?;
-            let _: f64 = price_str
-                .parse()
-                .map_err(|_| anyhow::anyhow!("Invalid --price '{}'", price_str))?;
+            let price_str = match args.price.as_deref() {
+                Some(p) => p,
+                None => {
+                    println!("{}", super::error_response("--price is required for limit orders", "INVALID_ARGUMENT", "Provide a limit price with --price."));
+                    return Ok(());
+                }
+            };
+            if price_str.parse::<f64>().is_err() {
+                println!("{}", super::error_response(&format!("Invalid --price '{}'", price_str), "INVALID_ARGUMENT", "Provide a valid numeric price with --price."));
+                return Ok(());
+            }
             let tif = if args.post_only { "Alo" } else { "Gtc" };
             build_limit_order_action(asset_idx, is_buy, price_str, &args.size, false, tif)
         }
-        _ => anyhow::bail!("Unknown order type '{}'", args.r#type),
+        _ => {
+            println!("{}", super::error_response(&format!("Unknown order type '{}'", args.r#type), "INVALID_ARGUMENT", "Use --type market or --type limit."));
+            return Ok(());
+        }
     };
 
     println!(
@@ -149,9 +183,27 @@ pub async fn run(args: SpotOrderArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let wallet = resolve_wallet(CHAIN_ID)?;
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!(
         "{}",

--- a/skills/hyperliquid-plugin/src/commands/tpsl.rs
+++ b/skills/hyperliquid-plugin/src/commands/tpsl.rs
@@ -22,6 +22,11 @@ pub struct TpslArgs {
     #[arg(long)]
     pub size: Option<String>,
 
+    /// Worst-fill slippage tolerance when the trigger fires, in percent (default 10.0 = 10%).
+    /// The limit price is set to trigger_px × (1 ± trigger_slippage/100).
+    #[arg(long, default_value = "10.0")]
+    pub trigger_slippage: f64,
+
     /// Dry run — show payload without signing or submitting
     #[arg(long)]
     pub dry_run: bool,
@@ -33,7 +38,21 @@ pub struct TpslArgs {
 
 pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
     if args.sl_px.is_none() && args.tp_px.is_none() {
-        anyhow::bail!("Provide at least one of --sl-px (stop-loss) or --tp-px (take-profit)");
+        println!("{}", super::error_response(
+            "Provide at least one of --sl-px (stop-loss) or --tp-px (take-profit)",
+            "INVALID_ARGUMENT",
+            "Example: hyperliquid tpsl --coin BTC --sl-px 90000 --tp-px 110000"
+        ));
+        return Ok(());
+    }
+
+    if args.trigger_slippage <= 0.0 || args.trigger_slippage > 100.0 {
+        println!("{}", super::error_response(
+            &format!("--trigger-slippage must be between 0 and 100 (got {})", args.trigger_slippage),
+            "INVALID_ARGUMENT",
+            "Provide a trigger slippage value between 0 and 100, e.g. --trigger-slippage 10.0"
+        ));
+        return Ok(());
     }
 
     let info = info_url();
@@ -41,11 +60,29 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
     let coin = normalize_coin(&args.coin);
     let nonce = now_ms();
 
-    let (asset_idx, sz_decimals) = get_asset_meta(info, &coin).await?;
-    let wallet = resolve_wallet(CHAIN_ID)?;
+    let (asset_idx, sz_decimals) = match get_asset_meta(info, &coin).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
+    let wallet = match resolve_wallet(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
 
     // Auto-detect position direction and size
-    let state = get_clearinghouse_state(info, &wallet).await?;
+    let state = match get_clearinghouse_state(info, &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let empty_vec = vec![];
     let positions = state["assetPositions"].as_array().unwrap_or(&empty_vec);
 
@@ -68,15 +105,25 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         }
     }
 
-    let szi = position_szi.ok_or_else(|| {
-        anyhow::anyhow!(
-            "No open {} position found. Use `hyperliquid positions` to check.",
-            coin
-        )
-    })?;
+    let szi = match position_szi {
+        Some(v) => v,
+        None => {
+            println!("{}", super::error_response(
+                &format!("No open {} position found.", coin),
+                "POSITION_NOT_FOUND",
+                "Run positions to see open positions."
+            ));
+            return Ok(());
+        }
+    };
 
     if szi == 0.0 {
-        anyhow::bail!("No open {} position (size is 0).", coin);
+        println!("{}", super::error_response(
+            &format!("No open {} position (size is 0).", coin),
+            "POSITION_NOT_FOUND",
+            "Run positions to see open positions."
+        ));
+        return Ok(());
     }
 
     let position_is_long = szi > 0.0;
@@ -84,7 +131,13 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
     let position_side = if position_is_long { "long" } else { "short" };
 
     // Validate TP/SL prices make sense relative to position direction
-    let mids = get_all_mids(info).await?;
+    let mids = match get_all_mids(info).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let current_price_str = mids
         .get(&coin)
         .and_then(|v| v.as_str())
@@ -93,45 +146,62 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
 
     if let Some(sl) = args.sl_px {
         if position_is_long && sl >= current_price {
-            anyhow::bail!(
-                "Stop-loss {} is above current price {} for a long position. \
-                 SL must be below current price.",
-                sl, current_price_str
-            );
+            println!("{}", super::error_response(
+                &format!("Stop-loss {} is above current price {} for a long position. SL must be below current price.", sl, current_price_str),
+                "INVALID_ARGUMENT",
+                "For a long position, stop-loss must be below the current price."
+            ));
+            return Ok(());
         }
         if !position_is_long && sl <= current_price {
-            anyhow::bail!(
-                "Stop-loss {} is below current price {} for a short position. \
-                 SL must be above current price.",
-                sl, current_price_str
-            );
+            println!("{}", super::error_response(
+                &format!("Stop-loss {} is below current price {} for a short position. SL must be above current price.", sl, current_price_str),
+                "INVALID_ARGUMENT",
+                "For a short position, stop-loss must be above the current price."
+            ));
+            return Ok(());
         }
     }
     if let Some(tp) = args.tp_px {
         if position_is_long && tp <= current_price {
-            anyhow::bail!(
-                "Take-profit {} is below current price {} for a long position. \
-                 TP must be above current price.",
-                tp, current_price_str
-            );
+            println!("{}", super::error_response(
+                &format!("Take-profit {} is below current price {} for a long position. TP must be above current price.", tp, current_price_str),
+                "INVALID_ARGUMENT",
+                "For a long position, take-profit must be above the current price."
+            ));
+            return Ok(());
         }
         if !position_is_long && tp >= current_price {
-            anyhow::bail!(
-                "Take-profit {} is above current price {} for a short position. \
-                 TP must be below current price.",
-                tp, current_price_str
-            );
+            println!("{}", super::error_response(
+                &format!("Take-profit {} is above current price {} for a short position. TP must be below current price.", tp, current_price_str),
+                "INVALID_ARGUMENT",
+                "For a short position, take-profit must be below the current price."
+            ));
+            return Ok(());
         }
     }
 
     // Determine order size
     let size_str = match &args.size {
         Some(s) => {
-            let v: f64 = s
-                .parse()
-                .map_err(|_| anyhow::anyhow!("Invalid --size '{}'", s))?;
+            let v: f64 = match s.parse() {
+                Ok(v) => v,
+                Err(_) => {
+                    println!("{}", super::error_response(
+                        &format!("Invalid --size '{}'", s),
+                        "INVALID_ARGUMENT",
+                        "Provide a numeric size value, e.g. --size 0.01"
+                    ));
+                    return Ok(());
+                }
+            };
             if v <= 0.0 || v > position_size {
-                anyhow::bail!("--size must be > 0 and ≤ position size {}", position_size);
+                println!("{}", super::error_response(
+                    &format!("--size must be > 0 and ≤ position size {}", position_size),
+                    "INVALID_ARGUMENT",
+                    &format!("Size must be between 0 and {}.", position_size)
+                ));
+                return Ok(());
             }
             s.clone()
         }
@@ -151,19 +221,18 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         sl_px_str.as_deref(),
         tp_px_str.as_deref(),
         sz_decimals,
+        args.trigger_slippage,
     );
 
-    // Compute implied slippage limit prices for display
-    let sl_limit_display = args.sl_px.map(|px| {
-        let closing_is_buy = !position_is_long;
-        let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        round_px(limit, sz_decimals)
-    });
-    let tp_limit_display = args.tp_px.map(|px| {
-        let closing_is_buy = !position_is_long;
-        let limit = if closing_is_buy { px * 1.1 } else { px * 0.9 };
-        round_px(limit, sz_decimals)
-    });
+    // Compute worst-fill limit prices for display (matches what is sent on-chain)
+    let closing_is_buy = !position_is_long;
+    let trigger_multiplier = if closing_is_buy {
+        1.0 + args.trigger_slippage / 100.0
+    } else {
+        1.0 - args.trigger_slippage / 100.0
+    };
+    let sl_limit_display = args.sl_px.map(|px| round_px(px * trigger_multiplier, sz_decimals));
+    let tp_limit_display = args.tp_px.map(|px| round_px(px * trigger_multiplier, sz_decimals));
 
     println!(
         "{}",
@@ -205,8 +274,20 @@ pub async fn run(args: TpslArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign(&action, nonce, &wallet, ARBITRUM_CHAIN_ID, true, false) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     println!(
         "{}",

--- a/skills/hyperliquid-plugin/src/commands/transfer.rs
+++ b/skills/hyperliquid-plugin/src/commands/transfer.rs
@@ -32,21 +32,38 @@ pub async fn run(args: TransferArgs) -> anyhow::Result<()> {
     let exchange = exchange_url();
 
     if args.amount <= 0.0 {
-        anyhow::bail!("--amount must be positive (got {})", args.amount);
+        println!("{}", super::error_response(
+            &format!("--amount must be positive (got {})", args.amount),
+            "INVALID_ARGUMENT",
+            "Provide a positive USDC amount with --amount."
+        ));
+        return Ok(());
     }
 
     let to_perp = args.direction == "spot-to-perp";
     let nonce = now_ms();
 
-    let (default_wallet, sign_chain_id) = resolve_wallet_with_chain(CHAIN_ID)?;
+    let (default_wallet, sign_chain_id) = match resolve_wallet_with_chain(CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
     let wallet = args.account.clone().unwrap_or(default_wallet);
 
     let (from_label, to_label) = if to_perp { ("spot", "perp") } else { ("perp", "spot") };
 
-    let (perp_state, spot_state) = tokio::try_join!(
+    let (perp_state, spot_state) = match tokio::try_join!(
         get_clearinghouse_state(info, &wallet),
         get_spot_clearinghouse_state(info, &wallet),
-    )?;
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
 
     let perp_withdrawable: f64 = perp_state["withdrawable"]
         .as_str().and_then(|s| s.parse().ok()).unwrap_or(0.0);
@@ -60,16 +77,20 @@ pub async fn run(args: TransferArgs) -> anyhow::Result<()> {
         .unwrap_or(0.0);
 
     if !to_perp && args.amount > perp_withdrawable {
-        anyhow::bail!(
-            "Insufficient perp balance: requested {:.6} USDC, withdrawable {:.6} USDC",
-            args.amount, perp_withdrawable
-        );
+        println!("{}", super::error_response(
+            &format!("Insufficient perp balance: requested {:.6} USDC, withdrawable {:.6} USDC", args.amount, perp_withdrawable),
+            "INSUFFICIENT_BALANCE",
+            "Ensure you have enough USDC in your perp account before transferring."
+        ));
+        return Ok(());
     }
     if to_perp && args.amount > spot_usdc {
-        anyhow::bail!(
-            "Insufficient spot USDC balance: requested {:.6} USDC, available {:.6} USDC",
-            args.amount, spot_usdc
-        );
+        println!("{}", super::error_response(
+            &format!("Insufficient spot USDC balance: requested {:.6} USDC, available {:.6} USDC", args.amount, spot_usdc),
+            "INSUFFICIENT_BALANCE",
+            "Ensure you have enough USDC in your spot account before transferring."
+        ));
+        return Ok(());
     }
 
     let action = build_spot_transfer_action(args.amount, to_perp, nonce);
@@ -93,13 +114,30 @@ pub async fn run(args: TransferArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let signed = onchainos_hl_sign_usd_class_transfer(
+    let signed = match onchainos_hl_sign_usd_class_transfer(
         &action, nonce, &wallet, sign_chain_id, true, false
-    )?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     if result["status"].as_str() == Some("err") {
-        anyhow::bail!("Transfer failed: {}", result["response"].as_str().unwrap_or("unknown error"));
+        println!("{}", super::error_response(
+            &format!("Transfer failed: {}", result["response"].as_str().unwrap_or("unknown error")),
+            "TX_SUBMIT_FAILED",
+            "Retry the command. If the issue persists, check onchainos status."
+        ));
+        return Ok(());
     }
 
     println!("{}", serde_json::json!({

--- a/skills/hyperliquid-plugin/src/commands/withdraw.rs
+++ b/skills/hyperliquid-plugin/src/commands/withdraw.rs
@@ -29,38 +29,62 @@ const WITHDRAWAL_FEE_USDC: f64 = 1.0;
 
 pub async fn run(args: WithdrawArgs) -> anyhow::Result<()> {
     if args.amount <= 0.0 {
-        anyhow::bail!("--amount must be positive (got {})", args.amount);
+        println!("{}", super::error_response(
+            &format!("--amount must be positive (got {})", args.amount),
+            "INVALID_ARGUMENT",
+            "Provide a positive USDC amount with --amount."
+        ));
+        return Ok(());
     }
     if args.amount < 2.0 {
-        anyhow::bail!(
-            "Minimum withdrawal is $2 USDC (got ${}).",
-            args.amount
-        );
+        println!("{}", super::error_response(
+            &format!("Minimum withdrawal is $2 USDC (got ${}).", args.amount),
+            "INVALID_ARGUMENT",
+            "Provide an amount of at least $2 USDC."
+        ));
+        return Ok(());
     }
 
     let info = info_url();
     let exchange = exchange_url();
     let nonce = now_ms();
 
-    let (wallet, sign_chain_id) = resolve_wallet_with_chain(ARBITRUM_CHAIN_ID)?;
+    let (wallet, sign_chain_id) = match resolve_wallet_with_chain(ARBITRUM_CHAIN_ID) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "WALLET_NOT_FOUND", "Run onchainos wallet addresses to verify login."));
+            return Ok(());
+        }
+    };
     let destination = args.destination.clone().unwrap_or_else(|| wallet.clone());
 
     // Format amount as string with up to 8 decimal places, trimming trailing zeros
     let amount_str = format!("{}", args.amount);
 
     // Fetch withdrawable balance
-    let state = get_clearinghouse_state(info, &wallet).await?;
+    let state = match get_clearinghouse_state(info, &wallet).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "API_ERROR", "Check your connection and retry."));
+            return Ok(());
+        }
+    };
     let withdrawable: f64 = state["withdrawable"]
         .as_str().and_then(|s| s.parse().ok()).unwrap_or(0.0);
 
     // Check balance covers amount + $1 fee
     let total_deducted = args.amount + WITHDRAWAL_FEE_USDC;
     if total_deducted > withdrawable {
-        anyhow::bail!(
-            "Insufficient balance: withdrawal ${:.2} + $1.00 fee = ${:.2} required, \
-             but only ${:.2} USDC available.",
-            args.amount, total_deducted, withdrawable
-        );
+        println!("{}", super::error_response(
+            &format!(
+                "Insufficient balance: withdrawal ${:.2} + $1.00 fee = ${:.2} required, \
+                 but only ${:.2} USDC available.",
+                args.amount, total_deducted, withdrawable
+            ),
+            "INSUFFICIENT_BALANCE",
+            "Ensure your Hyperliquid perp balance covers the withdrawal amount plus the $1 fee."
+        ));
+        return Ok(());
     }
 
     if args.dry_run || !args.confirm {
@@ -84,11 +108,28 @@ pub async fn run(args: WithdrawArgs) -> anyhow::Result<()> {
         "Withdrawing {} USDC to {} (+ $1.00 fee deducted from balance)...",
         args.amount, destination
     );
-    let signed = onchainos_hl_sign_withdraw(&destination, &amount_str, nonce, &wallet, sign_chain_id)?;
-    let result = submit_exchange_request(exchange, signed).await?;
+    let signed = match onchainos_hl_sign_withdraw(&destination, &amount_str, nonce, &wallet, sign_chain_id) {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "SIGNING_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
+    let result = match submit_exchange_request(exchange, signed).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&format!("{:#}", e), "TX_SUBMIT_FAILED", "Retry the command. If the issue persists, check onchainos status."));
+            return Ok(());
+        }
+    };
 
     if result["status"].as_str() == Some("err") {
-        anyhow::bail!("Withdraw failed: {}", result["response"].as_str().unwrap_or("unknown error"));
+        println!("{}", super::error_response(
+            &format!("Withdraw failed: {}", result["response"].as_str().unwrap_or("unknown error")),
+            "TX_SUBMIT_FAILED",
+            "Retry the command. If the issue persists, check onchainos status."
+        ));
+        return Ok(());
     }
 
     println!("{}", serde_json::json!({

--- a/skills/hyperliquid-plugin/src/signing.rs
+++ b/skills/hyperliquid-plugin/src/signing.rs
@@ -24,11 +24,12 @@ pub fn round_px(px: f64, sz_decimals: u32) -> String {
     if px == 0.0 {
         return "0".to_string();
     }
-    if sz_decimals == 0 {
-        return format!("{}", px.round() as i64);
-    }
+    // Match Python SDK: f"{px:.{sz_decimals}g}" uses at minimum 1 significant figure.
+    // Without this, coins with sz_decimals=0 and price < 0.5 (e.g. BIO at $0.032)
+    // produce price="0" via px.round() → HL rejects with "Order has invalid price."
+    let sig_figs = sz_decimals.max(1);
     let mag = px.abs().log10().floor() as i32;
-    let decimal_places = (sz_decimals as i32) - mag - 1;
+    let decimal_places = (sig_figs as i32) - mag - 1;
     let rounded = if decimal_places <= 0 {
         let factor = 10_f64.powi(-decimal_places);
         (px / factor).round() * factor
@@ -48,26 +49,13 @@ pub fn round_px(px: f64, sz_decimals: u32) -> String {
     }
 }
 
-/// Compute slippage-protected price for a market order.
-/// is_buy=true → price * 1.05 (pay up to 5% above mid)
-/// is_buy=false → price * 0.95 (accept down to 5% below mid)
-/// Rounds to sz_decimals significant figures to match HL's validation.
-pub fn market_slippage_px(mid_px: f64, is_buy: bool, sz_decimals: u32) -> String {
-    let px = if is_buy { mid_px * 1.05 } else { mid_px * 0.95 };
-    round_px(px, sz_decimals)
-}
-
 /// Slippage-protected limit price for market trigger orders.
 /// When a trigger fires as "market", HL still needs a worst-acceptable-price.
-/// Convention: 10% slippage tolerance (same as HL web UI default).
+/// slippage_pct: tolerance in percent (e.g. 10.0 = 10%, matching HL web UI default).
 /// Uses round_px so the limit price obeys the same tick-size rules as the trigger price.
-fn trigger_limit_px(trigger_px: f64, is_buy: bool, sz_decimals: u32) -> String {
-    let px = if is_buy {
-        trigger_px * 1.1
-    } else {
-        trigger_px * 0.9
-    };
-    round_px(px, sz_decimals)
+fn trigger_limit_px(trigger_px: f64, is_buy: bool, sz_decimals: u32, slippage_pct: f64) -> String {
+    let multiplier = if is_buy { 1.0 + slippage_pct / 100.0 } else { 1.0 - slippage_pct / 100.0 };
+    round_px(trigger_px * multiplier, sz_decimals)
 }
 
 // ─── Entry orders ────────────────────────────────────────────────────────────
@@ -173,6 +161,7 @@ pub fn build_trigger_order_element(
     is_market: bool,
     limit_px_override: Option<&str>,
     sz_decimals: u32,
+    trigger_slippage_pct: f64,
 ) -> Value {
     let is_buy = !position_is_long; // close opposite of entry
 
@@ -180,7 +169,7 @@ pub fn build_trigger_order_element(
         Some(px) => px.to_string(),
         None if is_market => {
             let trigger_px: f64 = trigger_px_str.parse().unwrap_or(0.0);
-            trigger_limit_px(trigger_px, is_buy, sz_decimals)
+            trigger_limit_px(trigger_px, is_buy, sz_decimals, trigger_slippage_pct)
         }
         None => trigger_px_str.to_string(),
     };
@@ -211,17 +200,18 @@ pub fn build_standalone_tpsl_action(
     sl_px: Option<&str>,
     tp_px: Option<&str>,
     sz_decimals: u32,
+    trigger_slippage_pct: f64,
 ) -> Value {
     let mut orders = vec![];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "sl", px, true, None, sz_decimals,
+            asset, position_is_long, size_str, "sl", px, true, None, sz_decimals, trigger_slippage_pct,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, position_is_long, size_str, "tp", px, true, None, sz_decimals,
+            asset, position_is_long, size_str, "tp", px, true, None, sz_decimals, trigger_slippage_pct,
         ));
     }
 
@@ -243,18 +233,19 @@ pub fn build_bracketed_order_action(
     sl_px: Option<&str>,
     tp_px: Option<&str>,
     sz_decimals: u32,
+    trigger_slippage_pct: f64,
 ) -> Value {
     let entry_is_long = position_is_long;
     let mut orders = vec![entry_order];
 
     if let Some(px) = sl_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "sl", px, true, None, sz_decimals,
+            asset, entry_is_long, size_str, "sl", px, true, None, sz_decimals, trigger_slippage_pct,
         ));
     }
     if let Some(px) = tp_px {
         orders.push(build_trigger_order_element(
-            asset, entry_is_long, size_str, "tp", px, true, None, sz_decimals,
+            asset, entry_is_long, size_str, "tp", px, true, None, sz_decimals, trigger_slippage_pct,
         ));
     }
 


### PR DESCRIPTION
## Summary

- **fix**: `round_px` — coins with `sz_decimals=0` and price < $0.50 (e.g. BIO at ~\$0.032) produced `price="0"` via `px.round()` truncation, causing HL to reject with `"Order has invalid price."`. Now uses `sig_figs = sz_decimals.max(1)` matching the Python SDK minimum-1-sig-fig behaviour.
- **feat**: `order` / `close` — expose `--slippage <pct>` (default `5.0`); replaces the previously hardcoded 5% market order worst-fill price. Preview now shows `slippagePct` and `worstFillPrice`.
- **feat**: `order` / `tpsl` — expose `--trigger-slippage <pct>` (default `10.0`); replaces the previously hardcoded 10% bracket/standalone TP-SL worst-fill tolerance.
- **feat**: `order` confirmed output — adds `data.{avg_px, fill_px, oid}` for programmatic consumers (e.g. liquidation scripts) reading fill price and order ID.
- **fix**: all commands — GEN-001 structured JSON errors on stdout instead of bare stderr text. New `error_response()` helper in `mod.rs`; all `run()` failures emit `{"ok":false,"error":"...","error_code":"...","suggestion":"..."}` and `return Ok(())`.

## Checklist
- [x] `cargo build` clean (0 errors)
- [x] All binary `--help` flags match SKILL.md documentation
- [x] Version bumped 0.3.6 → 0.3.7 in all 4 files (plugin.yaml, SKILL.md, Cargo.toml, plugin.json)
- [x] SKILL.md inline version references updated (LOCAL_VER, download URL, managed echo, report JSON)
- [x] `api_calls` whitelist unchanged (no new external domains added)
- [x] Fork main synced to `okx/main` before branching

🤖 Generated with [Claude Code](https://claude.com/claude-code)