### PR TITLE
docs(orca): add quickstart step, fix flag names and SOL mint

### DIFF
--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -7,8 +7,11 @@ Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX �
 - Some SOL for transaction fees
 
 **How it Works**
-1. **Discover pools**: Find all Whirlpool pools for a token pair with TVL, fee tier, and current price. `orca-plugin get-pools --token-a <mint> --token-b <mint>`
-2. **Get a swap quote**: Check expected output and best pool — no gas. `orca-plugin get-quote --input-mint <mint> --output-mint <mint> --amount <n>`
-3. **Execute the swap**: Swap tokens at the quoted rate — default slippage 0.5%. `orca-plugin swap --input-mint <mint> --output-mint <mint> --amount <n> --confirm`
-   - 3.1 **Non-SOL tokens**: The input token must be in your wallet — SPL token account is created automatically if needed.
-   - 3.2 **Common mints**: SOL `So11111111111111111111111111111111111111112` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`
+1. **Check your wallet**: Get a personalised next step based on your balances. `orca-plugin quickstart`
+   - If `status: no_funds` or `needs_gas` — fund your Solana wallet with SOL first
+   - If `status: ready` or `ready_sol_only` — proceed below
+2. **Discover pools**: Find all Whirlpool pools for a token pair with TVL, fee tier, and current price. `orca-plugin get-pools --token-a <mint> --token-b <mint>`
+3. **Get a swap quote**: Check expected output and best pool — no gas. `orca-plugin get-quote --from-token <mint> --to-token <mint> --amount <n>`
+4. **Execute the swap**: Swap tokens at the quoted rate — default slippage 0.5%. `orca-plugin swap --from-token <mint> --to-token <mint> --amount <n> --confirm`
+   - 4.1 **Non-SOL tokens**: The input token must be in your wallet — SPL token account is created automatically if needed.
+   - 4.2 **Common mints**: SOL `11111111111111111111111111111111` · USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` · USDT `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB`

--- a/skills/orca-plugin/SUMMARY.md
+++ b/skills/orca-plugin/SUMMARY.md
@@ -1,12 +1,12 @@
-**Overview**
+## Overview
 
 Swap tokens on Orca Whirlpools — Solana's leading concentrated liquidity DEX — with auto-routing to the best pool for your token pair.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some SOL for transaction fees
 
-**How it Works**
+## How it Works
 1. **Check your wallet**: Get a personalised next step based on your balances. `orca-plugin quickstart`
    - If `status: no_funds` or `needs_gas` — fund your Solana wallet with SOL first
    - If `status: ready` or `ready_sol_only` — proceed below


### PR DESCRIPTION
## Summary

- Add `orca-plugin quickstart` as step 1 of How it Works (with status-based branching: `no_funds`, `needs_gas`, `ready`, `ready_sol_only`)
- Fix `--input-mint`/`--output-mint` → `--from-token`/`--to-token` on `get-quote` and `swap` (wrong flag names from the original detail card PR)
- Fix SOL mint address in common mints: `So11111111111111111111111111111111111111112` (wSOL) → `11111111111111111111111111111111` (native SOL, as expected by `swap` and `get-quote`)
- Renumber steps 1–3 → 2–4 to accommodate the new quickstart step

## Files Changed

| File | Change |
|------|--------|
| `skills/orca-plugin/SUMMARY.md` | Add quickstart step, fix flag names, fix SOL mint, renumber steps |

## Notes

The `quickstart` command is implemented in source (`src/commands/quickstart.rs`) but the currently released binary predates it — a binary release will be needed for step 1 to be usable.

## Checklist

- [x] Only modifies files under `skills/orca-plugin/`
- [x] Flag names verified against `orca swap --help` and `orca get-quote --help`
- [x] SOL mint verified against `orca quickstart` output (built from source)
- [x] Follows detail card format (Overview → Prerequisites → How it Works)