### PR TITLE
docs(pump-fun): update SUMMARY.md to detail card format

### DIFF
--- a/skills/pump-fun-plugin/SUMMARY.md
+++ b/skills/pump-fun-plugin/SUMMARY.md
@@ -11,7 +11,7 @@ Buy and sell tokens on pump.fun bonding curves from the CLI — check token info
 1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL. `pump-fun-plugin quickstart`
 2. **Research a token**: See bonding curve reserves, current price, and graduation progress. `pump-fun-plugin get-token-info --mint <TOKEN_MINT>`
 3. **Get a price quote**: Check the expected cost before buying or expected proceeds before selling. `pump-fun-plugin get-price --mint <TOKEN_MINT> --direction buy`
-4. **Preview a buy**: See the transaction details without sending — no gas. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount 0.01`
-5. **Execute the buy**: Purchase tokens from the bonding curve. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount 0.01 --confirm`
+4. **Preview a buy**: See the transaction details without sending — no gas. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount>`
+5. **Execute the buy**: Purchase tokens from the bonding curve. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount> --confirm`
 6. **Preview a sell**: See expected SOL proceeds before selling. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT>`
 7. **Execute the sell**: Sell tokens back to the bonding curve — omit `--token-amount` to sell your full balance. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT> --confirm`

--- a/skills/pump-fun-plugin/SUMMARY.md
+++ b/skills/pump-fun-plugin/SUMMARY.md
@@ -3,7 +3,7 @@
 Buy and sell tokens on pump.fun bonding curves from the CLI — check token info, bonding curve progress, and price quotes before any on-chain action.
 
 **Prerequisites**
-- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- onchainos agentic wallet connected
 - At least 0.05 SOL in your wallet (covers a small buy plus network fees)
 - A pump.fun token mint address — active bonding curve tokens end in `pump`
 

--- a/skills/pump-fun-plugin/SUMMARY.md
+++ b/skills/pump-fun-plugin/SUMMARY.md
@@ -4,14 +4,15 @@ Buy and sell tokens on pump.fun bonding curves from the CLI — check token info
 
 **Prerequisites**
 - onchainos agentic wallet connected
-- At least 0.05 SOL in your wallet (covers a small buy plus network fees)
-- A pump.fun token mint address — active bonding curve tokens end in `pump`
+- Some SOL in your wallet for the buy amount plus network fees
 
 **How it Works**
-1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL. `pump-fun-plugin quickstart`
-2. **Research a token**: See bonding curve reserves, current price, and graduation progress. `pump-fun-plugin get-token-info --mint <TOKEN_MINT>`
-3. **Get a price quote**: Check the expected cost before buying or expected proceeds before selling. `pump-fun-plugin get-price --mint <TOKEN_MINT> --direction buy`
-4. **Preview a buy**: See the transaction details without sending — no gas. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount>`
-5. **Execute the buy**: Purchase tokens from the bonding curve. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount> --confirm`
-6. **Preview a sell**: See expected SOL proceeds before selling. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT>`
-7. **Execute the sell**: Sell tokens back to the bonding curve — omit `--token-amount` to sell your full balance. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT> --confirm`
+1. **Research**: Look up a token before trading — active bonding curve tokens end in `pump`.
+   - 1.1 **Token info**: See bonding curve reserves, current price, and graduation progress. `pump-fun-plugin get-token-info --mint <TOKEN_MINT>`
+   - 1.2 **Get a price quote**: Check the expected cost before buying or expected proceeds before selling. `pump-fun-plugin get-price --mint <TOKEN_MINT> --direction buy`
+2. **Buy**:
+   - 2.1 **Preview**: See the transaction details without sending — no gas. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount>`
+   - 2.2 **Execute**: Purchase tokens from the bonding curve. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount <amount> --confirm`
+3. **Sell**:
+   - 3.1 **Preview**: See expected SOL proceeds before selling. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT>`
+   - 3.2 **Execute**: Sell tokens back to the bonding curve — omit `--token-amount` to sell your full balance. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT> --confirm`

--- a/skills/pump-fun-plugin/SUMMARY.md
+++ b/skills/pump-fun-plugin/SUMMARY.md
@@ -1,13 +1,17 @@
-# pump-fun
-A Solana-based DeFi skill for trading tokens on pump.fun bonding curves with buy/sell operations and price checking.
+**Overview**
 
-## Highlights
-- Trade tokens on pump.fun bonding curves on Solana mainnet
-- Check token prices and bonding curve progress in real-time
-- Buy tokens with SOL through bonding curve mechanics
-- Sell tokens back to bonding curve or graduated DEX pools
-- Preview operations with dry-run mode before execution
-- Automatic slippage protection and fee calculation
-- Support for both bonding curve and graduated tokens
-- Real-time market cap and graduation progress tracking
+Buy and sell tokens on pump.fun bonding curves from the CLI — check token info, bonding curve progress, and price quotes before any on-chain action.
 
+**Prerequisites**
+- onchainos agentic wallet connected with a Solana wallet (chain 501)
+- At least 0.05 SOL in your wallet (covers a small buy plus network fees)
+- A pump.fun token mint address — active bonding curve tokens end in `pump`
+
+**How it Works**
+1. **Check wallet readiness**: Verify your wallet is connected and has enough SOL. `pump-fun-plugin quickstart`
+2. **Research a token**: See bonding curve reserves, current price, and graduation progress. `pump-fun-plugin get-token-info --mint <TOKEN_MINT>`
+3. **Get a price quote**: Check the expected cost before buying or expected proceeds before selling. `pump-fun-plugin get-price --mint <TOKEN_MINT> --direction buy`
+4. **Preview a buy**: See the transaction details without sending — no gas. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount 0.01`
+5. **Execute the buy**: Purchase tokens from the bonding curve. `pump-fun-plugin buy --mint <TOKEN_MINT> --sol-amount 0.01 --confirm`
+6. **Preview a sell**: See expected SOL proceeds before selling. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT>`
+7. **Execute the sell**: Sell tokens back to the bonding curve — omit `--token-amount` to sell your full balance. `pump-fun-plugin sell --mint <TOKEN_MINT> --token-amount <AMOUNT> --confirm`


### PR DESCRIPTION
## Summary

Rewrites `skills/pump-fun-plugin/SUMMARY.md` from the old Highlights bullet list to the standard detail card format (Overview → Prerequisites → How it Works):

- Bold action labels on each How it Works step
- Separate preview and execute steps for buy and sell flows
- Bonding curve token identification note (ends in `pump`)
- Removed redundant "plugin installed" prereq (covered by onchainos skill install)
- Prereq standardized to "onchainos agentic wallet connected with a Solana wallet (chain 501)"
- All commands use `pump-fun-plugin` binary name

## Files Changed

| File | Change |
|------|--------|
| `skills/pump-fun-plugin/SUMMARY.md` | Rewrite to detail card format |

## Checklist

- [x] Only files under `skills/pump-fun-plugin/` changed
- [x] Format matches lido-plugin and pancakeswap-clmm-plugin detail cards