### PR TITLE
docs(pancakeswap-clmm-plugin): ## headings, quickstart step, add collect-fees

### DIFF
--- a/skills/pancakeswap-clmm-plugin/SUMMARY.md
+++ b/skills/pancakeswap-clmm-plugin/SUMMARY.md
@@ -8,8 +8,8 @@ Stake PancakeSwap V3 LP NFTs into MasterChefV3 to earn CAKE rewards on top of sw
 - Native gas token in your wallet (BNB on BSC, ETH on Ethereum / Base / Arbitrum)
 
 ## How it Works
-1. **Check your wallet**: Get a personalised next step based on your BNB balance and existing positions. `pancakeswap-clmm-plugin quickstart`
-   - If `status: needs_gas` — send at least 0.005 BNB to your wallet first
+1. **Check your wallet**: Get a personalised next step based on your gas balance and existing positions. `pancakeswap-clmm-plugin quickstart`
+   - If `status: needs_gas` — top up the native gas token for your chain (BNB on BSC, ETH on Ethereum / Base / Arbitrum)
    - If `status: ready` — proceed to view positions below
 2. **Get an LP NFT** (skip if you already have one):
    - 2.1 **Find a pool**: Look up available fee tiers for your token pair — `pancakeswap-v3-plugin pools --token-a CAKE --token-b BNB`

--- a/skills/pancakeswap-clmm-plugin/SUMMARY.md
+++ b/skills/pancakeswap-clmm-plugin/SUMMARY.md
@@ -5,7 +5,7 @@ Stake PancakeSwap V3 LP NFTs into MasterChefV3 to earn CAKE rewards on top of sw
 ## Prerequisites
 - onchainos agentic wallet connected
 - A PancakeSwap V3 LP NFT (create one with `pancakeswap-v3-plugin`)
-- Some BNB in your wallet for gas
+- Native gas token in your wallet (BNB on BSC, ETH on Ethereum / Base / Arbitrum)
 
 ## How it Works
 1. **Check your wallet**: Get a personalised next step based on your BNB balance and existing positions. `pancakeswap-clmm-plugin quickstart`

--- a/skills/pancakeswap-clmm-plugin/SUMMARY.md
+++ b/skills/pancakeswap-clmm-plugin/SUMMARY.md
@@ -1,19 +1,23 @@
-**Overview**
+## Overview
 
 Stake PancakeSwap V3 LP NFTs into MasterChefV3 to earn CAKE rewards on top of swap fees — with harvest, unfarm, and collect-fees commands across BSC, Ethereum, Base, and Arbitrum.
 
-**Prerequisites**
+## Prerequisites
 - onchainos agentic wallet connected
 - A PancakeSwap V3 LP NFT (create one with `pancakeswap-v3-plugin`)
 - Some BNB in your wallet for gas
 
