### PR TITLE
fix(polymarket-plugin): redeem pre-flight + structured errors (v0.4.8)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit, BTC 5分钟, ETH 5分钟, 5分钟市场, 5min market, 五分钟市场, 短线市场, list 5-minute, BTC up or down, 找5分钟, 看5分钟, 5m updown, crypto 5m, 5分钟涨跌, 五分钟涨跌, updown market, BTC 5min, ETH 5min, SOL 5min, 5分钟预测."
-version: "0.4.7"
+version: "0.4.8"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.7"
+LOCAL_VER="0.4.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.7/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.8/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -309,7 +309,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket-plugin --version
 ```
 
-Expected: `polymarket-plugin 0.4.7`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket-plugin 0.4.8`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -730,7 +730,7 @@ polymarket cancel --all
 
 ### `redeem` — Redeem Winning Outcome Tokens
 
-After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. The binary automatically detects which wallet (EOA or proxy) holds the winning tokens by querying the Data API, then calls the correct redemption path for each wallet. Each tx is confirmed on-chain before returning. No manual mode selection needed.
+After a market resolves, the winning side's tokens can be redeemed for USDC.e at a 1:1 rate. The binary queries the Data API to find which wallet (EOA or proxy) holds the winning tokens, pre-flights each call via `eth_call` to catch reverts before broadcast, and waits for on-chain confirmation (up to 45s per tx). Batch mode also checks EOA POL balance up front so insufficient gas fails fast instead of timing out mid-batch.
 
 ```
 polymarket redeem --market-id <condition_id_or_slug>
@@ -743,23 +743,37 @@ polymarket redeem --all --dry-run
 |------|-------------|
 | `--market-id` | Market to redeem from: condition_id (0x-prefixed) or slug. Omit when using `--all`. |
 | `--all` | Discover and redeem **all** redeemable positions across EOA and proxy wallets in one pass, sequentially with on-chain confirmation between each. |
-| `--dry-run` | Preview without submitting: shows which wallets/markets will be redeemed |
+| `--dry-run` | Preview without submitting: shows which wallets/markets will be redeemed and estimated POL gas cost |
 
 **Auth required:** onchainos wallet (for signing the on-chain tx). No CLOB credentials needed.
 
 **Not supported:** `neg_risk: true` (multi-outcome) markets — use the Polymarket web UI for those.
 
 **Wallet routing (automatic):**
-- EOA has winning tokens → direct `redeemPositions` from EOA, waits for confirmation
-- Proxy has winning tokens → `PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])`, waits for confirmation
+- EOA has winning tokens → direct `redeemPositions` from EOA, pre-flight simulated, tx confirmed
+- Proxy has winning tokens → `PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])`, pre-flight simulated, tx confirmed
 - Both wallets have tokens → EOA tx confirmed first, then proxy tx
-- Data API lag (nothing redeemable yet) → fallback EOA redeem with a warning
+- **Neither wallet has redeemable positions** → fails fast with `NO_REDEEMABLE_POSITIONS` (suggests running `setup-proxy` if the user trades in POLY_PROXY mode)
+
+**Pre-flight checks (batch mode):**
+1. EOA POL balance ≥ N × 0.015 POL (where N = number of markets to redeem) — fails with `INSUFFICIENT_POL_GAS` otherwise
+2. Per-market `eth_call` simulation — fails with `SIMULATION_REVERTED` if the tx would revert, avoiding a 45s timeout on a tx that was never broadcast
 
 **Output fields — single market (`--market-id`):** `condition_id`, `question`, `note`, and one or both of:
 - `eoa_tx` + `eoa_note` (if EOA held winning tokens)
 - `proxy_tx` + `proxy_note` (if proxy held winning tokens)
 
-**Output fields — batch (`--all`):** `redeemed_count`, `error_count`, `results` (array of per-market results above), `errors`
+**Output fields — batch (`--all`):** `redeemed_count`, `error_count`, `results` (array of per-market results above), `errors` (each entry includes `condition_id`, `title`, `error`, `error_code`, `suggestion`). In dry-run mode additionally: `estimated_pol_needed`.
+
+**Error codes (per GEN-001 structured output to stdout):**
+| `error_code` | When | Fix |
+|--------------|------|-----|
+| `NO_REDEEMABLE_POSITIONS` | Data API shows no redeemable tokens on either wallet | Run `setup-proxy` if trading in POLY_PROXY mode, or verify mode with `balance` |
+| `INSUFFICIENT_POL_GAS` | EOA POL < N × 0.015 | Top up POL on the EOA |
+| `SIMULATION_REVERTED` | `eth_call` pre-flight reverts | Usually EOA doesn't hold the outcome tokens — check trading mode / proxy wallet |
+| `TX_NOT_CONFIRMED` | Tx hash returned but never appears on-chain within 45s | Check Polygonscan; if missing, onchainos signed but did not broadcast (typically a revert) |
+| `TX_REVERTED` | Tx mined with status 0x0 | Caller wallet does not hold the winning outcome tokens |
+| `NEG_RISK_NOT_SUPPORTED` | Market is multi-outcome | Use Polymarket web UI |
 
 **Agent flow:**
 1. If user has multiple resolved positions, prefer `--all` to clear everything in one command

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.7"
+version: "0.4.8"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/mod.rs
+++ b/skills/polymarket-plugin/src/commands/mod.rs
@@ -13,3 +13,88 @@ pub mod redeem;
 pub mod sell;
 pub mod setup_proxy;
 pub mod switch_mode;
+
+/// Build a structured error JSON string for stdout output (per GEN-001).
+///
+/// Use when a command hits a business-logic failure (insufficient gas, tx never
+/// broadcast, revert, missing positions, etc.) — the caller should `println!` this
+/// and `return Ok(())` so external agents can parse the error instead of seeing
+/// only exit code 1 + stderr.
+///
+/// `extra_hint`, when present, is appended to `suggestion` — useful for attaching
+/// context the classifier cannot derive from the error message alone (e.g. a proxy
+/// wallet address discovered on-chain for this specific EOA).
+pub fn error_response(
+    err: &anyhow::Error,
+    context: Option<&str>,
+    extra_hint: Option<&str>,
+) -> String {
+    let msg = format!("{:#}", err);
+    let (error_code, mut suggestion) = classify_error(&msg, context);
+    if let Some(h) = extra_hint {
+        let h = h.trim();
+        if !h.is_empty() {
+            suggestion.push(' ');
+            suggestion.push_str(h);
+        }
+    }
+    serde_json::to_string_pretty(&serde_json::json!({
+        "ok": false,
+        "error": msg,
+        "error_code": error_code,
+        "suggestion": suggestion,
+    }))
+    .unwrap_or_else(|_| format!(r#"{{"ok":false,"error":{:?}}}"#, msg))
+}
+
+fn classify_error(msg: &str, _ctx: Option<&str>) -> (&'static str, String) {
+    let m = msg.to_lowercase();
+
+    if m.contains("insufficient pol") {
+        return (
+            "INSUFFICIENT_POL_GAS",
+            "Top up POL on your EOA wallet (Polygon). Redeem costs ~0.015 POL per market; \
+             batch redeem N markets needs ~N × 0.015 POL.".into(),
+        );
+    }
+    if m.contains("no redeemable positions") {
+        return (
+            "NO_REDEEMABLE_POSITIONS",
+            "Data API shows no redeemable positions on either the EOA or the proxy wallet. \
+             If you traded in POLY_PROXY mode, run `setup-proxy` first so the plugin knows \
+             your proxy address; otherwise verify your trading mode with `balance`.".into(),
+        );
+    }
+    if m.contains("simulation reverted") || m.contains("eth_call reverted") {
+        return (
+            "SIMULATION_REVERTED",
+            "eth_call simulation reverted before broadcast. The most common cause for redeem \
+             is that the EOA does not hold the winning outcome tokens (they live in the proxy \
+             wallet). Run `setup-proxy` or check your trading mode.".into(),
+        );
+    }
+    if m.contains("not observed on-chain") || m.contains("not confirmed within") {
+        return (
+            "TX_NOT_CONFIRMED",
+            "Tx hash was returned but never appeared on-chain. Usually means onchainos signed \
+             a tx that would revert and dropped it silently. Check Polygonscan for the hash — \
+             if missing, re-run with --dry-run to inspect, or verify your trading mode.".into(),
+        );
+    }
+    if m.contains("mined but reverted") || m.contains("status 0x0") {
+        return (
+            "TX_REVERTED",
+            "Tx mined but reverted on-chain. For redeem this usually means the calling wallet \
+             does not hold the winning outcome tokens.".into(),
+        );
+    }
+    if m.contains("neg_risk") {
+        return (
+            "NEG_RISK_NOT_SUPPORTED",
+            "Multi-outcome (neg_risk) markets cannot be redeemed via this plugin — \
+             use the Polymarket web UI.".into(),
+        );
+    }
+
+    ("REDEEM_FAILED", "See error field for details.".into())
+}

--- a/skills/polymarket-plugin/src/commands/redeem.rs
+++ b/skills/polymarket-plugin/src/commands/redeem.rs
@@ -1,11 +1,21 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, Result};
 use reqwest::Client;
 
 use crate::api::{get_clob_market, get_gamma_market_by_slug, get_positions};
 use crate::config::load_credentials;
 use crate::onchainos::{
-    ctf_redeem_positions, ctf_redeem_via_proxy, get_wallet_address, wait_for_tx_receipt,
+    ctf_redeem_positions, ctf_redeem_via_proxy, get_existing_proxy, get_pol_balance,
+    get_wallet_address, wait_for_tx_receipt_labeled,
 };
+
+/// Per-redeem timeout (Polygon block time ~2s; a healthy tx mines in <30s).
+/// Kept short so batch redeem stays under typical subprocess timeouts.
+const REDEEM_WAIT_SECS: u64 = 45;
+
+/// Estimated POL gas cost per redeem call (conservative).
+/// CTF.redeemPositions on Polygon typically costs ~0.008 POL; we budget 2×
+/// to absorb gas price spikes.
+const POL_PER_REDEEM: f64 = 0.015;
 
 /// Resolve (condition_id, neg_risk, question) from a market_id (condition_id or slug).
 async fn resolve_market(client: &Client, market_id: &str) -> Result<(String, bool, String)> {
@@ -17,7 +27,7 @@ async fn resolve_market(client: &Client, market_id: &str) -> Result<(String, boo
         let m = get_gamma_market_by_slug(client, market_id).await?;
         let cid = m
             .condition_id
-            .ok_or_else(|| anyhow::anyhow!("market has no conditionId: {}", market_id))?;
+            .ok_or_else(|| anyhow!("market has no conditionId: {}", market_id))?;
         let q = m.question.unwrap_or_default();
         let neg_risk = match get_clob_market(client, &cid).await {
             Ok(clob) => clob.neg_risk,
@@ -27,12 +37,46 @@ async fn resolve_market(client: &Client, market_id: &str) -> Result<(String, boo
     }
 }
 
+/// Summary of which wallet(s) hold redeemable tokens for a given condition_id.
+#[derive(Default)]
+struct Redeemability {
+    eoa: bool,
+    proxy: bool,
+}
+
+async fn check_redeemability(
+    client: &Client,
+    condition_id: &str,
+    eoa_addr: &str,
+    proxy_addr: Option<&str>,
+) -> Redeemability {
+    let cid_hex = condition_id.trim_start_matches("0x");
+    let cid_display = format!("0x{}", cid_hex);
+    let matches = |cid_opt: Option<&str>| -> bool {
+        cid_opt == Some(condition_id) || cid_opt == Some(&cid_display)
+    };
+
+    let eoa_positions = get_positions(client, eoa_addr).await.unwrap_or_default();
+    let eoa = eoa_positions
+        .iter()
+        .any(|p| matches(p.condition_id.as_deref()) && p.redeemable);
+
+    let proxy = if let Some(proxy) = proxy_addr {
+        let positions = get_positions(client, proxy).await.unwrap_or_default();
+        positions
+            .iter()
+            .any(|p| matches(p.condition_id.as_deref()) && p.redeemable)
+    } else {
+        false
+    };
+
+    Redeemability { eoa, proxy }
+}
+
 /// Core redeem logic for a single condition_id.
 ///
-/// Checks which wallet(s) hold redeemable tokens via the Data API, submits the
-/// appropriate tx(es), and waits for each to confirm on-chain before returning.
-///
-/// Returns a JSON Value summarising the result (for use in both single and batch flows).
+/// Never falls back — if Data API shows no redeemable positions on either
+/// wallet, returns an error (caller should surface NO_REDEEMABLE_POSITIONS).
 async fn redeem_one(
     client: &Client,
     condition_id: &str,
@@ -43,88 +87,50 @@ async fn redeem_one(
     let cid_hex = condition_id.trim_start_matches("0x");
     let cid_display = format!("0x{}", cid_hex);
 
-    let eoa_redeemable = {
-        let positions = get_positions(client, eoa_addr).await.unwrap_or_default();
-        let has = positions.iter().any(|p| {
-            (p.condition_id.as_deref() == Some(condition_id)
-                || p.condition_id.as_deref() == Some(&cid_display))
-                && p.redeemable
-        });
-        if !has {
-            let lost: f64 = positions
-                .iter()
-                .filter(|p| {
-                    p.condition_id.as_deref() == Some(condition_id)
-                        || p.condition_id.as_deref() == Some(&cid_display)
-                })
-                .map(|p| p.current_value.unwrap_or(0.0))
-                .sum();
-            if lost < 0.000_001
-                && positions.iter().any(|p| {
-                    p.condition_id.as_deref() == Some(condition_id)
-                        || p.condition_id.as_deref() == Some(&cid_display)
-                })
-            {
-                eprintln!(
-                    "[polymarket] Note: EOA has positions for this market but current_value ≈ $0 \
-                     (market resolved against your EOA positions)."
-                );
-            }
-        }
-        has
-    };
+    let r = check_redeemability(client, condition_id, eoa_addr, proxy_addr).await;
 
-    let proxy_redeemable = if let Some(proxy) = proxy_addr {
-        let positions = get_positions(client, proxy).await.unwrap_or_default();
-        positions.iter().any(|p| {
-            (p.condition_id.as_deref() == Some(condition_id)
-                || p.condition_id.as_deref() == Some(&cid_display))
-                && p.redeemable
-        })
-    } else {
-        false
-    };
+    if !r.eoa && !r.proxy {
+        return Err(anyhow!(
+            "No redeemable positions found for {} on EOA ({}) {}. \
+             Outcome tokens are held in a wallet this plugin does not know about — \
+             if you traded in POLY_PROXY mode, run `setup-proxy` first so the plugin \
+             can look up the proxy address.",
+            cid_display,
+            eoa_addr,
+            proxy_addr
+                .map(|p| format!("or proxy ({})", p))
+                .unwrap_or_else(|| "(no proxy configured)".into())
+        ));
+    }
 
     let mut out = serde_json::json!({
         "condition_id": cid_display,
         "question": question,
     });
 
-    // Fallback: if Data API shows nothing (can lag after resolution), attempt EOA redeem.
-    if !eoa_redeemable && !proxy_redeemable {
+    if r.eoa {
+        eprintln!("[polymarket] EOA holds winning tokens — submitting EOA redeemPositions...");
+        let tx = ctf_redeem_positions(condition_id, eoa_addr).await?;
         eprintln!(
-            "[polymarket] Warning: Data API shows no redeemable positions for {} \
-             (may lag after resolution). Attempting EOA redeem as fallback.",
-            cid_display
+            "[polymarket] EOA redeem tx {} — waiting up to {}s for on-chain confirmation...",
+            tx, REDEEM_WAIT_SECS
         );
-        let tx_hash = ctf_redeem_positions(condition_id).await?;
-        eprintln!("[polymarket] Waiting for EOA redeem tx to confirm...");
-        wait_for_tx_receipt(&tx_hash, 120).await?;
-        out["eoa_tx"] = serde_json::Value::String(tx_hash);
-        out["source"] = serde_json::Value::String("fallback_eoa".into());
-        out["note"] = serde_json::Value::String(
-            "EOA redeemPositions confirmed (fallback).".into(),
-        );
-        return Ok(out);
-    }
-
-    if eoa_redeemable {
-        eprintln!("[polymarket] EOA has winning tokens — submitting EOA redeemPositions...");
-        let tx = ctf_redeem_positions(condition_id).await?;
-        eprintln!("[polymarket] Waiting for EOA redeem tx to confirm...");
-        wait_for_tx_receipt(&tx, 120).await?;
+        wait_for_tx_receipt_labeled(&tx, REDEEM_WAIT_SECS, "EOA redeem").await?;
         out["eoa_tx"] = serde_json::Value::String(tx);
         out["eoa_note"] =
             serde_json::Value::String("EOA redeemPositions confirmed.".into());
     }
 
-    if proxy_redeemable {
+    if r.proxy {
         eprintln!(
-            "[polymarket] Proxy has winning tokens — submitting proxy redeemPositions via PROXY_FACTORY..."
+            "[polymarket] Proxy holds winning tokens — submitting proxy redeemPositions via PROXY_FACTORY..."
         );
-        let tx = ctf_redeem_via_proxy(condition_id).await?;
-        eprintln!("[polymarket] Waiting for proxy redeem tx to confirm...");
-        wait_for_tx_receipt(&tx, 120).await?;
+        let tx = ctf_redeem_via_proxy(condition_id, eoa_addr).await?;
+        eprintln!(
+            "[polymarket] Proxy redeem tx {} — waiting up to {}s for on-chain confirmation...",
+            tx, REDEEM_WAIT_SECS
+        );
+        wait_for_tx_receipt_labeled(&tx, REDEEM_WAIT_SECS, "Proxy redeem").await?;
         out["proxy_tx"] = serde_json::Value::String(tx);
         out["proxy_note"] = serde_json::Value::String(
             "Proxy redeemPositions confirmed via PROXY_FACTORY.".into(),
@@ -137,24 +143,91 @@ async fn redeem_one(
     Ok(out)
 }
 
+/// Look up an on-chain proxy wallet that is not yet recorded in credentials.
+///
+/// Safe to call freely: uses `debug_traceCall` (read-only, no gas, no tx). If the
+/// RPC doesn't support `debug_traceCall` or anything else fails, returns None and
+/// callers should fall through silently — this is purely a UX hint.
+async fn discover_uncached_proxy(eoa: &str, creds_proxy: Option<&str>) -> Option<String> {
+    if creds_proxy.is_some() {
+        return None;
+    }
+    get_existing_proxy(eoa).await.ok().flatten()
+}
+
+/// Build a human-readable hint pointing at a proxy wallet discovered on-chain,
+/// to be appended to an error's `suggestion` field. Empty string if no proxy found.
+fn proxy_hint(discovered: Option<&str>) -> String {
+    match discovered {
+        Some(addr) => format!(
+            "Detected existing proxy wallet on-chain for this EOA: {}. \
+             Run `polymarket-plugin setup-proxy` to save it to credentials — \
+             once saved, redeem will route through the proxy automatically.",
+            addr
+        ),
+        None => String::new(),
+    }
+}
+
+/// Fail-fast POL balance check: EOA pays gas for both EOA and proxy redeem paths.
+async fn check_pol_budget(eoa_addr: &str, tx_count: usize) -> Result<f64> {
+    let pol = get_pol_balance(eoa_addr).await?;
+    let needed = tx_count as f64 * POL_PER_REDEEM;
+    if pol < needed {
+        return Err(anyhow!(
+            "Insufficient POL for gas: EOA {} has {:.4} POL but redeeming {} market(s) \
+             needs ~{:.4} POL (budgeting {} POL per market). \
+             Top up {:.4} more POL.",
+            eoa_addr,
+            pol,
+            tx_count,
+            needed,
+            POL_PER_REDEEM,
+            needed - pol
+        ));
+    }
+    Ok(pol)
+}
+
 /// Redeem a single market by market_id (condition_id or slug).
 pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
     let client = Client::new();
-    let (condition_id, neg_risk, question) = resolve_market(&client, market_id).await?;
+
+    let (condition_id, neg_risk, question) = match resolve_market(&client, market_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some("redeem"), None));
+            return Ok(());
+        }
+    };
 
     if neg_risk {
-        bail!(
+        let e = anyhow!(
             "redeem is not supported for neg_risk (multi-outcome) markets — \
              use the Polymarket web UI to redeem positions in this market"
         );
+        println!("{}", super::error_response(&e, Some("redeem"), None));
+        return Ok(());
     }
 
     let cid_display = format!("0x{}", condition_id.trim_start_matches("0x"));
-    let eoa_addr = get_wallet_address().await?;
+    let eoa_addr = match get_wallet_address().await {
+        Ok(a) => a,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some("redeem"), None));
+            return Ok(());
+        }
+    };
     let creds = load_credentials().unwrap_or_default();
     let proxy_addr = creds.and_then(|c| c.proxy_wallet);
 
+    // Best-effort: if no proxy in creds, check on-chain so error hints can cite the address.
+    let discovered_proxy = discover_uncached_proxy(&eoa_addr, proxy_addr.as_deref()).await;
+    let hint = proxy_hint(discovered_proxy.as_deref());
+    let hint_opt = if hint.is_empty() { None } else { Some(hint.as_str()) };
+
     if dry_run {
+        let r = check_redeemability(&client, &condition_id, &eoa_addr, proxy_addr.as_deref()).await;
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
@@ -167,32 +240,59 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
                     "neg_risk": false,
                     "eoa_wallet": eoa_addr,
                     "proxy_wallet": proxy_addr,
+                    "discovered_proxy": discovered_proxy,
+                    "eoa_redeemable": r.eoa,
+                    "proxy_redeemable": r.proxy,
                     "action": "redeemPositions",
                     "index_sets": [1, 2],
-                    "note": "dry-run: will redeem from whichever wallet (EOA / proxy) holds the winning tokens."
+                    "note": "dry-run: will redeem from whichever wallet holds the winning tokens. \
+                             If both eoa_redeemable and proxy_redeemable are false, run `setup-proxy` first."
                 }
             }))?
         );
         return Ok(());
     }
 
-    let result = redeem_one(&client, &condition_id, &question, &eoa_addr, proxy_addr.as_deref()).await?;
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&serde_json::json!({ "ok": true, "data": result }))?
-    );
+    if let Err(e) = check_pol_budget(&eoa_addr, 1).await {
+        println!("{}", super::error_response(&e, Some("redeem"), hint_opt));
+        return Ok(());
+    }
+
+    match redeem_one(&client, &condition_id, &question, &eoa_addr, proxy_addr.as_deref()).await {
+        Ok(result) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "ok": true,
+                    "data": result
+                }))?
+            );
+        }
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some("redeem"), hint_opt));
+        }
+    }
     Ok(())
 }
 
 /// Redeem ALL redeemable positions across EOA and proxy wallets in one pass.
-///
-/// Discovers redeemable condition_ids from both wallets via the Data API, then
-/// redeems each sequentially, waiting for on-chain confirmation between markets.
 pub async fn run_all(dry_run: bool) -> Result<()> {
     let client = Client::new();
-    let eoa_addr = get_wallet_address().await?;
+    let eoa_addr = match get_wallet_address().await {
+        Ok(a) => a,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some("redeem"), None));
+            return Ok(());
+        }
+    };
     let creds = load_credentials().unwrap_or_default();
     let proxy_addr = creds.and_then(|c| c.proxy_wallet);
+
+    // Best-effort discovery: if creds has no proxy but one exists on-chain,
+    // surface it in error hints so the user knows `setup-proxy` is the fix.
+    let discovered_proxy = discover_uncached_proxy(&eoa_addr, proxy_addr.as_deref()).await;
+    let hint = proxy_hint(discovered_proxy.as_deref());
+    let hint_opt = if hint.is_empty() { None } else { Some(hint.as_str()) };
 
     // Collect all unique redeemable condition_ids from both wallets.
     let mut redeemable: Vec<(String, String)> = Vec::new(); // (condition_id, title)
@@ -224,22 +324,24 @@ pub async fn run_all(dry_run: bool) -> Result<()> {
     }
 
     if redeemable.is_empty() {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "ok": true,
-                "data": {
-                    "message": "No redeemable positions found.",
-                    "redeemed_count": 0
-                }
-            }))?
+        let e = anyhow!(
+            "No redeemable positions found on EOA ({}) {}. \
+             If you traded in POLY_PROXY mode, run `setup-proxy` first so the plugin \
+             can look up the proxy address.",
+            eoa_addr,
+            proxy_addr
+                .as_ref()
+                .map(|p| format!("or proxy ({})", p))
+                .unwrap_or_else(|| "(no proxy configured)".into())
         );
+        println!("{}", super::error_response(&e, Some("redeem"), hint_opt));
         return Ok(());
     }
 
+    let n = redeemable.len();
     eprintln!(
         "[polymarket] Found {} redeemable position(s). Redeeming sequentially...",
-        redeemable.len()
+        n
     );
 
     if dry_run {
@@ -253,7 +355,9 @@ pub async fn run_all(dry_run: bool) -> Result<()> {
                 "ok": true,
                 "data": {
                     "dry_run": true,
-                    "redeemable_count": items.len(),
+                    "redeemable_count": n,
+                    "estimated_pol_needed": n as f64 * POL_PER_REDEEM,
+                    "discovered_proxy": discovered_proxy,
                     "positions": items,
                     "note": "dry-run: would redeem each position sequentially, waiting for on-chain confirmation between each."
                 }
@@ -262,6 +366,21 @@ pub async fn run_all(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
+    // Fail fast if EOA does not have enough POL to cover all redeems.
+    let pol_balance = match check_pol_budget(&eoa_addr, n).await {
+        Ok(b) => b,
+        Err(e) => {
+            println!("{}", super::error_response(&e, Some("redeem"), hint_opt));
+            return Ok(());
+        }
+    };
+    eprintln!(
+        "[polymarket] POL budget OK: {:.4} POL available, ~{:.4} POL needed for {} redeem(s).",
+        pol_balance,
+        n as f64 * POL_PER_REDEEM,
+        n
+    );
+
     let mut results = Vec::new();
     let mut errors = Vec::new();
 
@@ -269,14 +388,24 @@ pub async fn run_all(dry_run: bool) -> Result<()> {
         eprintln!(
             "[polymarket] [{}/{}] Redeeming: {}",
             i + 1,
-            redeemable.len(),
+            n,
             title
         );
         match redeem_one(&client, cid, title, &eoa_addr, proxy_addr.as_deref()).await {
             Ok(r) => results.push(r),
             Err(e) => {
-                eprintln!("[polymarket] Error redeeming {}: {}", cid, e);
-                errors.push(serde_json::json!({ "condition_id": cid, "error": e.to_string() }));
+                eprintln!("[polymarket] Error redeeming {}: {:#}", cid, e);
+                let classified: serde_json::Value = serde_json::from_str(
+                    &super::error_response(&e, Some("redeem"), hint_opt),
+                )
+                .unwrap_or_else(|_| serde_json::json!({ "error": e.to_string() }));
+                errors.push(serde_json::json!({
+                    "condition_id": cid,
+                    "title": title,
+                    "error": classified.get("error"),
+                    "error_code": classified.get("error_code"),
+                    "suggestion": classified.get("suggestion"),
+                }));
             }
         }
     }

--- a/skills/polymarket-plugin/src/onchainos.rs
+++ b/skills/polymarket-plugin/src/onchainos.rs
@@ -658,33 +658,40 @@ pub async fn approve_ctf(neg_risk: bool) -> Result<String> {
 /// YES (bit 0) and NO (bit 1) outcomes — the CTF contract only pays out for winning tokens
 /// and silently no-ops for losing ones, so passing both is safe.
 /// For neg_risk (multi-outcome) markets use the NEG_RISK_ADAPTER path (not implemented here).
-pub async fn ctf_redeem_positions(condition_id: &str) -> Result<String> {
+fn build_redeem_positions_calldata(condition_id: &str) -> String {
     use sha3::{Digest, Keccak256};
     use crate::config::Contracts;
 
-    // Compute the 4-byte function selector: keccak256("redeemPositions(address,bytes32,bytes32,uint256[])")
     let selector = Keccak256::digest(b"redeemPositions(address,bytes32,bytes32,uint256[])");
     let selector_hex = hex::encode(&selector[..4]);
 
-    // ABI-encode the four parameters.
-    // Slots 0-2 are static (address and bytes32); slot 3 is the offset to the dynamic uint256[] array.
-    let collateral  = pad_address(Contracts::USDC_E);         // address padded to 32 bytes
-    let parent_id   = format!("{:064x}", 0u128);               // bytes32(0) — null parent collection
+    let collateral  = pad_address(Contracts::USDC_E);
+    let parent_id   = format!("{:064x}", 0u128);
     let cond_id_hex = condition_id.trim_start_matches("0x");
-    let cond_id_pad = format!("{:0>64}", cond_id_hex);         // conditionId as bytes32
-    let array_offset = pad_u256(4 * 32);                       // 4 static slots → offset = 128
-
-    // Dynamic array: length=2, [1, 2] (YES indexSet=1, NO indexSet=2)
+    let cond_id_pad = format!("{:0>64}", cond_id_hex);
+    let array_offset = pad_u256(4 * 32);
     let array_len  = pad_u256(2);
-    let index_yes  = pad_u256(1);  // outcome 0, indexSet bit 0
-    let index_no   = pad_u256(2);  // outcome 1, indexSet bit 1
+    let index_yes  = pad_u256(1);
+    let index_no   = pad_u256(2);
 
-    let calldata = format!(
+    format!(
         "0x{}{}{}{}{}{}{}{}",
         selector_hex, collateral, parent_id, cond_id_pad,
         array_offset, array_len, index_yes, index_no
-    );
+    )
+}
 
+/// Simulate + broadcast `CTF.redeemPositions(...)` directly from the EOA.
+///
+/// Pre-flights via `eth_call` so reverts (e.g. EOA does not hold the outcome
+/// tokens) are surfaced before `wallet_contract_call --force` masks them by
+/// returning a tx hash that was signed but never broadcast.
+pub async fn ctf_redeem_positions(condition_id: &str, from: &str) -> Result<String> {
+    use crate::config::Contracts;
+    let calldata = build_redeem_positions_calldata(condition_id);
+    eth_call_simulate(from, Contracts::CTF, &calldata)
+        .await
+        .context("EOA redeemPositions would revert on-chain")?;
     let result = wallet_contract_call(Contracts::CTF, &calldata).await?;
     extract_tx_hash(&result)
 }
@@ -695,11 +702,10 @@ pub async fn ctf_redeem_positions(condition_id: &str) -> Result<String> {
 /// Routes: EOA → PROXY_FACTORY.proxy([(CALL, CTF, 0, redeemPositions_calldata)])
 /// The factory forwards the call from the proxy wallet's context, so CTF sees
 /// msg.sender = proxy wallet, which holds the winning tokens.
-pub async fn ctf_redeem_via_proxy(condition_id: &str) -> Result<String> {
+fn build_redeem_via_proxy_calldata(condition_id: &str) -> String {
     use sha3::{Digest, Keccak256};
     use crate::config::Contracts;
 
-    // Build inner redeemPositions calldata (identical to ctf_redeem_positions)
     let inner_selector = Keccak256::digest(b"redeemPositions(address,bytes32,bytes32,uint256[])");
     let inner_selector_hex = hex::encode(&inner_selector[..4]);
     let collateral   = pad_address(Contracts::USDC_E);
@@ -716,20 +722,17 @@ pub async fn ctf_redeem_via_proxy(condition_id: &str) -> Result<String> {
         inner_selector_hex, collateral, parent_id, cond_id_pad,
         array_offset, array_len, index_yes, index_no
     );
-    // inner calldata = 4 + 7*32 = 228 bytes
     let inner_bytes = hex::decode(&inner_hex).expect("inner redeem calldata");
     let inner_len   = inner_bytes.len();
     let pad_len     = (32 - inner_len % 32) % 32;
     let inner_padded = format!("{}{}", inner_hex, "00".repeat(pad_len));
 
-    // Wrap in PROXY_FACTORY.proxy([(CALL, CTF, 0, inner_calldata)])
-    // Layout mirrors withdraw_usdc_from_proxy exactly, only `to` changes to CTF.
     let outer_selector = Keccak256::digest(b"proxy((uint8,address,uint256,bytes)[])");
     let outer_selector_hex = hex::encode(&outer_selector[..4]);
     let ctf_padded     = pad_address(Contracts::CTF);
     let data_len_padded = format!("{:064x}", inner_len);
 
-    let calldata = format!(
+    format!(
         "0x{}\
          {}\
          {}\
@@ -741,17 +744,28 @@ pub async fn ctf_redeem_via_proxy(condition_id: &str) -> Result<String> {
          {}\
          {}",
         outer_selector_hex,
-        "0000000000000000000000000000000000000000000000000000000000000020", // params array offset
-        "0000000000000000000000000000000000000000000000000000000000000001", // array length = 1
-        "0000000000000000000000000000000000000000000000000000000000000020", // tuple[0] offset
-        "0000000000000000000000000000000000000000000000000000000000000001", // op = 1 (CALL)
-        ctf_padded,                                                         // to = CTF
-        "0000000000000000000000000000000000000000000000000000000000000000", // value = 0
-        "0000000000000000000000000000000000000000000000000000000000000080", // data offset in tuple
+        "0000000000000000000000000000000000000000000000000000000000000020",
+        "0000000000000000000000000000000000000000000000000000000000000001",
+        "0000000000000000000000000000000000000000000000000000000000000020",
+        "0000000000000000000000000000000000000000000000000000000000000001",
+        ctf_padded,
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000080",
         data_len_padded,
         inner_padded,
-    );
+    )
+}
 
+/// Simulate + broadcast `CTF.redeemPositions(...)` routed through the proxy wallet.
+///
+/// Pre-flights via `eth_call` so reverts are surfaced before onchainos's `--force`
+/// flag masks them.
+pub async fn ctf_redeem_via_proxy(condition_id: &str, from: &str) -> Result<String> {
+    use crate::config::Contracts;
+    let calldata = build_redeem_via_proxy_calldata(condition_id);
+    eth_call_simulate(from, Contracts::PROXY_FACTORY, &calldata)
+        .await
+        .context("Proxy redeemPositions would revert on-chain")?;
     let result = wallet_contract_call(Contracts::PROXY_FACTORY, &calldata).await?;
     extract_tx_hash(&result)
 }
@@ -810,11 +824,56 @@ pub async fn get_usdc_balance(addr: &str) -> Result<f64> {
     Ok(raw as f64 / 1_000_000.0) // USDC.e has 6 decimals
 }
 
+/// Simulate a contract call via eth_call on Polygon. Returns Ok(()) if no revert.
+///
+/// Use this as a pre-flight before `wallet_contract_call` to catch reverts that
+/// onchainos's `--force` flag would otherwise mask (returning a txHash that was
+/// signed but never broadcast).
+pub async fn eth_call_simulate(from: &str, to: &str, input_data: &str) -> Result<()> {
+    use crate::config::Urls;
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "params": [{
+            "from": from,
+            "to": to,
+            "data": input_data,
+        }, "latest"],
+        "id": 1
+    });
+    let v: serde_json::Value = reqwest::Client::new()
+        .post(Urls::POLYGON_RPC)
+        .json(&body)
+        .send()
+        .await
+        .context("Polygon RPC eth_call failed")?
+        .json()
+        .await
+        .context("parsing eth_call response")?;
+    if let Some(err) = v.get("error") {
+        let msg = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown");
+        anyhow::bail!("eth_call simulation reverted: {}", msg);
+    }
+    Ok(())
+}
+
 /// Poll eth_getTransactionReceipt until the tx is mined (or timeout).
 ///
 /// Polygon block time is ~2 seconds. We poll every 2 seconds for up to max_wait_secs.
-/// Call this after submitting an approval tx before posting any order.
 pub async fn wait_for_tx_receipt(tx_hash: &str, max_wait_secs: u64) -> Result<()> {
+    wait_for_tx_receipt_labeled(tx_hash, max_wait_secs, "Transaction").await
+}
+
+/// Same as `wait_for_tx_receipt` but with a caller-supplied label used in error
+/// messages (e.g. "Approve", "Redeem") so the bail text is accurate.
+pub async fn wait_for_tx_receipt_labeled(
+    tx_hash: &str,
+    max_wait_secs: u64,
+    label: &str,
+) -> Result<()> {
     use crate::config::Urls;
     use std::time::{Duration, Instant};
     use tokio::time::sleep;
@@ -834,14 +893,13 @@ pub async fn wait_for_tx_receipt(tx_hash: &str, max_wait_secs: u64) -> Result<()
             .await;
         if let Ok(r) = resp {
             if let Ok(v) = r.json::<serde_json::Value>().await {
-                // receipt is an object (not null) once the tx is mined
                 if v["result"].is_object() {
-                    // status "0x1" = success, "0x0" = reverted
                     let status = v["result"]["status"].as_str().unwrap_or("0x1");
                     if status == "0x0" {
                         anyhow::bail!(
-                            "Transaction {} was mined but reverted (status 0x0). \
+                            "{} tx {} was mined but reverted (status 0x0). \
                              Check Polygonscan for details.",
+                            label,
                             tx_hash
                         );
                     }
@@ -851,9 +909,13 @@ pub async fn wait_for_tx_receipt(tx_hash: &str, max_wait_secs: u64) -> Result<()
         }
         if Instant::now() >= deadline {
             anyhow::bail!(
-                "Approval tx {} not confirmed within {}s. \
-                 Check Polygonscan and retry.",
-                tx_hash, max_wait_secs
+                "{} tx {} not observed on-chain within {}s. \
+                 If the hash does not appear on Polygonscan, onchainos signed the tx \
+                 but never broadcast it — usually because it would revert. \
+                 Check your trading mode / outcome token ownership and retry.",
+                label,
+                tx_hash,
+                max_wait_secs
             );
         }
         sleep(Duration::from_millis(2000)).await;


### PR DESCRIPTION
## Summary

User reported batch `redeem --all` hanging for 120s per market with no output — Python subprocess (`timeout=120`) was always killed before any redeem could finish. Root cause: `onchainos --force` returned a fake tx hash for a call that would revert on-chain (EOA didn't hold the winning outcome tokens — they lived in the user's plugin-unknown proxy wallet), and `wait_for_tx_receipt` polled for a tx that was never broadcast.

## Changes

### P0 — unblock batch redeem
- **`eth_call` pre-flight** in `ctf_redeem_positions` / `ctf_redeem_via_proxy` catches reverts before `--force` masks them
- **Remove fallback EOA redeem** (`redeem.rs:94-109`) that blindly submitted when Data API showed no redeemable positions on either wallet — now bails `NO_REDEEMABLE_POSITIONS` with a concrete suggestion
- **Structured errors (GEN-001)** — all redeem failures emit `{ok:false, error_code, suggestion}` JSON to stdout instead of exit 1 + stderr. Python scripts can now parse `error_code` to decide next step
- **`wait_for_tx_receipt` labeled variant** — old message said \"Approval tx\" for every wait; now accepts `label` (e.g. `\"EOA redeem\"`) and, on timeout, explains \"tx hash returned but never observed on-chain — onchainos likely signed a tx that would revert\"
- **Per-tx wait shortened from 120s to 45s** — Polygon block time 2s, healthy tx mines <30s; fits comfortably under the typical 120s Python subprocess limit for batch mode

