### PR TITLE
chore(compound-v3-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/compound-v3-plugin/SUMMARY.md
+++ b/skills/compound-v3-plugin/SUMMARY.md
@@ -1,13 +1,18 @@
-# compound-v3
-Compound V3 (Comet) lending plugin for supplying collateral, borrowing/repaying assets, and claiming COMP rewards across multiple chains.
+**Overview**
 
-## Highlights
-- Multi-chain support (Ethereum, Base, Arbitrum, Polygon) with USDC markets
-- Supply collateral assets and borrow base assets with automated debt handling
-- Repay borrowed assets with overflow protection and automatic balance calculations
-- Withdraw supplied collateral with debt validation safeguards
-- Claim COMP rewards from the CometRewards contract
-- Real-time market data including utilization rates, APRs, and total supply/borrow
-- Position tracking with supply/borrow balances and collateralization status
-- Dry-run mode for previewing all transactions before execution
+Compound V3 (Comet) is a single-asset lending protocol on Ethereum, Base, Arbitrum, and Polygon. This skill lets you supply the base asset to earn yield, supply collateral to borrow, repay and withdraw, check positions, and claim COMP rewards.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- ETH for gas on the target chain (Ethereum / Base / Arbitrum / Polygon)
+- USDC or WETH to supply as base asset, or a supported collateral asset (WETH, cbETH, ...) to borrow against
+
+**Quick Start**
+1. Check your balance on the target chain: `onchainos wallet balance --chain 8453` (Base; use 1 / 42161 / 137 for Ethereum / Arbitrum / Polygon)
+2. Browse market rates, utilization, and collateral assets: `compound-v3 --chain 8453 get-markets`
+3. To earn yield, preview a supply of the base asset (no tx sent): `compound-v3 --chain 8453 --market usdc supply --asset <BASE_ASSET_ADDR> --amount 10`
+4. Re-run with `--confirm` to execute: `compound-v3 --chain 8453 --market usdc --confirm supply --asset <BASE_ASSET_ADDR> --amount 10`
+5. Check your position any time: `compound-v3 --chain 8453 --market usdc get-position`
+6. To borrow, first supply a collateral asset, then borrow the base asset: `compound-v3 --chain 8453 --market usdc --confirm supply --asset <COLLATERAL_ADDR> --amount 0.005` → `compound-v3 --chain 8453 --market usdc --confirm borrow --amount 5`
+7. Exit the borrow: `compound-v3 --chain 8453 --market usdc --confirm repay` then `compound-v3 --chain 8453 --market usdc --confirm withdraw --asset <COLLATERAL_ADDR> --amount 0.005`
+8. Claim COMP rewards: `compound-v3 --chain 8453 --market usdc --confirm claim-rewards`


### PR DESCRIPTION
## Summary

Rewrite `skills/compound-v3-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used by `pancakeswap-clmm-plugin`, `hyperliquid-plugin`, and `morpho-plugin`:

- **Overview** — one concise sentence on what Compound V3 is and what the skill can do
- **Prerequisites** — onchainos CLI, gas ETH on target chain, base or collateral asset
- **Quick Start** — 8-step guided flow covering balance check → browse markets → supply for yield → position check → supply collateral + borrow → repay + withdraw → claim COMP rewards

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/compound-v3-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/compound-v3-plugin/` shows only `SUMMARY.md` changed