### PR TITLE
chore(kamino-liquidity-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/kamino-liquidity-plugin/SUMMARY.md
+++ b/skills/kamino-liquidity-plugin/SUMMARY.md
@@ -1,13 +1,17 @@
-# kamino-liquidity
-Auto-compounding KVault earn vaults on Solana for depositing tokens to earn yield with automated liquidity allocation.
+**Overview**
 
-## Highlights
-- Single-token deposits (SOL, USDC) with share-based yield tracking
-- Auto-compounding vault strategies with optimized liquidity allocation
-- Zero performance and management fees on select vaults
-- Real-time position monitoring across all KVaults
-- Secure transaction preview with dry-run capability
-- Direct integration with Kamino Finance API
-- Solana mainnet support with solscan.io transaction tracking
-- Built-in fund limits and safety checks for testing
+Kamino Liquidity (KVaults) are automated yield-optimization vaults on Solana that accept single-token deposits (SOL / USDC / etc.) and earn yield via auto-compounding liquidity allocation. This skill lets you browse KVaults, deposit tokens, monitor positions, and withdraw shares.
 
+**Prerequisites**
+- onchainos CLI installed and logged in
+- SOL for gas on Solana mainnet
+- USDC, SOL, or another supported SPL token to deposit
+
+**Quick Start**
+1. Check your state and get a guided next step: `kamino-liquidity quickstart`
+2. If you see `status: no_funds` / `needs_gas` / `needs_funds` — fund the wallet address shown in the output (SOL for gas + USDC or another supported token to deposit)
+3. Browse available KVaults filtered by token: `kamino-liquidity vaults --token USDC`
+4. Preview a deposit (no tx sent): `kamino-liquidity deposit --vault <VAULT_ADDR> --amount 10 --dry-run`
+5. If `status: ready` — execute the deposit: `kamino-liquidity deposit --vault <VAULT_ADDR> --amount 10 --confirm`
+6. If `status: active` — review your KVault positions with current share value: `kamino-liquidity positions`
+7. Withdraw shares when ready: `kamino-liquidity withdraw --vault <VAULT_ADDR> --amount <SHARES> --confirm`


### PR DESCRIPTION
## Summary

Rewrite `skills/kamino-liquidity-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used across recently aligned plugins:

- **Overview** — one concise sentence on what Kamino KVaults are and what the skill can do
- **Prerequisites** — onchainos CLI, SOL for gas, SPL token to deposit
- **Quick Start** — 7-step guided flow driven by the `quickstart` command's five `status` values (`no_funds` / `needs_gas` / `needs_funds` / `ready` / `active`), covering vaults → deposit (dry-run + confirm) → positions → withdraw

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/kamino-liquidity-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/kamino-liquidity-plugin/` shows only `SUMMARY.md` changed