### PR TITLE
docs(raydium): update SUMMARY.md to detail card format

### DIFF
--- a/skills/raydium-plugin/SUMMARY.md
+++ b/skills/raydium-plugin/SUMMARY.md
@@ -4,12 +4,14 @@ Swap tokens on Raydium — Solana's largest AMM — with live quotes, multi-mint
 
 **Prerequisites**
 - onchainos agentic wallet connected
-- At least 0.01 SOL in your wallet for gas plus the swap amount
+- Some SOL for gas plus the swap amount
 
 **How it Works**
-1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL for gas. `raydium-plugin quickstart`
-2. **Get a live quote**: See the expected output before committing — no gas. `raydium-plugin get-swap-quote --input-mint So11111111111111111111111111111111111111112 --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount <amount>`
-3. **Check token prices**: Look up current prices for one or more token mints. `raydium-plugin get-token-price --mints So11111111111111111111111111111111111111112`
-4. **Browse pools**: Find pools sorted by liquidity, volume, or APR. `raydium-plugin get-pool-list --sort-field liquidity --sort-type desc --page-size 5`
-5. **Preview a swap**: See the full transaction details before signing — no gas, no transaction. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50`
-6. **Execute the swap**: Broadcast the transaction after confirming the preview. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50 --confirm`
+1. **Discover**: Browse and research before swapping.
+   - 1.1 **Get a live quote**: See the expected output before committing — no gas. `raydium-plugin get-swap-quote --input-mint <input-mint> --output-mint <output-mint> --amount <amount>`
+   - 1.2 **Check token prices**: Look up current prices for one or more token mints. `raydium-plugin get-token-price --mints <mint>`
+   - 1.3 **Browse pools**: Find pools sorted by liquidity, volume, or APR. `raydium-plugin get-pool-list --sort-field liquidity --sort-type desc --page-size 5`
+2. **Swap**:
+   - 2.1 **Preview**: See the full transaction details before signing — no gas, no transaction. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50`
+   - 2.2 **Execute**: Broadcast the transaction after confirming the preview. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50 --confirm`
+   - 2.3 **Common mints**: SOL `So11111111111111111111111111111111111111112` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`

--- a/skills/raydium-plugin/SUMMARY.md
+++ b/skills/raydium-plugin/SUMMARY.md
@@ -3,7 +3,7 @@
 Swap tokens on Raydium — Solana's largest AMM — with live quotes, multi-mint price checks, pool browsing, and a preview-before-execute flow using your onchainos wallet.
 
 **Prerequisites**
-- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- onchainos agentic wallet connected
 - At least 0.01 SOL in your wallet for gas plus the swap amount
 
 **How it Works**

--- a/skills/raydium-plugin/SUMMARY.md
+++ b/skills/raydium-plugin/SUMMARY.md
@@ -8,8 +8,8 @@ Swap tokens on Raydium — Solana's largest AMM — with live quotes, multi-mint
 
 **How it Works**
 1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL for gas. `raydium-plugin quickstart`
-2. **Get a live quote**: See the expected output before committing — no gas. `raydium-plugin get-swap-quote --input-mint So11111111111111111111111111111111111111112 --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount 0.1`
+2. **Get a live quote**: See the expected output before committing — no gas. `raydium-plugin get-swap-quote --input-mint So11111111111111111111111111111111111111112 --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount <amount>`
 3. **Check token prices**: Look up current prices for one or more token mints. `raydium-plugin get-token-price --mints So11111111111111111111111111111111111111112`
 4. **Browse pools**: Find pools sorted by liquidity, volume, or APR. `raydium-plugin get-pool-list --sort-field liquidity --sort-type desc --page-size 5`
-5. **Preview a swap**: See the full transaction details before signing — no gas, no transaction. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount 0.1 --slippage-bps 50`
-6. **Execute the swap**: Broadcast the transaction after confirming the preview. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount 0.1 --slippage-bps 50 --confirm`
+5. **Preview a swap**: See the full transaction details before signing — no gas, no transaction. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50`
+6. **Execute the swap**: Broadcast the transaction after confirming the preview. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount <amount> --slippage-bps 50 --confirm`

--- a/skills/raydium-plugin/SUMMARY.md
+++ b/skills/raydium-plugin/SUMMARY.md
@@ -1,13 +1,15 @@
-# raydium
-Raydium AMM plugin for token swaps, price queries, and pool information on Solana mainnet.
+**Overview**
 
-## Highlights
-- Execute token swaps on Raydium DEX with automatic slippage protection
-- Get real-time swap quotes and price impact analysis before trading
-- Query USD prices for any SPL token using Raydium's price feeds
-- Access comprehensive pool information including liquidity and TVL data
-- Browse and search through all available Raydium liquidity pools
-- Built-in safety guards that warn or abort swaps with high price impact
-- Automatic token decimal handling for human-readable amount inputs
-- Integration with onchainos wallet for seamless Solana transaction execution
+Swap tokens on Raydium — Solana's largest AMM — with live quotes, multi-mint price checks, pool browsing, and a preview-before-execute flow using your onchainos wallet.
 
+**Prerequisites**
+- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- At least 0.01 SOL in your wallet for gas plus the swap amount
+
+**How it Works**
+1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL for gas. `raydium-plugin quickstart`
+2. **Get a live quote**: See the expected output before committing — no gas. `raydium-plugin get-swap-quote --input-mint So11111111111111111111111111111111111111112 --output-mint EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --amount 0.1`
+3. **Check token prices**: Look up current prices for one or more token mints. `raydium-plugin get-token-price --mints So11111111111111111111111111111111111111112`
+4. **Browse pools**: Find pools sorted by liquidity, volume, or APR. `raydium-plugin get-pool-list --sort-field liquidity --sort-type desc --page-size 5`
+5. **Preview a swap**: See the full transaction details before signing — no gas, no transaction. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount 0.1 --slippage-bps 50`
+6. **Execute the swap**: Broadcast the transaction after confirming the preview. `raydium-plugin swap --input-mint <mint> --output-mint <mint> --amount 0.1 --slippage-bps 50 --confirm`


### PR DESCRIPTION
## Summary

Rewrites `skills/raydium-plugin/SUMMARY.md` from the old Highlights bullet list to the standard detail card format (Overview → Prerequisites → How it Works):

- Bold action labels on each How it Works step
- Quickstart step moved to step 1 of How it Works (wallet readiness check)
- Clear preview → execute pattern for swaps (steps 5 and 6)
- Removed redundant "plugin installed" prereq (covered by onchainos skill install)
- Prereq standardized to "onchainos agentic wallet connected with a Solana wallet (chain 501)"
- All commands use `raydium-plugin` binary name

## Files Changed

| File | Change |
|------|--------|
| `skills/raydium-plugin/SUMMARY.md` | Rewrite to detail card format |

## Checklist

- [x] Only files under `skills/raydium-plugin/` changed
- [x] Format matches lido-plugin and pancakeswap-clmm-plugin detail cards