-**How it Works**
-1. **Get an LP NFT** (skip if you already have one):
-   - 1.1 **Find a pool**: Look up available fee tiers for your token pair — `pancakeswap-v3-plugin pools --token-a CAKE --token-b BNB`
-   - 1.2 **Mint the LP position**: Provide liquidity to receive an LP NFT — note the token ID in the output. `pancakeswap-v3-plugin add-liquidity --token-a CAKE --token-b BNB --fee 2500 --amount-a <amount-a> --amount-b <amount-b> --confirm`
-2. **Check existing positions**: See all your V3 LP NFTs — both staked and unstaked. `pancakeswap-clmm-plugin positions`
-3. **Browse farming pools**: Find pools with active CAKE emissions and their allocation points. `pancakeswap-clmm-plugin farm-pools`
-4. **Stake the NFT**: Deposit your LP NFT into MasterChefV3 to start earning CAKE — preview first, add `--confirm` to execute. `pancakeswap-clmm-plugin farm --token-id <TOKEN_ID> --confirm`
-5. **Check pending rewards**: See how much CAKE has accrued since staking. `pancakeswap-clmm-plugin pending-rewards --token-id <TOKEN_ID>`
-6. **Harvest CAKE**: Claim rewards without withdrawing your LP position. `pancakeswap-clmm-plugin harvest --token-id <TOKEN_ID> --confirm`
-7. **Stop farming**: Withdraw the NFT and harvest all remaining CAKE in one transaction. `pancakeswap-clmm-plugin unfarm --token-id <TOKEN_ID> --confirm`
+## How it Works
+1. **Check your wallet**: Get a personalised next step based on your BNB balance and existing positions. `pancakeswap-clmm-plugin quickstart`
+   - If `status: needs_gas` — send at least 0.005 BNB to your wallet first
+   - If `status: ready` — proceed to view positions below
+2. **Get an LP NFT** (skip if you already have one):
+   - 2.1 **Find a pool**: Look up available fee tiers for your token pair — `pancakeswap-v3-plugin pools --token-a CAKE --token-b BNB`
+   - 2.2 **Mint the LP position**: Provide liquidity to receive an LP NFT — note the token ID in the output. `pancakeswap-v3-plugin add-liquidity --token-a CAKE --token-b BNB --fee 2500 --amount-a <amount-a> --amount-b <amount-b> --confirm`
+3. **Check existing positions**: See all your V3 LP NFTs — both staked and unstaked. `pancakeswap-clmm-plugin positions`
+4. **Browse farming pools**: Find pools with active CAKE emissions and their allocation points. `pancakeswap-clmm-plugin farm-pools`
+5. **Stake the NFT**: Deposit your LP NFT into MasterChefV3 to start earning CAKE — preview first, add `--confirm` to execute. `pancakeswap-clmm-plugin farm --token-id <TOKEN_ID> --confirm`
+6. **Check pending rewards**: See how much CAKE has accrued since staking. `pancakeswap-clmm-plugin pending-rewards --token-id <TOKEN_ID>`
+7. **Harvest CAKE**: Claim rewards without withdrawing your LP position. `pancakeswap-clmm-plugin harvest --token-id <TOKEN_ID> --confirm`
+8. **Collect swap fees**: Claim accumulated trading fees from an unstaked LP position. `pancakeswap-clmm-plugin collect-fees --token-id <TOKEN_ID> --confirm`
+9. **Stop farming**: Withdraw the NFT and harvest all remaining CAKE in one transaction. `pancakeswap-clmm-plugin unfarm --token-id <TOKEN_ID> --confirm`

--- a/skills/pancakeswap-clmm-plugin/SUMMARY.md
+++ b/skills/pancakeswap-clmm-plugin/SUMMARY.md
@@ -9,7 +9,7 @@ Stake PancakeSwap V3 LP NFTs into MasterChefV3 to earn CAKE rewards on top of sw
 
 ## How it Works
 1. **Check your wallet**: Get a personalised next step based on your gas balance and existing positions. `pancakeswap-clmm-plugin quickstart`
-   - If `status: needs_gas` — top up the native gas token for your chain (BNB on BSC, ETH on Ethereum / Base / Arbitrum)
+   - If `status: needs_gas` — the quickstart checks your BSC wallet; send at least 0.005 BNB first. For other chains, ensure you have the native gas token (ETH on Ethereum / Base / Arbitrum)
    - If `status: ready` — proceed to view positions below
 2. **Get an LP NFT** (skip if you already have one):
    - 2.1 **Find a pool**: Look up available fee tiers for your token pair — `pancakeswap-v3-plugin pools --token-a CAKE --token-b BNB`


### PR DESCRIPTION
## Summary

- Apply `##` section headings to Overview / Prerequisites / How it Works
- Add `quickstart` as step 1 with statuses: `ready`, `needs_gas`
- Add missing `collect-fees` step (command exists in binary but was absent from docs)
- Renumber existing steps 1–7 → 2–9 to accommodate new steps
- No flag changes — existing commands were already correct

## Files Changed

| File | Change |
|------|--------|
| `skills/pancakeswap-clmm-plugin/SUMMARY.md` | ## headings, quickstart step 1, collect-fees step 8, renumbered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)