### PR TITLE
chore(pendle-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/pendle-plugin/SUMMARY.md
+++ b/skills/pendle-plugin/SUMMARY.md
@@ -1,1 +1,18 @@
-Pendle Finance yield tokenization plugin for onchainos. Enables buying and selling PT (Principal Tokens) for fixed yield, trading YT (Yield Tokens) for floating yield, providing/removing AMM liquidity, and minting/redeeming PT+YT pairs. Supports Ethereum, Arbitrum, BSC, and Base via the Pendle Hosted SDK.
+**Overview**
+
+Pendle is a yield tokenization protocol that splits yield-bearing assets into Principal Tokens (PT, fixed yield) and Yield Tokens (YT, floating yield). This skill lets you browse markets, buy/sell PT for fixed yield, buy/sell YT for floating yield, mint/redeem PT+YT pairs, and add/remove liquidity on Ethereum, Arbitrum, BSC, and Base.
+
+**Prerequisites**
+- onchainos CLI installed and logged in
+- ETH (or BNB on BSC) for gas on the target chain
+- A stablecoin (e.g. USDC) or yield-bearing asset (e.g. weETH, wstETH) on the target chain to trade
+
+**Quick Start**
+1. Check your balance on the target chain: `onchainos wallet balance --chain 42161` (Arbitrum default; use 1 / 56 / 8453 for Ethereum / BSC / Base)
+2. Browse active markets — note `pt` address and `address` (= LP address); look for high `impliedApy` and `liquidity.usd > $1M`: `pendle-plugin --chain 42161 list-markets --active-only --limit 10`
+3. Search markets by asset (e.g. ETH-derivatives, stablecoins): `pendle-plugin --chain 42161 list-markets --search weETH --active-only`
+4. Buy PT for fixed yield — preview first (no `--confirm`): `pendle-plugin --chain 42161 buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
+5. Re-run with `--confirm` to execute: `pendle-plugin --chain 42161 --confirm buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
+6. Check your positions (allow 15–30s for the Pendle indexer): `pendle-plugin --chain 42161 get-positions`
+7. For leveraged floating yield, buy YT instead of PT: `pendle-plugin --chain 42161 --confirm buy-yt --token-in <USDC_ADDR> --amount-in 5000000 --yt-address <YT_ADDR>`
+8. Exit before expiry: `pendle-plugin --chain 42161 --confirm sell-pt --pt-address <PT_ADDR> --amount-in <PT_WEI> --token-out <USDC_ADDR>`


### PR DESCRIPTION
## Summary

Rewrite `skills/pendle-plugin/SUMMARY.md` from a single-paragraph blurb to the new three-section standard used across recently aligned plugins (`pancakeswap-clmm-plugin`, `hyperliquid-plugin`, `morpho-plugin`, `compound-v3-plugin`, `pancakeswap-v3-plugin`):

- **Overview** — one concise sentence on what Pendle is (PT/YT split) and what the skill can do
- **Prerequisites** — onchainos CLI, gas token on target chain, stablecoin / yield-bearing asset to trade
- **Quick Start** — 8-step guided flow: balance check → browse markets → buy PT for fixed yield → check positions → optional YT for floating yield → exit before expiry

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/pendle-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/pendle-plugin/` shows only `SUMMARY.md` changed