### PR TITLE
chore(morpho-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/morpho-plugin/SUMMARY.md
+++ b/skills/morpho-plugin/SUMMARY.md
@@ -1,13 +1,18 @@
-# morpho
-Supply, borrow and earn yield on Morpho — a permissionless lending protocol with $5B+ TVL.
+**Overview**
 
-## Highlights
-- Supply assets to MetaMorpho vaults and earn yield with curated risk management
-- Borrow from Morpho Blue isolated markets with competitive rates
-- Withdraw from vaults (partial or full) with dust-free operations
-- Supply collateral to Morpho Blue markets for borrowing positions
-- View positions with health factors across Blue markets and MetaMorpho vaults
-- Browse markets and vaults with real-time APYs and utilization rates
-- Claim rewards via Merkl distributor integration
-- Supports Ethereum Mainnet and Base networks
+Morpho is a permissionless lending protocol on Ethereum and Base. This skill lets you earn yield via MetaMorpho vaults, borrow against collateral on Morpho Blue isolated markets, repay, withdraw, monitor positions with health factors, and claim Merkl rewards.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- ETH for gas on Ethereum mainnet (chain 1) or Base (chain 8453)
+- USDC / WETH (or other supported asset) on the target chain to supply or use as collateral
+
+**Quick Start**
+1. Check your state and get a guided next step: `morpho-plugin quickstart`
+2. If you see `status: no_funds` / `needs_gas` / `needs_funds` — fund the wallet address shown in the output (ETH for gas, plus USDC or WETH to supply)
+3. Browse available vaults and markets: `morpho-plugin vaults --asset USDC` or `morpho-plugin markets --asset USDC`
+4. If `status: ready` — earn yield by supplying to a MetaMorpho vault: `morpho-plugin supply --vault <VAULT_ADDR> --asset USDC --amount 100 --confirm`
+5. To leverage, supply collateral first then borrow: `morpho-plugin supply-collateral --market-id <HEX> --amount 1 --confirm` → `morpho-plugin borrow --market-id <HEX> --amount 1000 --confirm`
+6. If `status: active` — review open positions and health factors: `morpho-plugin positions`
+7. Exit: `morpho-plugin withdraw --vault <VAULT_ADDR> --asset USDC --all --confirm` or `morpho-plugin repay --market-id <HEX> --all --confirm`
+8. Claim Merkl rewards when available: `morpho-plugin claim-rewards --confirm`


### PR DESCRIPTION
## Summary

Rewrite `skills/morpho-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used by `pancakeswap-clmm-plugin` and `hyperliquid-plugin`:

- **Overview** — one concise sentence on what Morpho is and what the skill can do
- **Prerequisites** — onchainos CLI, ETH for gas, USDC/WETH on target chain
- **Quick Start** — 8-step guided flow driven by the `quickstart` command's five `status` values (`no_funds` / `needs_gas` / `needs_funds` / `ready` / `active`), covering supply-to-vault, supply-collateral-then-borrow, position monitoring, repay/withdraw, and Merkl rewards

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/morpho-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/morpho-plugin/` shows only `SUMMARY.md` changed