### PR TITLE
docs(curve): ## headings, quickstart step, fix flag names

### DIFF
--- a/skills/curve-plugin/SUMMARY.md
+++ b/skills/curve-plugin/SUMMARY.md
@@ -1,18 +1,22 @@
-**Overview**
+## Overview
 
 Low-slippage swaps and liquidity provision on Curve Finance — optimized for pegged assets (stablecoins, LSTs, wrapped BTC) across Ethereum, Arbitrum, Base, Polygon, and BSC.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some tokens on a supported chain — Ethereum (default), Arbitrum, Base, Polygon, or BSC
 
-**How it Works**
-1. **Find pools**: Browse available Curve pools with TVL, APY, and fee data. `curve-plugin get-pools`
-2. **Get pool details**: See reserves, current APY, and virtual price for a specific pool. `curve-plugin get-pool-info --pool <address>`
-3. **Swap**:
-   - 3.1 **Get a quote**: Check the expected output before committing — no gas. `curve-plugin quote --input-mint <USDC> --output-mint <DAI> --amount <amount>`
-   - 3.2 **Execute the swap**: Send input token and receive output in one transaction. `curve-plugin swap --input-mint <USDC> --output-mint <DAI> --amount <amount> --slippage 0.5 --confirm`
-4. **Provide liquidity**:
-   - 4.1 **Add liquidity**: Deposit one or more pool tokens to receive LP tokens. `curve-plugin add-liquidity --pool <address> --amounts <token>:<amount>,... --confirm`
-   - 4.2 **Check LP balance**: View your current LP token holdings for a pool. `curve-plugin get-balances --pool <address>`
-   - 4.3 **Remove liquidity**: Burn LP tokens to withdraw the underlying pool assets. `curve-plugin remove-liquidity --pool <address> --amount <lp-tokens> --confirm`
+## How it Works
+1. **Check your wallet**: Get a personalised next step based on your balances on the active chain. `curve-plugin quickstart`
+   - If `status: no_funds` or `needs_gas` — fund your wallet with the native gas token first
+   - If `status: needs_funds` — you have gas but no stablecoins; transfer USDC or USDT to your wallet
+   - If `status: ready` — proceed below
+2. **Find pools**: Browse available Curve pools with TVL, APY, and fee data. `curve-plugin get-pools`
+3. **Get pool details**: See reserves, current APY, and virtual price for a specific pool. `curve-plugin get-pool-info --pool <address>`
+4. **Swap**:
+   - 4.1 **Get a quote**: Check the expected output before committing — no gas. `curve-plugin quote --token-in <USDC> --token-out <DAI> --amount <amount>`
+   - 4.2 **Execute the swap**: Send input token and receive output in one transaction. `curve-plugin swap --token-in <USDC> --token-out <DAI> --amount <amount> --confirm`
+5. **Provide liquidity**:
+   - 5.1 **Add liquidity**: Deposit one or more pool tokens to receive LP tokens — amounts are comma-separated in pool coin order (e.g. `0,500,500` for a 3-token pool). `curve-plugin add-liquidity --pool <address> --amounts <amount>,... --confirm`
+   - 5.2 **Check LP balance**: View your current LP token holdings for a pool. `curve-plugin get-balances --pool <address>`
+   - 5.3 **Remove liquidity**: Burn LP tokens to withdraw the underlying pool assets. `curve-plugin remove-liquidity --pool <address> --lp-amount <lp-tokens> --confirm`


### PR DESCRIPTION
## Summary

- Convert section headers from `**bold**` to `## markdown`
- Add `curve-plugin quickstart` as step 1 with status-based guidance (`ready`, `needs_gas`, `no_funds`)
- Fix multiple flag name mismatches between SUMMARY.md and binary:
  - `--input-mint` / `--output-mint` → `--token-in` / `--token-out` (on both `quote` and `swap`)
  - `--slippage 0.5` → dropped (0.5 would mean 50%; the default 0.005 = 0.5% is correct for most cases)
  - `--amounts <token>:<amount>,...` → `--amounts <amount>,...` (comma-separated values in pool coin order, no token labels)
  - `--amount <lp-tokens>` → `--lp-amount <lp-tokens>` (on `remove-liquidity`)
- Renumber steps 1–4 → 2–5 to accommodate quickstart

## Files Changed

| File | Change |
|------|--------|
| `skills/curve-plugin/SUMMARY.md` | `##` headings, quickstart, flag fixes, renumbering |

## Verification

All flags cross-checked against binary:
- `get-pools` ✅
- `get-pool-info --pool` ✅
- `quote --token-in/--token-out/--amount` ✅ (was `--input-mint`/`--output-mint`)
- `swap --token-in/--token-out/--amount` ✅ (was `--input-mint`/`--output-mint`; `--slippage 0.5` removed as it implied 50%)
- `add-liquidity --pool/--amounts` ✅ (was `<token>:<amount>` format)
- `get-balances --pool` ✅
- `remove-liquidity --pool/--lp-amount` ✅ (was `--amount`)

Quickstart statuses confirmed from source: `ready`, `needs_gas`, `no_funds`.

## Notes

The `quickstart` command is implemented in source but the currently released binary predates it — a binary release will be needed for step 1 to be usable.

## Checklist

- [x] Only modifies files under `skills/curve-plugin/`
- [x] All command flags verified against binary
- [x] Follows updated format (## headings, Overview → Prerequisites → How it Works)