### PR TITLE
docs(orca): add SUMMARY.md in detail card format

### DIFF
--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -4,12 +4,11 @@ Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX �
 
 **Prerequisites**
 - onchainos agentic wallet connected with a Solana wallet (chain 501)
-- SOL balance for transaction fees (minimum ~0.01 SOL)
-- For non-SOL input tokens: the input token in your wallet (SPL token account created automatically if needed)
+- Some SOL for transaction fees
 
 **How it Works**
 1. **Discover pools**: Find all Whirlpool pools for a token pair with TVL, fee tier, and current price. `orca-plugin get-pools --token-a <mint> --token-b <mint>`
 2. **Get a swap quote**: Check expected output and best pool — no gas. `orca-plugin get-quote --input-mint <mint> --output-mint <mint> --amount <n>`
 3. **Execute the swap**: Swap tokens at the quoted rate — default slippage 0.5%. `orca-plugin swap --input-mint <mint> --output-mint <mint> --amount <n> --confirm`
-
-Common mints: SOL `So11111111111111111111111111111111111111112` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`
+   - 3.1 **Non-SOL tokens**: The input token must be in your wallet — SPL token account is created automatically if needed.
+   - 3.2 **Common mints**: SOL `So11111111111111111111111111111111111111112` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`

--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -3,7 +3,7 @@
 Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX — with auto-routing to the best pool for your token pair.
 
 **Prerequisites**
-- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- onchainos agentic wallet connected
 - Some SOL for transaction fees
 
 **How it Works**

--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -1,6 +1,6 @@
 **Overview**
 
-Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX with $1B+ TVL — with auto-routing to the best pool for your token pair.
+Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX — with auto-routing to the best pool for your token pair.
 
 **Prerequisites**
 - onchainos agentic wallet connected with a Solana wallet (chain 501)

--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -1,0 +1,15 @@
+**Overview**
+
+Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX with $1B+ TVL — with auto-routing to the best pool for your token pair.
+
+**Prerequisites**
+- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- SOL balance for transaction fees (minimum ~0.01 SOL)
+- For non-SOL input tokens: the input token in your wallet (SPL token account created automatically if needed)
+
+**How it Works**
+1. **Discover pools**: Find all Whirlpool pools for a token pair with TVL, fee tier, and current price. `orca-plugin get-pools --token-a <mint> --token-b <mint>`
+2. **Get a swap quote**: Check expected output and best pool — no gas. `orca-plugin get-quote --input-mint <mint> --output-mint <mint> --amount <n>`
+3. **Execute the swap**: Swap tokens at the quoted rate — default slippage 0.5%. `orca-plugin swap --input-mint <mint> --output-mint <mint> --amount <n> --confirm`
+
+Common mints: SOL `So11111111111111111111111111111111111111112` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`


### PR DESCRIPTION
## Summary

Adds `skills/orca-plugin/SUMMARY.md` (previously missing) in the standard detail card format (Overview → Prerequisites → How it Works):

- Bold action labels on each How it Works step
- Compact 3-step flow: discover pools → quote → swap
- Common Solana token mints included for quick reference
- Prereq standardized to "onchainos agentic wallet connected with a Solana wallet (chain 501)"
- All commands use `orca-plugin` binary name

## Files Changed

| File | Change |
|------|--------|
| `skills/orca-plugin/SUMMARY.md` | New file — detail card format |

## Checklist

- [x] Only files under `skills/orca-plugin/` changed
- [x] Format matches lido-plugin and pancakeswap-clmm-plugin detail cards