### PR TITLE
docs(aave-v3): ## headings, quickstart step, fix command and flag names

### DIFF
--- a/skills/aave-v3-plugin/SUMMARY.md
+++ b/skills/aave-v3-plugin/SUMMARY.md
@@ -1,17 +1,22 @@
-**Overview**
+## Overview
 
 Supply assets and borrow against collateral on Aave V3 across Ethereum, Base, Polygon, and Arbitrum — with real-time Health Factor tracking to prevent liquidation.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - Some tokens on a supported chain — Ethereum, Base (default), Polygon, or Arbitrum
 
-**How it Works**
-1. **Supply**:
-   - 1.1 **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin get-reserves`
-   - 1.2 **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount <amount> --confirm`
-   - 1.3 **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
-2. **Borrow** (requires collateral supplied first; Health Factor must stay above 1.0):
-   - 2.1 **Borrow**: Draw against your supplied collateral — choose variable or stable rate. `aave-v3-plugin borrow --asset WETH --amount <amount> --rate-mode variable --confirm`
-   - 2.2 **Repay**: Return borrowed assets and free up collateral — use `--amount max` to repay in full. `aave-v3-plugin repay --asset WETH --amount <amount> --confirm`
-   - 2.3 **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount <amount> --confirm`
+## How it Works
+1. **Check your wallet**: Get a personalised next step based on your balances and active positions. `aave-v3-plugin quickstart`
+   - If `status: no_funds` or `needs_gas` — fund your wallet first
+   - If `status: needs_funds` — you have gas but no assets to supply; add USDC or WETH to your wallet
+   - If `status: ready` — proceed to supply below
+   - If `status: active` — you already have a position; monitor your Health Factor
+2. **Supply**:
+   - 2.1 **Check available markets**: Browse assets with supply APY, borrow rate, and utilization. `aave-v3-plugin reserves`
+   - 2.2 **Supply assets**: Deposit tokens to earn yield — ERC-20 approval fires automatically. `aave-v3-plugin supply --asset USDC --amount <amount> --confirm`
+   - 2.3 **Monitor your position**: View total collateral, debt, borrow power, and Health Factor. `aave-v3-plugin positions`
+3. **Borrow** (requires collateral supplied first; Health Factor must stay above 1.0):
+   - 3.1 **Borrow**: Draw against your supplied collateral at the variable rate. `aave-v3-plugin borrow --asset WETH --amount <amount> --confirm`
+   - 3.2 **Repay**: Return borrowed assets and free up collateral — use `--all` to repay in full. `aave-v3-plugin repay --asset WETH --amount <amount> --confirm`
+   - 3.3 **Withdraw collateral**: Reclaim supplied assets — only possible while Health Factor stays above 1.0. `aave-v3-plugin withdraw --asset USDC --amount <amount> --confirm`


### PR DESCRIPTION
## Summary

- Convert section headers from `**bold**` to `## markdown`
- Add `aave-v3-plugin quickstart` as step 1 with status-based guidance (`active`, `ready`, `needs_gas`, `no_funds`)
- Fix three command/flag mismatches:
  - `get-reserves` → `reserves` (command was renamed)
  - `borrow --rate-mode variable` → remove `--rate-mode` (flag does not exist in binary)
  - `repay --amount max` → `repay --all` (full repayment uses `--all` flag, not `--amount max`)
- Renumber steps 1–2 → 2–3 to accommodate quickstart

## Files Changed

| File | Change |
|------|--------|
| `skills/aave-v3-plugin/SUMMARY.md` | `##` headings, quickstart, command/flag fixes, renumbering |

## Verification

All flags cross-checked against binary:
- `reserves` ✅ (was `get-reserves`)
- `supply --asset/--amount` ✅
- `positions` ✅
- `borrow --asset/--amount` ✅ (`--rate-mode` removed — not in binary)
- `repay --asset/--amount/--all` ✅ (was `--amount max`)
- `withdraw --asset/--amount` ✅

Quickstart statuses confirmed from source: `active`, `ready`, `needs_gas`, `no_funds`.

## Notes

The `quickstart` command is implemented in source but the currently released binary predates it — a binary release will be needed for step 1 to be usable.

## Checklist

- [x] Only modifies files under `skills/aave-v3-plugin/`
- [x] All command flags verified against binary
- [x] Follows updated format (## headings, Overview → Prerequisites → How it Works)