### PR TITLE
chore(hyperliquid-plugin): use H2 headings in SUMMARY.md

### DIFF
--- a/skills/hyperliquid-plugin/SUMMARY.md
+++ b/skills/hyperliquid-plugin/SUMMARY.md
@@ -1,13 +1,13 @@
-**Overview**
+## Overview
 
 Hyperliquid is a high-performance on-chain perpetuals DEX on its own L1, settling in USDC. This skill lets you deposit from Arbitrum, trade perps & spot (market/limit, TP/SL, leverage), close positions, transfer between perp/spot, and withdraw back to Arbitrum.
 
-**Prerequisites**
+## Prerequisites
 - onchainos CLI installed and logged in
 - USDC on Arbitrum (chain 42161) to deposit into Hyperliquid
 - A small amount of ETH on Arbitrum for gas
 
-**Quick Start**
+## Quick Start
 1. Check your current state and get a guided next step: `hyperliquid quickstart`
 2. If you see `status: no_funds` / `low_balance` — get your deposit address and top up USDC on Arbitrum: `hyperliquid address`
 3. If you see `status: needs_deposit` — bridge Arbitrum USDC into Hyperliquid (arrives in 2–5 min): `hyperliquid deposit --amount 50 --confirm`


### PR DESCRIPTION
## Summary

Replace bold `**Overview**` / `**Prerequisites**` / `**Quick Start**` with `## Overview` / `## Prerequisites` / `## Quick Start` in `skills/hyperliquid-plugin/SUMMARY.md`.

User feedback: in the webview, the current bold section titles blend into the body copy and do not look like section headings. H2 should render as proper headings.

## Why H2 specifically

- `**bold**` is just styled body text — webview renders it almost identically to the paragraph around it
- `## H2` is a real markdown heading — webview renders it at a larger size with clear visual separation

## Scope

- Single file: `skills/hyperliquid-plugin/SUMMARY.md`
- 3 lines changed (each section title: `**X**` → `## X`)
- No content changes (paragraphs, bullets, numbered steps untouched)

## Follow-up

This PR is intentionally scoped to hyperliquid-plugin only so we can verify the webview rendering first. If H2 looks right in the webview, a follow-up PR will batch-align the other 9 SUMMARY.md files that currently use bold section titles.

Docs-only change — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)