### PR TITLE
docs(meteora): add SUMMARY.md in detail card format

### DIFF
--- a/skills/meteora-plugin/SUMMARY.md
+++ b/skills/meteora-plugin/SUMMARY.md
@@ -4,14 +4,15 @@ Add concentrated liquidity to Meteora DLMM pools on Solana — earning fees only
 
 **Prerequisites**
 - onchainos agentic wallet connected with a Solana wallet (chain 501)
-- SOL balance for transaction fees (minimum ~0.01 SOL)
-- For two-sided liquidity: both tokens of the pair in your wallet
+- Some SOL for transaction fees
 
 **How it Works**
-1. **Find high-volume pools**: Browse pools sorted by volume, TVL, or APR. `meteora-plugin get-pools --search-term SOL-USDC --sort-key volume --order-by desc`
+1. **Find pools**: Browse pools sorted by volume, TVL, or APR. `meteora-plugin get-pools --search-term SOL-USDC --sort-key volume --order-by desc`
 2. **Get pool details**: See active bin price, fee tier, TVL, and bin step for a specific pool. `meteora-plugin get-pool-detail --address <pool>`
 3. **Check existing positions**: List open positions with bin ranges and accrued fees. `meteora-plugin get-user-positions`
-4. **Get a swap quote**: Check expected output before committing — no gas. `meteora-plugin get-swap-quote --pool <address> --input-mint <token> --amount <n>`
-5. **Swap**: Execute the swap against the DLMM pool. `meteora-plugin swap --pool <address> --input-mint <token> --amount <n> --confirm`
-6. **Add liquidity**: Deposit into price bins to earn fees — omit one side for single-token deposit. `meteora-plugin add-liquidity --pool <address> --amount-x <SOL> --amount-y <USDC> --confirm`
-7. **Remove liquidity**: Withdraw your position and collect accrued fees. `meteora-plugin remove-liquidity --pool <address> --position <address> --confirm`
+4. **Swap**:
+   - 4.1 **Get a quote**: Check expected output before committing — no gas. `meteora-plugin get-swap-quote --pool <address> --input-mint <token> --amount <n>`
+   - 4.2 **Execute the swap**: Swap against the DLMM pool. `meteora-plugin swap --pool <address> --input-mint <token> --amount <n> --confirm`
+5. **Provide liquidity**:
+   - 5.1 **Add liquidity**: Deposit into price bins to earn fees — omit one side for single-token deposit. `meteora-plugin add-liquidity --pool <address> --amount-x <amount-x> --amount-y <amount-y> --confirm`
+   - 5.2 **Remove liquidity**: Withdraw your position and collect accrued fees. `meteora-plugin remove-liquidity --pool <address> --position <address> --confirm`

--- a/skills/meteora-plugin/SUMMARY.md
+++ b/skills/meteora-plugin/SUMMARY.md
@@ -3,7 +3,7 @@
 Add concentrated liquidity to Meteora DLMM pools on Solana — earning fees only on actively-traded price bins — with support for SOL-only, token-only, or two-sided deposits.
 
 **Prerequisites**
-- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- onchainos agentic wallet connected
 - Some SOL for transaction fees
 
 **How it Works**

--- a/skills/meteora-plugin/SUMMARY.md
+++ b/skills/meteora-plugin/SUMMARY.md
@@ -1,0 +1,17 @@
+**Overview**
+
+Add concentrated liquidity to Meteora DLMM pools on Solana — earning fees only on actively-traded price bins — with support for SOL-only, token-only, or two-sided deposits.
+
+**Prerequisites**
+- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- SOL balance for transaction fees (minimum ~0.01 SOL)
+- For two-sided liquidity: both tokens of the pair in your wallet
+
+**How it Works**
+1. **Find high-volume pools**: Browse pools sorted by volume, TVL, or APR. `meteora-plugin get-pools --search-term SOL-USDC --sort-key volume --order-by desc`
+2. **Get pool details**: See active bin price, fee tier, TVL, and bin step for a specific pool. `meteora-plugin get-pool-detail --address <pool>`
+3. **Check existing positions**: List open positions with bin ranges and accrued fees. `meteora-plugin get-user-positions`
+4. **Get a swap quote**: Check expected output before committing — no gas. `meteora-plugin get-swap-quote --pool <address> --input-mint <token> --amount <n>`
+5. **Swap**: Execute the swap against the DLMM pool. `meteora-plugin swap --pool <address> --input-mint <token> --amount <n> --confirm`
+6. **Add liquidity**: Deposit into price bins to earn fees — omit one side for single-token deposit. `meteora-plugin add-liquidity --pool <address> --amount-x <SOL> --amount-y <USDC> --confirm`
+7. **Remove liquidity**: Withdraw your position and collect accrued fees. `meteora-plugin remove-liquidity --pool <address> --position <address> --confirm`


### PR DESCRIPTION
## Summary

Adds `skills/meteora-plugin/SUMMARY.md` (previously missing) in the standard detail card format (Overview → Prerequisites → How it Works):

- Bold action labels on each How it Works step
- Single-token vs two-sided deposit options noted in Prerequisites and add-liquidity step
- Full flow: pool discovery → position check → quote → swap → add/remove liquidity
- Prereq standardized to "onchainos agentic wallet connected with a Solana wallet (chain 501)"
- All commands use `meteora-plugin` binary name

## Files Changed

| File | Change |
|------|--------|
| `skills/meteora-plugin/SUMMARY.md` | New file — detail card format |

## Checklist

- [x] Only files under `skills/meteora-plugin/` changed
- [x] Format matches lido-plugin and pancakeswap-clmm-plugin detail cards