### PR TITLE
docs(velodrome-v2): use ## headings for section headers

### DIFF
--- a/skills/velodrome-v2-plugin/SUMMARY.md
+++ b/skills/velodrome-v2-plugin/SUMMARY.md
@@ -1,12 +1,12 @@
-**Overview**
+## Overview
 
 Swap tokens and provide liquidity on Velodrome V2's AMM on Optimism — supporting volatile and stable pool types — earning trading fees and VELO emissions from pool gauges.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some tokens on Optimism to swap or provide as liquidity
 
-**How it Works**
+## How it Works
 1. **Swap tokens**:
    - 1.1 **Get a quote**: Check the expected output before committing — auto-checks both volatile and stable pools (no gas). `velodrome-v2-plugin quote --token-in WETH --token-out USDC --amount-in <amount>`
    - 1.2 **Execute the swap**: Send tokens and receive output in one transaction. `velodrome-v2-plugin swap --token-in WETH --token-out USDC --amount-in <amount> --slippage 0.5 --confirm`


### PR DESCRIPTION
## Summary

- Convert section headers from `**bold**` to `## markdown` (Overview, Prerequisites, How it Works)
- No other content changes — all existing command flags verified correct against binary

## Files Changed

| File | Change |
|------|--------|
| `skills/velodrome-v2-plugin/SUMMARY.md` | `##` headings only |

## Verification

All flags cross-checked against binary — no mismatches found:
- `quote --token-in/--token-out/--amount-in` ✅
- `swap --token-in/--token-out/--amount-in/--slippage/--confirm` ✅
- `pools --token-a/--token-b` ✅
- `add-liquidity --token-a/--token-b/--amount-a-desired/--confirm` ✅
- `positions --token-a/--token-b` ✅
- `remove-liquidity --token-a/--token-b/--confirm` ✅
- `claim-rewards --token-a/--token-b/--confirm` ✅

No `quickstart` command exists in source — no step added.

## Checklist

- [x] Only modifies files under `skills/velodrome-v2-plugin/`
- [x] All command flags verified against binary
- [x] Follows updated format (## headings)