### PR TITLE
chore(gmx-v2-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/gmx-v2-plugin/SUMMARY.md
+++ b/skills/gmx-v2-plugin/SUMMARY.md
@@ -1,13 +1,18 @@
-# gmx-v2
-Trade perpetuals and spot on GMX V2 with leverage, limit orders, and liquidity provision on Arbitrum and Avalanche.
+**Overview**
 
-## Highlights
-- Open/close leveraged positions (long/short) on GMX V2 perpetuals
-- Place conditional orders (limit, stop-loss, take-profit)
-- Add/remove liquidity to GM pools and earn fees
-- Query real-time market data, positions, and pending orders
-- Support for Arbitrum and Avalanche chains
-- Keeper-based execution model with 1-30 second settlement
-- Built-in slippage protection and risk management
-- Claim funding fees from active positions
+GMX V2 is a decentralized perpetuals and spot exchange with leveraged positions and GM pool liquidity on Arbitrum and Avalanche. This skill lets you open/close long/short positions, place limit / stop-loss / take-profit orders, add/remove GM pool liquidity, check positions/orders/prices, and claim funding fees.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- ETH for execution fees on Arbitrum (chain 42161, default) or AVAX on Avalanche (43114)
+- USDC (≥ $10 recommended) on the target chain as collateral
+
+**Quick Start**
+1. Check your state and get a guided next step: `gmx-v2 quickstart` (Arbitrum default; use `gmx-v2 --chain avalanche quickstart` for Avalanche)
+2. If you see `status: no_funds` / `needs_fee` / `needs_collateral` — fund the wallet address shown in the output (ETH/AVAX for fees + USDC as collateral)
+3. Browse active markets with liquidity and rates: `gmx-v2 --chain arbitrum list-markets`
+4. Get current oracle prices: `gmx-v2 --chain arbitrum get-prices --token ETH`
+5. If `status: ready` — open a leveraged long (preview first without `--confirm`, then re-run with it): `gmx-v2 --chain arbitrum open-position --market ETH/USD --collateral-token <USDC_ADDR> --collateral-amount 10000000 --size-usd 50 --long --confirm`
+6. If `status: active` — review open positions and pending orders: `gmx-v2 --chain arbitrum get-positions` / `gmx-v2 --chain arbitrum get-orders`
+7. Attach a stop-loss or take-profit (use `stop-loss` or `limit-decrease` as `--order-type`): `gmx-v2 --chain arbitrum place-order --order-type stop-loss --market-token <MKT_ADDR> --collateral-token <USDC_ADDR> --size-usd 50 --collateral-amount 10000000 --trigger-price-usd 3000 --acceptable-price-usd 2990 --long --confirm`
+8. Close a position: `gmx-v2 --chain arbitrum close-position --market-token <MKT_ADDR> --collateral-token <USDC_ADDR> --size-usd 50 --collateral-amount 10000000 --long --confirm`


### PR DESCRIPTION
## Summary

Rewrite `skills/gmx-v2-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used across recently aligned plugins (`pancakeswap-clmm-plugin`, `hyperliquid-plugin`, `morpho-plugin`, `compound-v3-plugin`, `pancakeswap-v3-plugin`, `pendle-plugin`):

- **Overview** — one concise sentence on what GMX V2 is and what the skill can do
- **Prerequisites** — onchainos CLI, ETH/AVAX for execution fees, USDC as collateral
- **Quick Start** — 8-step guided flow driven by the `quickstart` command's five `status` values (`no_funds` / `needs_fee` / `needs_collateral` / `ready` / `active`), covering list-markets → get-prices → open-position → get-positions → place-order (SL/TP) → close-position

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/gmx-v2-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/gmx-v2-plugin/` shows only `SUMMARY.md` changed