### PR TITLE
docs(aave-v3): update SUMMARY.md to detail card format

### DIFF
--- a/skills/aave-v3-plugin/SUMMARY.md
+++ b/skills/aave-v3-plugin/SUMMARY.md
@@ -1,6 +1,6 @@
 **Overview**
 
-Supply assets and borrow against collateral on Aave V3 ($43B+ TVL) across Ethereum, Base, Polygon, and Arbitrum — with real-time Health Factor tracking to prevent liquidation.
+Supply assets and borrow against collateral on Aave V3 across Ethereum, Base, Polygon, and Arbitrum — with real-time Health Factor tracking to prevent liquidation.
 
 **Prerequisites**
 - onchainos agentic wallet connected

--- a/skills/aave-v3-plugin/SUMMARY.md
+++ b/skills/aave-v3-plugin/SUMMARY.md
@@ -1,13 +1,20 @@
-# aave-v3-plugin
-Lend and borrow crypto assets on Aave V3, the leading decentralized liquidity protocol with over $43B TVL.
+**Overview**
 
-## Highlights
-- Supply assets to earn yield across Ethereum, Polygon, Arbitrum, and Base
-- Borrow against collateral with variable interest rates
-- Real-time health factor monitoring to prevent liquidations
-- Enable efficiency mode (E-Mode) for correlated assets like stablecoins
-- Claim protocol rewards automatically
-- Support for collateral management and position tracking
-- Built-in safety checks with dry-run simulation before transactions
-- Direct integration with onchainos wallet for secure transaction execution
+Supply assets and borrow against collateral on Aave V3 ($43B+ TVL) across Ethereum, Base, Polygon, and Arbitrum — with real-time Health Factor tracking to prevent liquidation.
 
+**Prerequisites**
+- onchainos agentic wallet connected
+- EVM wallet with funds on Ethereum (1), Base (8453, default), Polygon (137), or Arbitrum (42161)
+- For borrowing: sufficient collateral supplied first; Health Factor must stay above 1.0
+
+**How it Works**
+
+Supplying and earning yield:
+1. **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin get-reserves`
+2. **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount 100 --confirm`
+3. **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
+
+Borrowing:
+4. **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount 0.05 --rate-mode variable --confirm`
+5. **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount 0.05 --confirm`
+6. **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount 100 --confirm`

--- a/skills/aave-v3-plugin/SUMMARY.md
+++ b/skills/aave-v3-plugin/SUMMARY.md
@@ -4,17 +4,14 @@ Supply assets and borrow against collateral on Aave V3 ($43B+ TVL) across Ethere
 
 **Prerequisites**
 - onchainos agentic wallet connected
-- EVM wallet with funds on Ethereum (1), Base (8453, default), Polygon (137), or Arbitrum (42161)
-- For borrowing: sufficient collateral supplied first; Health Factor must stay above 1.0
+- Some tokens on a supported chain — Ethereum, Base (default), Polygon, or Arbitrum
 
 **How it Works**
-
-Supplying and earning yield:
-1. **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin get-reserves`
-2. **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount <amount> --confirm`
-3. **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
-
-Borrowing:
-4. **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount <amount> --rate-mode variable --confirm`
-5. **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount <amount> --confirm`
-6. **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount <amount> --confirm`
+1. **Supply**:
+   - 1.1 **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin get-reserves`
+   - 1.2 **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount <amount> --confirm`
+   - 1.3 **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
+2. **Borrow** (requires collateral supplied first; Health Factor must stay above 1.0):
+   - 2.1 **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount <amount> --rate-mode variable --confirm`
+   - 2.2 **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount <amount> --confirm`
+   - 2.3 **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount <amount> --confirm`

--- a/skills/aave-v3-plugin/SUMMARY.md
+++ b/skills/aave-v3-plugin/SUMMARY.md
@@ -11,10 +11,10 @@ Supply assets and borrow against collateral on Aave V3 ($43B+ TVL) across Ethere
 
 Supplying and earning yield:
 1. **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin get-reserves`
-2. **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount 100 --confirm`
+2. **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount <amount> --confirm`
 3. **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
 
 Borrowing:
-4. **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount 0.05 --rate-mode variable --confirm`
-5. **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount 0.05 --confirm`
-6. **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount 100 --confirm`
+4. **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount <amount> --rate-mode variable --confirm`
+5. **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount <amount> --confirm`
+6. **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount <amount> --confirm`


### PR DESCRIPTION
## Summary

Rewrites `skills/aave-v3-plugin/SUMMARY.md` from the old Highlights bullet list to the standard detail card format (Overview → Prerequisites → How it Works):

- Bold action labels on each How it Works step
- Two-section structure: Supplying and earning yield / Borrowing
- Health Factor constraint called out in both Prerequisites and withdraw step
- 4-chain support with chain IDs in Prerequisites
- Prereq standardized to "onchainos agentic wallet connected"
- All commands use `aave-v3-plugin` binary name

## Files Changed

| File | Change |
|------|--------|
| `skills/aave-v3-plugin/SUMMARY.md` | Rewrite to detail card format |

## Checklist

- [x] Only files under `skills/aave-v3-plugin/` changed
- [x] Format matches lido-plugin and pancakeswap-clmm-plugin detail cards