### PR TITLE
chore(kamino-lend-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/kamino-lend-plugin/SUMMARY.md
+++ b/skills/kamino-lend-plugin/SUMMARY.md
@@ -1,13 +1,18 @@
-# kamino-lend
-Supply, borrow, and manage positions on Kamino Lend — the leading Solana lending protocol.
+**Overview**
 
-## Highlights
-- View all Kamino lending markets with current supply/borrow APYs and TVL
-- Check your current lending positions and health factor
-- Supply assets to earn yield on Solana's leading lending protocol
-- Withdraw supplied assets with real-time availability checks
-- Preview borrowing operations with dry-run functionality
-- Repay outstanding loans with transaction preview
-- Automatic transaction handling via onchainos integration
-- Support for major Solana tokens (USDC, SOL) with UI-friendly amounts
+Kamino Lend is a leading lending protocol on Solana. This skill lets you browse lending markets and reserves with supply/borrow APYs, supply assets to earn yield, borrow against collateral, repay loans, withdraw, and monitor positions with health factors.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- SOL for gas on Solana mainnet
+- USDC (or another supported SPL token) to supply or use as collateral
+
+**Quick Start**
+1. Check your state and get a guided next step: `kamino-lend quickstart`
+2. If you see `status: no_funds` / `needs_gas` / `needs_funds` — fund the wallet address shown in the output (SOL for gas + USDC or another supported token to supply)
+3. Browse available reserves with APYs: `kamino-lend reserves --min-apy 2`
+4. View lending markets for deeper detail: `kamino-lend markets`
+5. If `status: ready` — supply to earn yield (preview without `--confirm`, then re-run with it): `kamino-lend supply --asset USDC --amount 100 --confirm`
+6. If `status: active` — review positions and health factor: `kamino-lend positions`
+7. Borrow against your supplied collateral: `kamino-lend borrow --asset USDC --amount 50 --confirm`
+8. Exit: `kamino-lend repay --asset USDC --amount all --confirm` or `kamino-lend withdraw --asset USDC --amount 100 --confirm`


### PR DESCRIPTION
## Summary

Rewrite `skills/kamino-lend-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used across recently aligned plugins (`pancakeswap-clmm-plugin`, `hyperliquid-plugin`, `morpho-plugin`, `compound-v3-plugin`, `pancakeswap-v3-plugin`, `pendle-plugin`, `gmx-v2-plugin`):

- **Overview** — one concise sentence on what Kamino Lend is and what the skill can do
- **Prerequisites** — onchainos CLI, SOL for gas, USDC/SPL token to supply
- **Quick Start** — 8-step guided flow driven by the `quickstart` command's five `status` values (`no_funds` / `needs_gas` / `needs_funds` / `ready` / `active`), covering reserves → markets → supply → positions → borrow → repay/withdraw

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/kamino-lend-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/kamino-lend-plugin/` shows only `SUMMARY.md` changed