### PR TITLE
docs(pancakeswap-clmm): standardize prereq wording and amount placeholders

### DIFF
--- a/skills/pancakeswap-clmm-plugin/SUMMARY.md
+++ b/skills/pancakeswap-clmm-plugin/SUMMARY.md
@@ -3,14 +3,14 @@
 Stake PancakeSwap V3 LP NFTs into MasterChefV3 to earn CAKE rewards on top of swap fees — with harvest, unfarm, and collect-fees commands across BSC, Ethereum, Base, and Arbitrum.
 
 **Prerequisites**
-- onchainos CLI installed and logged in with a BSC wallet (chain 56, default)
+- onchainos agentic wallet connected
 - A PancakeSwap V3 LP NFT (create one with `pancakeswap-v3-plugin`)
 - Some BNB in your wallet for gas
 
 **How it Works**
 1. **Get an LP NFT** (skip if you already have one):
    - 1.1 **Find a pool**: Look up available fee tiers for your token pair — `pancakeswap-v3-plugin pools --token-a CAKE --token-b BNB`
-   - 1.2 **Mint the LP position**: Provide liquidity to receive an LP NFT — note the token ID in the output. `pancakeswap-v3-plugin add-liquidity --token-a CAKE --token-b BNB --fee 2500 --amount-a 10 --amount-b 0.05 --confirm`
+   - 1.2 **Mint the LP position**: Provide liquidity to receive an LP NFT — note the token ID in the output. `pancakeswap-v3-plugin add-liquidity --token-a CAKE --token-b BNB --fee 2500 --amount-a <amount-a> --amount-b <amount-b> --confirm`
 2. **Check existing positions**: See all your V3 LP NFTs — both staked and unstaked. `pancakeswap-clmm-plugin positions`
 3. **Browse farming pools**: Find pools with active CAKE emissions and their allocation points. `pancakeswap-clmm-plugin farm-pools`
 4. **Stake the NFT**: Deposit your LP NFT into MasterChefV3 to start earning CAKE — preview first, add `--confirm` to execute. `pancakeswap-clmm-plugin farm --token-id <TOKEN_ID> --confirm`


### PR DESCRIPTION
## Summary

Follow-up to #260 — two small fixes missed in the initial detail card PR:

- Prereq 1: `onchainos CLI installed and logged in with a BSC wallet (chain 56, default)` → `onchainos agentic wallet connected` (Phase 4 CI had reverted to old wording; standardized to match all other plugins)
- Step 1.2: hardcoded `--amount-a 10 --amount-b 0.05` → `--amount-a <amount-a> --amount-b <amount-b>` (consistent with amount placeholder convention applied across all plugins)

## Files Changed

| File | Change |
|------|--------|
| `skills/pancakeswap-clmm-plugin/SUMMARY.md` | Prereq wording + amount placeholders |

## Checklist

- [x] Only files under `skills/pancakeswap-clmm-plugin/` changed