### PR TITLE
chore(pancakeswap-v3-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/pancakeswap-v3-plugin/SUMMARY.md
+++ b/skills/pancakeswap-v3-plugin/SUMMARY.md
@@ -1,13 +1,18 @@
-# pancakeswap
-Swap tokens and manage concentrated liquidity on PancakeSwap V3 on BNB Chain and Base.
+**Overview**
 
-## Highlights
-- Token swaps via SmartRouter across all fee tiers
-- Concentrated liquidity position management (add/remove)
-- Real-time swap quotes without gas costs
-- Support for BNB Chain (BSC) and Base networks
-- Pool discovery and liquidity analytics
-- Position tracking and portfolio viewing
-- Multi-step transaction safety with user confirmations
-- Integration with onchainos wallet infrastructure
+PancakeSwap V3 is a concentrated liquidity DEX. This skill lets you get swap quotes, swap tokens via SmartRouter, browse pools across fee tiers, and manage concentrated liquidity positions (add, view, remove) on BNB Chain, Base, and Arbitrum.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- Gas token on the target chain: BNB on BSC (chain 56, default), ETH on Base (8453) or Arbitrum (42161)
+- Tokens to swap or provide as liquidity (e.g. WBNB / USDT / USDC / WETH)
+
+**Quick Start**
+1. Check your BNB Chain state and get a guided next step: `pancakeswap-v3 quickstart`
+2. If you see `status: no_funds` / `needs_gas` / `needs_funds` — fund the wallet address shown in the output (BNB for gas + USDT/USDC to trade)
+3. Get a swap quote (read-only, no gas): `pancakeswap-v3 quote --from WBNB --to USDT --amount 0.1 --chain 56`
+4. Execute a swap (preview first without `--confirm`, then re-run with it): `pancakeswap-v3 swap --from WBNB --to USDT --amount 0.1 --chain 56 --confirm`
+5. Browse pools for a pair across all fee tiers: `pancakeswap-v3 pools --token0 WBNB --token1 USDT --chain 56`
+6. Provide concentrated liquidity (auto ±10% range if ticks omitted): `pancakeswap-v3 add-liquidity --token-a WBNB --token-b USDT --fee 500 --amount-a 0.1 --amount-b 60 --chain 56`
+7. If `status: active` — review your LP positions: `pancakeswap-v3 positions --owner <YOUR_ADDR> --chain 56`
+8. Remove liquidity and collect accrued fees: `pancakeswap-v3 remove-liquidity --token-id <TOKEN_ID> --chain 56`


### PR DESCRIPTION
## Summary

Rewrite `skills/pancakeswap-v3-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used by `pancakeswap-clmm-plugin`, `hyperliquid-plugin`, `morpho-plugin`, and `compound-v3-plugin`:

- **Overview** — one concise sentence on what PancakeSwap V3 is and what the skill can do
- **Prerequisites** — onchainos CLI, gas token for target chain, tokens to swap or LP
- **Quick Start** — 8-step guided flow driven by the `quickstart` command's five `status` values (`no_funds` / `needs_gas` / `needs_funds` / `ready` / `active`), covering quote → swap → pools → add-liquidity → positions → remove-liquidity

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/pancakeswap-v3-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/pancakeswap-v3-plugin/` shows only `SUMMARY.md` changed