### PR TITLE
chore(polymarket-plugin): align SUMMARY.md to new standard

### DIFF
--- a/skills/polymarket-plugin/SUMMARY.md
+++ b/skills/polymarket-plugin/SUMMARY.md
@@ -1,13 +1,19 @@
-# polymarket-plugin
-Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon.
+**Overview**
 
-## Highlights
-- Browse active prediction markets with keyword filtering
-- Buy YES/NO outcome tokens with USDC.e collateral
-- Sell existing positions with limit or market orders
-- View open positions with real-time P&L tracking
-- Cancel individual or bulk orders
-- Uses onchainos wallet for EIP-712 signing — no separate key setup required
-- Supports both regular and negative risk markets
-- Direct integration with Polymarket CLOB API
+Polymarket is a prediction market protocol on Polygon where users trade YES/NO outcome shares of real-world events. This skill lets you browse markets (including 5-minute crypto up/down markets), buy and sell outcome shares, check positions, cancel orders, redeem winning tokens, and optionally set up a proxy wallet for gasless trading.
 
+**Prerequisites**
+- onchainos CLI installed and logged in with a Polygon address (chain 137)
+- USDC.e on Polygon for trading (≥ $5 recommended for a first test trade)
+- POL for gas in EOA mode (default; each buy/sell does an on-chain approve) — skip with one-time POLY_PROXY setup
+- Accessible region — Polymarket blocks the US and OFAC-sanctioned jurisdictions
+
+**Quick Start**
+1. Verify your region is not restricted: `polymarket-plugin check-access`
+2. Check balances on both EOA and proxy wallets: `polymarket-plugin balance`
+3. (Optional, recommended) Switch to gasless mode by creating a proxy wallet and funding it: `polymarket-plugin setup-proxy` then `polymarket-plugin deposit --amount 50`
+4. Browse active markets by keyword, or list 5-minute crypto up/down markets: `polymarket-plugin list-markets --keyword "trump"` or `polymarket-plugin list-5m`
+5. Get details and order book for a specific market: `polymarket-plugin get-market --market-id <SLUG>`
+6. Buy YES or NO outcome shares at market price: `polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5`
+7. Review your open positions and P&L: `polymarket-plugin get-positions`
+8. Exit a position, or redeem winnings when the market resolves: `polymarket-plugin sell --market-id <SLUG> --outcome yes --amount 5` / `polymarket-plugin redeem --market-id <SLUG>`


### PR DESCRIPTION
## Summary

Rewrite `skills/polymarket-plugin/SUMMARY.md` from the legacy `# title + ## Highlights` layout to the new three-section standard used across recently aligned plugins:

- **Overview** — one concise sentence on what Polymarket is and what the skill can do (including 5-minute crypto markets and gasless proxy trading)
- **Prerequisites** — onchainos CLI on Polygon, USDC.e to trade, POL for gas in EOA mode, region restriction notice (US / OFAC blocked)
- **Quick Start** — 8-step guided flow: region check → balance → optional gasless proxy setup → browse markets → get market detail → buy → positions → sell/redeem

## Scope

- Docs only — no code changes
- No version bump (SUMMARY.md does not ship as part of the installed artifact)
- Touched files: `skills/polymarket-plugin/SUMMARY.md`

## Test plan

- [x] Fork `main` synced with `okx/main` to avoid multi-plugin CI diff
- [x] `git diff okx/main -- skills/polymarket-plugin/` shows only `SUMMARY.md` changed