### P1 — POL budget pre-flight
- `check_pol_budget(eoa, n_markets)` runs before any tx with `N × 0.015 POL` estimate. Bails `INSUFFICIENT_POL_GAS` with shortfall amount. Reporter's EOA had 0.018 POL vs. 1.185 POL needed for 79 markets → would have failed fast in <1s instead of hanging for 120s × 79

### Bonus — on-chain proxy discovery (zero-risk)
When creds has no `proxy_wallet` but one exists on-chain for this EOA, a `debug_traceCall` (read-only, zero gas, factory is idempotent — `type=CALL` on existing proxy, never `CREATE`) appends the address to the error suggestion:

> Detected existing proxy wallet on-chain for this EOA: 0xc1e2d45f527ff6de8014b9e7f36bb44a6045d0ea. Run \`polymarket-plugin setup-proxy\` to save it to credentials — once saved, redeem will route through the proxy automatically.

Called once per command (not per market), silent fallback if the RPC doesn't support `debug_traceCall`.

### Scope note

Changes are contained to `redeem` / `onchainos` redeem helpers. `buy` / `sell` / `deposit` are untouched. `plugin.yaml` `api_calls` is unchanged (no new external domains introduced).

## Error codes (all to stdout, `ok:false`)

| `error_code` | When |
|---|---|
| `NO_REDEEMABLE_POSITIONS` | Data API shows nothing redeemable on either wallet |
| `INSUFFICIENT_POL_GAS` | EOA POL < N × 0.015 |
| `SIMULATION_REVERTED` | `eth_call` pre-flight reverts (usually wrong wallet holds tokens) |
| `TX_NOT_CONFIRMED` | Receipt never arrives within 45s |
| `TX_REVERTED` | Tx mined with status 0x0 |
| `NEG_RISK_NOT_SUPPORTED` | Multi-outcome market |

## Test plan

- [x] `cargo build` — clean
- [x] `polymarket-plugin --version` → `polymarket 0.4.8`
- [x] `polymarket-plugin redeem --help` — flags unchanged (`--market-id`, `--all`, `--dry-run`)
- [x] Trace-verified on reporter's EOA (`0xb7c5b8f34352b5a7876bf1ebe9aff5510fdd2e9a`): on-chain proxy discovery returns `0xc1e2d45...` with EIP-1167 bytecode pointing at Polymarket Safe master
- [ ] Reviewer: sanity-check `ctf_redeem_positions` simulate path on a resolved market
- [ ] Reviewer: confirm 45s per-tx wait is sufficient for Polygon mainnet in peak conditions

## Not in this PR (follow-ups)
- `buy`/`sell`/`deposit` don't emit GEN-001 structured errors yet (left for a focused follow-up, avoiding scope creep on a redeem bugfix)
- `plugin.yaml` `api_calls` missing entries for cross-chain deposit RPC domains (`arbitrum.drpc.org`, `base.drpc.org`, `bsc.publicnode.com`, `ethereum.publicnode.com`, `optimism.drpc.org`) — pre-existing, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)