### PR TITLE
docs(pancakeswap-v2): ## headings, quickstart step, fix flag names

### DIFF
--- a/skills/pancakeswap-v2-plugin/SUMMARY.md
+++ b/skills/pancakeswap-v2-plugin/SUMMARY.md
@@ -1,18 +1,22 @@
-**Overview**
+## Overview
 
 Swap tokens and manage liquidity on PancakeSwap V2's constant-product AMM (0.25% fee) across BSC, Base, and Arbitrum — LP tokens are standard ERC-20 and composable with other DeFi protocols.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some tokens on a supported chain — BSC (default), Base, or Arbitrum
 
-**How it Works**
-1. **Swap**:
-   - 1.1 **Get a quote**: Check the expected output before committing — no gas. `pancakeswap-v2-plugin quote --token-in USDT --token-out CAKE --amount-in <amount>`
-   - 1.2 **Execute the swap**: Send input token and receive output — ERC-20 approval fires automatically if needed. `pancakeswap-v2-plugin swap --token-in USDT --token-out CAKE --amount-in <amount> --confirm`
-2. **Provide liquidity**:
-   - 2.1 **Look up a pair**: Find the LP contract address for a token pair. `pancakeswap-v2-plugin get-pair --token-a CAKE --token-b BNB`
-   - 2.2 **Check reserves**: See the current token balances and implied price in a pair. `pancakeswap-v2-plugin get-reserves --pair <address>`
-   - 2.3 **Add liquidity**: Deposit both tokens of the pair to receive LP tokens. `pancakeswap-v2-plugin add-liquidity --token-a CAKE --token-b BNB --amount-a <amount-a> --amount-b <amount-b> --confirm`
-   - 2.4 **Check LP balance**: View your LP token holdings for a pair. `pancakeswap-v2-plugin lp-balance --pair <address>`
-   - 2.5 **Remove liquidity**: Burn LP tokens to withdraw your proportional share of the pool. `pancakeswap-v2-plugin remove-liquidity --pair <address> --liquidity <amount> --confirm`
+## How it Works
+1. **Check your wallet**: Get a personalised next step based on your balances on the active chain. `pancakeswap-v2-plugin quickstart`
+   - If `status: no_funds` or `needs_gas` — fund your wallet with the native gas token first
+   - If `status: needs_funds` — you have gas but no tokens; transfer tokens to your wallet or swap the native token
+   - If `status: ready` — proceed below
+2. **Swap**:
+   - 2.1 **Get a quote**: Check the expected output before committing — no gas. `pancakeswap-v2-plugin quote --token-in USDT --token-out CAKE --amount-in <amount>`
+   - 2.2 **Execute the swap**: Send input token and receive output — ERC-20 approval fires automatically if needed. `pancakeswap-v2-plugin swap --token-in USDT --token-out CAKE --amount-in <amount> --confirm`
+3. **Provide liquidity**:
+   - 3.1 **Look up a pair**: Find the LP contract address for a token pair. `pancakeswap-v2-plugin get-pair --token-a CAKE --token-b BNB`
+   - 3.2 **Check reserves**: See the current token balances and implied price in a pair. `pancakeswap-v2-plugin get-reserves --token-a CAKE --token-b BNB`
+   - 3.3 **Add liquidity**: Deposit both tokens of the pair to receive LP tokens. `pancakeswap-v2-plugin add-liquidity --token-a CAKE --token-b BNB --amount-a <amount-a> --amount-b <amount-b> --confirm`
+   - 3.4 **Check LP balance**: View your LP token holdings for a pair. `pancakeswap-v2-plugin lp-balance --token-a CAKE --token-b BNB`
+   - 3.5 **Remove liquidity**: Burn LP tokens to withdraw your proportional share of the pool. `pancakeswap-v2-plugin remove-liquidity --token-a CAKE --token-b BNB --liquidity <amount> --confirm`


### PR DESCRIPTION
## Summary

- Convert section headers from `**bold**` to `## markdown`
- Add `pancakeswap-v2-plugin quickstart` as step 1 with status-based guidance (`ready`, `needs_gas`, `no_funds`)
- Fix `--pair <address>` → `--token-a/--token-b` on three commands (binary takes token symbols/addresses, not pair contract address):
  - `get-reserves --pair` → `get-reserves --token-a/--token-b`
  - `lp-balance --pair` → `lp-balance --token-a/--token-b`
  - `remove-liquidity --pair` → `remove-liquidity --token-a/--token-b`
- Renumber steps 1–2 → 2–3 to accommodate quickstart

## Files Changed

| File | Change |
|------|--------|
| `skills/pancakeswap-v2-plugin/SUMMARY.md` | `##` headings, quickstart, flag fixes, renumbering |

## Verification

All flags cross-checked against binary:
- `quote --token-in/--token-out/--amount-in` ✅
- `swap --token-in/--token-out/--amount-in` ✅
- `get-pair --token-a/--token-b` ✅
- `get-reserves --token-a/--token-b` ✅ (was `--pair`)
- `add-liquidity --token-a/--token-b/--amount-a/--amount-b` ✅
- `lp-balance --token-a/--token-b` ✅ (was `--pair`)
- `remove-liquidity --token-a/--token-b/--liquidity` ✅ (was `--pair`)

Quickstart statuses confirmed from source: `ready`, `needs_gas`, `no_funds`.

## Notes

The `quickstart` command is implemented in source but the currently released binary predates it — a binary release will be needed for step 1 to be usable.

## Checklist

- [x] Only modifies files under `skills/pancakeswap-v2-plugin/`
- [x] All command flags verified against binary
- [x] Follows updated format (## headings, Overview → Prerequisites → How it Works)