### PR TITLE
docs(etherfi): ## headings, add quickstart step, surface unwrap command

### DIFF
--- a/skills/etherfi-plugin/SUMMARY.md
+++ b/skills/etherfi-plugin/SUMMARY.md
@@ -1,16 +1,20 @@
-**Overview**
+## Overview
 
 Liquid restake ETH on Ethereum to receive eETH — earning staking rewards and EigenLayer restaking points simultaneously — with an optional wrap to auto-compounding weETH and an exit via withdrawal queue.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some ETH on Ethereum mainnet
 
-**How it Works**
-1. **Check your positions and APY**: See current eETH/weETH balances and the live staking rate before committing. `etherfi-plugin positions`
-2. **Stake ETH**: Deposit ETH into ether.fi and receive eETH — approval fires automatically; minimum 0.001 ETH enforced by the protocol. `etherfi-plugin stake --amount <amount> --confirm`
-3. **Choose how to hold your stake**:
-   - 3.1 **Hold as eETH** (simple): Your eETH balance grows daily via rebase — no further action needed.
-   - 3.2 **Wrap to weETH** (auto-compounding): Convert eETH to weETH, whose exchange rate appreciates over time rather than rebasing. `etherfi-plugin wrap --amount <amount> --confirm`
-4. **Exit**: Queue a withdrawal to start the exit process — burns eETH (unwrap weETH first if needed) and mints a WithdrawRequestNFT. Expect 1–7 days. `etherfi-plugin unstake --amount <amount> --confirm`
-5. **Claim ETH**: Once finalized, redeem your WithdrawRequestNFT for ETH back to your wallet. `etherfi-plugin unstake --claim --token-id <ID> --confirm`
+## How it Works
+1. **Check your wallet**: Get a personalised next step based on your ETH and eETH/weETH balances. `etherfi-plugin quickstart`
+   - If `status: no_funds` — fund your wallet with ETH on Ethereum mainnet first
+   - If `status: needs_gas` — send at least 0.005 ETH to your wallet for gas
+   - If `status: ready` — proceed to stake below
+2. **Check your positions and APY**: See current eETH/weETH balances and the live staking rate before committing. `etherfi-plugin positions`
+3. **Stake ETH**: Deposit ETH into ether.fi and receive eETH — minimum 0.001 ETH enforced by the protocol. `etherfi-plugin stake --amount <amount> --confirm`
+4. **Choose how to hold your stake**:
+   - 4.1 **Hold as eETH** (simple): Your eETH balance grows daily via rebase — no further action needed.
+   - 4.2 **Wrap to weETH** (auto-compounding): Convert eETH to weETH, whose exchange rate appreciates over time rather than rebasing — ERC-20 approval fires automatically. `etherfi-plugin wrap --amount <amount> --confirm`
+5. **Exit**: Queue a withdrawal to start the exit process — burns eETH (unwrap weETH first if needed: `etherfi-plugin unwrap --amount <amount> --confirm`) and mints a WithdrawRequestNFT — ERC-20 approval fires automatically. Expect 1–7 days. `etherfi-plugin unstake --amount <amount> --confirm`
+6. **Claim ETH**: Once finalized, redeem your WithdrawRequestNFT for ETH back to your wallet. `etherfi-plugin unstake --claim --token-id <ID> --confirm`


### PR DESCRIPTION
## Summary

- Convert section headers from `**bold**` to `## markdown`
- Add `etherfi-plugin quickstart` as step 1 with status-based guidance (`active`, `ready`, `no_funds`)
- Surface the `unwrap` command inline in the exit step (was only mentioned as a parenthetical with no command shown)
- Renumber existing steps 1–5 → 2–6

## Files Changed

| File | Change |
|------|--------|
| `skills/etherfi-plugin/SUMMARY.md` | `##` headings, quickstart step, unwrap surfaced, renumbering |

## Verification

All flags cross-checked against binary — no mismatches found:
- `positions` ✅
- `stake --amount` ✅
- `wrap --amount` ✅
- `unwrap --amount` ✅
- `unstake --amount` ✅
- `unstake --claim --token-id` ✅

Quickstart statuses confirmed from source (`src/commands/quickstart.rs`): `active`, `ready`, `no_funds`.

## Notes

The `quickstart` command is implemented in source but the currently released binary predates it — a binary release will be needed for step 1 to be usable.

## Checklist

- [x] Only modifies files under `skills/etherfi-plugin/`
- [x] All command flags verified against binary
- [x] Follows updated format (## headings, Overview → Prerequisites → How it Works)