### PR TITLE
feat(polymarket-plugin): add quickstart command with 7-state onboarding (v0.4.9)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit, BTC 5分钟, ETH 5分钟, 5分钟市场, 5min market, 五分钟市场, 短线市场, list 5-minute, BTC up or down, 找5分钟, 看5分钟, 5m updown, crypto 5m, 5分钟涨跌, 五分钟涨跌, updown market, BTC 5min, ETH 5min, SOL 5min, 5分钟预测."
-version: "0.4.8"
+version: "0.4.9"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.8"
+LOCAL_VER="0.4.9"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.8/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.9/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.8"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.9"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -309,7 +309,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket-plugin --version
 ```
 
-Expected: `polymarket-plugin 0.4.8`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket-plugin 0.4.9`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -357,6 +357,7 @@ Shows both EOA and proxy wallet balances. EOA mode → check `eoa_wallet.usdc_e`
 
 | Command | Auth | Description |
 |---------|------|-------------|
+| `quickstart` | No | Check wallet state and get a guided next-step command |
 | `check-access` | No | Verify region is not restricted |
 | `list-markets` | No | Browse active prediction markets |
 | `get-market` | No | Get market details and order book |
@@ -369,6 +370,47 @@ Shows both EOA and proxy wallet balances. EOA mode → check `eoa_wallet.usdc_e`
 | `setup-proxy` | Yes | Deploy proxy wallet for gasless trading (one-time) |
 | `deposit` | Yes | Transfer USDC.e from EOA to proxy wallet |
 | `switch-mode` | Yes | Switch default trading mode (eoa / proxy) |
+
+---
+
+### `quickstart` — Check Status and Get a Guided Next Step
+
+**Trigger phrases:** get started with polymarket, just installed polymarket, how do I use polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, 怎么开始用 polymarket, 我要开始玩 polymarket
+
+```
+polymarket-plugin quickstart [--address <ADDRESS>]
+```
+
+**Auth required:** No
+
+**How it works:** In parallel, checks CLOB region access, reads EOA POL + USDC.e balances, reads proxy USDC.e balance (if `setup-proxy` has been run), and queries open positions on the maker wallet (proxy if initialized, else EOA). Computes a `status` and returns a ready-to-run `next_command`. Silently tolerates transient RPC failures (returns 0 balance + still emits guidance) — this command is a status probe, not a trading command.
+
+**Parameters:**
+- `--address <ADDRESS>` (optional) — Query a specific wallet instead of the connected onchainos wallet
+
+**Output fields:** `ok`, `about`, `wallet.eoa`, `wallet.proxy` (null if not set up), `accessible` (bool), `assets.eoa_pol`, `assets.eoa_usdc_e`, `assets.proxy_usdc_e` (only if proxy initialized), `positions` (summary array), `open_positions_count`, `status`, `suggestion`, `next_command`, `onboarding_steps` (optional array)
+
+**Status values:**
+
+| `status` | Meaning | Recommended next step |
+|----------|---------|-----------------------|
+| `restricted` | CLOB blocked this IP (US / OFAC) | Switch region, re-run |
+| `active` | Has open positions | `polymarket-plugin get-positions` |
+| `proxy_ready` | Proxy wallet funded ≥ $5 USDC.e | `polymarket-plugin list-markets` → `buy` (gasless) |
+| `needs_deposit` | Proxy set up but under-funded; EOA has ≥ $5 | `polymarket-plugin deposit --amount <N>` |
+| `needs_setup` | EOA has ≥ $5 but proxy not set up (default: recommend gasless) | `polymarket-plugin setup-proxy` |
+| `low_balance` | EOA has some USDC.e but below $5 minimum | Top up EOA, re-run |
+| `no_funds` | EOA has no USDC.e | Send USDC.e to EOA on Polygon, re-run |
+
+> Use `next_command` directly — it is already formatted with a reasonable deposit amount (90 % of EOA USDC.e, floored to cents, clamped to ≥ $5) where applicable.
+
+**Agent flow:** Run this first for any new/returning user before `buy` or `balance`. Relay `status` and `suggestion` to the user, then either execute `next_command` or let the user decide. For `restricted` / `low_balance` / `no_funds`, do not proceed with trading commands.
+
+**Example:**
+```bash
+polymarket-plugin quickstart
+# status: needs_setup → next_command: polymarket-plugin setup-proxy
+```
 
 ---
 

--- a/skills/polymarket-plugin/SUMMARY.md
+++ b/skills/polymarket-plugin/SUMMARY.md
@@ -5,7 +5,7 @@ Polymarket is a prediction market protocol on Polygon where users trade YES/NO o
 ## Prerequisites
 - onchainos CLI installed and logged in with a Polygon address (chain 137)
 - USDC.e on Polygon for trading (≥ $5 recommended for a first test trade)
-- POL for gas in EOA mode (default; each buy/sell does an on-chain approve) — skip with one-time POLY_PROXY setup
+- Recommended: run `setup-proxy` once for gasless trading (Polymarket's relayer pays gas). Fallback EOA mode needs POL on Polygon for every buy/sell approval
 - Accessible region — Polymarket blocks the US and OFAC-sanctioned jurisdictions
 
 ## Quick Start

--- a/skills/polymarket-plugin/SUMMARY.md
+++ b/skills/polymarket-plugin/SUMMARY.md
@@ -1,19 +1,19 @@
-**Overview**
+## Overview
 
 Polymarket is a prediction market protocol on Polygon where users trade YES/NO outcome shares of real-world events. This skill lets you browse markets (including 5-minute crypto up/down markets), buy and sell outcome shares, check positions, cancel orders, redeem winning tokens, and optionally set up a proxy wallet for gasless trading.
 
-**Prerequisites**
+## Prerequisites
 - onchainos CLI installed and logged in with a Polygon address (chain 137)
 - USDC.e on Polygon for trading (≥ $5 recommended for a first test trade)
 - POL for gas in EOA mode (default; each buy/sell does an on-chain approve) — skip with one-time POLY_PROXY setup
 - Accessible region — Polymarket blocks the US and OFAC-sanctioned jurisdictions
 
-**Quick Start**
-1. Verify your region is not restricted: `polymarket-plugin check-access`
-2. Check balances on both EOA and proxy wallets: `polymarket-plugin balance`
-3. (Optional, recommended) Switch to gasless mode by creating a proxy wallet and funding it: `polymarket-plugin setup-proxy` then `polymarket-plugin deposit --amount 50`
-4. Browse active markets by keyword, or list 5-minute crypto up/down markets: `polymarket-plugin list-markets --keyword "trump"` or `polymarket-plugin list-5m`
-5. Get details and order book for a specific market: `polymarket-plugin get-market --market-id <SLUG>`
-6. Buy YES or NO outcome shares at market price: `polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5`
-7. Review your open positions and P&L: `polymarket-plugin get-positions`
+## Quick Start
+1. Check your current state and get a guided next step: `polymarket-plugin quickstart`
+2. If you see `status: restricted` — switch to an accessible region and re-run `polymarket-plugin quickstart`
+3. If you see `status: no_funds` / `low_balance` — send ≥ $5 USDC.e to your EOA wallet on Polygon (chain 137); view the address with `polymarket-plugin balance`
+4. If you see `status: needs_setup` — create the Polymarket proxy wallet (one-time POL gas) for gasless trading: `polymarket-plugin setup-proxy`
+5. If you see `status: needs_deposit` — deposit EOA USDC.e into your proxy wallet: `polymarket-plugin deposit --amount 50`
+6. If you see `status: proxy_ready` — browse markets and place your first gasless order: `polymarket-plugin list-markets` → `polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5`
+7. If you see `status: active` — review open positions and P&L: `polymarket-plugin get-positions`
 8. Exit a position, or redeem winnings when the market resolves: `polymarket-plugin sell --market-id <SLUG> --outcome yes --amount 5` / `polymarket-plugin redeem --market-id <SLUG>`

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.8"
+version: "0.4.9"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/mod.rs
+++ b/skills/polymarket-plugin/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod get_positions;
 pub mod get_series;
 pub mod list_5m;
 pub mod list_markets;
+pub mod quickstart;
 pub mod redeem;
 pub mod sell;
 pub mod setup_proxy;

--- a/skills/polymarket-plugin/src/commands/quickstart.rs
+++ b/skills/polymarket-plugin/src/commands/quickstart.rs
@@ -1,0 +1,303 @@
+use clap::Args;
+use reqwest::Client;
+
+use crate::api::{check_clob_access, get_positions, Position};
+use crate::config::load_credentials;
+use crate::onchainos::{get_pol_balance, get_usdc_balance, get_wallet_address};
+
+const ABOUT: &str = "Polymarket is the largest prediction-market protocol on Polygon — trade YES/NO outcome tokens on real-world events with USDC.e. This skill supports both EOA and Polymarket proxy (gasless) trading modes.";
+
+/// Minimum USD balance for a first deposit or first trade.
+const MIN_FUND: f64 = 5.0;
+
+/// Minimum POL balance considered sufficient to run `setup-proxy` (needs one tx gas).
+const MIN_POL_FOR_SETUP: f64 = 0.05;
+
+#[derive(Args)]
+pub struct QuickstartArgs {
+    /// Wallet address to query. Defaults to the connected onchainos wallet.
+    #[arg(long)]
+    pub address: Option<String>,
+}
+
+pub async fn run(args: QuickstartArgs) -> anyhow::Result<()> {
+    let client = Client::new();
+
+    // 1. Resolve EOA wallet (fails fast if onchainos CLI is not logged in)
+    let eoa = match args.address {
+        Some(addr) => addr,
+        None => get_wallet_address().await?,
+    };
+
+    eprintln!(
+        "Checking Polymarket status for {}...",
+        &eoa[..std::cmp::min(10, eoa.len())]
+    );
+
+    // 2. Read local creds — proxy_wallet is Some(addr) after `setup-proxy` has run
+    let proxy: Option<String> = load_credentials()
+        .ok()
+        .flatten()
+        .and_then(|c| c.proxy_wallet);
+
+    // 3. Positions belong to the maker wallet — proxy if it exists, else EOA
+    let primary_wallet = proxy.clone().unwrap_or_else(|| eoa.clone());
+
+    // 4. Parallel fetch: CLOB access + EOA POL + EOA USDC.e + positions
+    let (access_result, pol_result, eoa_usdc_result, positions_result) = tokio::join!(
+        check_clob_access(&client),
+        get_pol_balance(&eoa),
+        get_usdc_balance(&eoa),
+        get_positions(&client, &primary_wallet),
+    );
+
+    // 5. Optional: proxy USDC balance (only if proxy is initialized)
+    let proxy_usdc: Option<f64> = match &proxy {
+        Some(paddr) => get_usdc_balance(paddr).await.ok(),
+        None => None,
+    };
+
+    // Accessibility: check_clob_access returns Some(warning) when blocked
+    let accessible = access_result.is_none();
+    let access_warning = access_result;
+
+    // Silently tolerate RPC errors on balance/positions — quickstart is a status probe,
+    // not a trading command; returning 0 + a clear status is better than aborting.
+    let eoa_pol = pol_result.unwrap_or(0.0);
+    let eoa_usdc = eoa_usdc_result.unwrap_or(0.0);
+    let positions: Vec<Position> = positions_result.unwrap_or_default();
+    let open_positions_count = positions.len();
+
+    // Brief positions summary (cap at 10 to keep output readable)
+    let positions_summary: Vec<_> = positions
+        .iter()
+        .take(10)
+        .map(|p| {
+            serde_json::json!({
+                "title":             p.title,
+                "slug":              p.slug,
+                "outcome":           p.outcome,
+                "size":              p.size,
+                "avg_price":         p.avg_price,
+                "cur_price":         p.cur_price,
+                "current_value_usd": p.current_value,
+                "cash_pnl_usd":      p.cash_pnl,
+            })
+        })
+        .collect();
+
+    // 6. Build state-machine guidance
+    let (status, suggestion, onboarding_steps, next_command) = build_suggestion(
+        &eoa,
+        accessible,
+        access_warning.as_deref(),
+        proxy.as_deref(),
+        eoa_pol,
+        eoa_usdc,
+        proxy_usdc,
+        open_positions_count,
+    );
+
+    let mut assets = serde_json::json!({
+        "eoa_pol":    format!("{:.4}", eoa_pol),
+        "eoa_usdc_e": format!("{:.2}", eoa_usdc),
+    });
+    if let Some(u) = proxy_usdc {
+        assets["proxy_usdc_e"] = serde_json::json!(format!("{:.2}", u));
+    }
+
+    let mut out = serde_json::json!({
+        "ok":    true,
+        "about": ABOUT,
+        "wallet": {
+            "eoa":   eoa,
+            "proxy": proxy,
+        },
+        "accessible":           accessible,
+        "assets":               assets,
+        "positions":            positions_summary,
+        "open_positions_count": open_positions_count,
+        "status":               status,
+        "suggestion":           suggestion,
+        "next_command":         next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = serde_json::json!(onboarding_steps);
+    }
+
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}
+
+/// Default deposit amount: 90% of EOA USDC.e, floored to cents, clamped to [MIN_FUND, eoa_usdc].
+fn suggest_deposit(eoa_usdc: f64) -> f64 {
+    let raw = (eoa_usdc * 0.9 * 100.0).floor() / 100.0;
+    raw.max(MIN_FUND).min(eoa_usdc)
+}
+
+/// Returns (status, human-readable suggestion, onboarding_steps, ready-to-run command).
+fn build_suggestion(
+    eoa: &str,
+    accessible: bool,
+    access_warning: Option<&str>,
+    proxy: Option<&str>,
+    eoa_pol: f64,
+    eoa_usdc: f64,
+    proxy_usdc: Option<f64>,
+    open_positions: usize,
+) -> (&'static str, String, Vec<String>, String) {
+    // Case 1: region-locked — Polymarket blocks US and OFAC jurisdictions
+    if !accessible {
+        let base = "Polymarket is not accessible from this network. \
+                    The CLOB may be blocking your IP (US/OFAC jurisdictions are blocked). \
+                    Switch to an accessible region before continuing.";
+        let msg = match access_warning {
+            Some(w) => format!("{base} Detail: {w}"),
+            None => base.to_string(),
+        };
+        return (
+            "restricted",
+            msg,
+            vec![],
+            "polymarket-plugin check-access".to_string(),
+        );
+    }
+
+    // Case 2: active trader — has open positions on the maker wallet
+    if open_positions > 0 {
+        return (
+            "active",
+            format!(
+                "You have {} open position(s) on Polymarket. Review them below.",
+                open_positions
+            ),
+            vec![],
+            "polymarket-plugin get-positions".to_string(),
+        );
+    }
+
+    // Case 3: proxy wallet exists (setup-proxy has been run)
+    if proxy.is_some() {
+        let pu = proxy_usdc.unwrap_or(0.0);
+
+        // 3a. proxy_ready — gasless trading is fully set up
+        if pu >= MIN_FUND {
+            return (
+                "proxy_ready",
+                format!(
+                    "Proxy wallet is funded (${:.2} USDC.e). Place your first gasless trade.",
+                    pu
+                ),
+                vec![
+                    "1. Browse active markets:".to_string(),
+                    "   polymarket-plugin list-markets".to_string(),
+                    "2. (Optional) Pick a 5-minute crypto up/down market:".to_string(),
+                    "   polymarket-plugin list-5m".to_string(),
+                    "3. Preview a buy with --dry-run:".to_string(),
+                    "   polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5 --dry-run"
+                        .to_string(),
+                    "4. When ready, remove --dry-run to submit the order:".to_string(),
+                    "   polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5"
+                        .to_string(),
+                ],
+                "polymarket-plugin list-markets".to_string(),
+            );
+        }
+
+        // 3b. needs_deposit — proxy exists but under-funded; EOA has enough to deposit
+        if eoa_usdc >= MIN_FUND {
+            let suggest = suggest_deposit(eoa_usdc);
+            return (
+                "needs_deposit",
+                format!(
+                    "Proxy wallet has ${:.2} USDC.e — below the $5 minimum. Deposit from your EOA wallet (${:.2} USDC.e available).",
+                    pu, eoa_usdc
+                ),
+                vec![
+                    "1. Deposit USDC.e from EOA into the proxy wallet (gasless):".to_string(),
+                    format!("   polymarket-plugin deposit --amount {:.2}", suggest),
+                    "2. Re-run quickstart to confirm the proxy is funded:".to_string(),
+                    "   polymarket-plugin quickstart".to_string(),
+                    "3. Place your first gasless trade:".to_string(),
+                    "   polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5"
+                        .to_string(),
+                ],
+                format!("polymarket-plugin deposit --amount {:.2}", suggest),
+            );
+        }
+        // 3c. proxy exists but neither proxy nor EOA has enough — fall through to low_balance/no_funds
+    }
+
+    // Case 4: EOA has enough USDC.e but proxy not set up → guide to setup-proxy (gasless default)
+    if eoa_usdc >= MIN_FUND {
+        let suggest = suggest_deposit(eoa_usdc);
+        let mut steps = vec![
+            "1. Create a Polymarket proxy wallet (one-time POL gas):".to_string(),
+            "   polymarket-plugin setup-proxy".to_string(),
+            "2. Deposit USDC.e from EOA into the proxy wallet:".to_string(),
+            format!("   polymarket-plugin deposit --amount {:.2}", suggest),
+            "3. Re-run quickstart to confirm the proxy is ready:".to_string(),
+            "   polymarket-plugin quickstart".to_string(),
+            "4. Place your first gasless trade:".to_string(),
+            "   polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5".to_string(),
+        ];
+        if eoa_pol < MIN_POL_FOR_SETUP {
+            steps.insert(
+                0,
+                format!(
+                    "0. First top up POL on your EOA wallet ({} POL needed for setup-proxy gas; current: {:.4} POL). Send POL to:",
+                    MIN_POL_FOR_SETUP, eoa_pol
+                ),
+            );
+            steps.insert(1, format!("   {}", eoa));
+        }
+        return (
+            "needs_setup",
+            format!(
+                "You have ${:.2} USDC.e on your EOA wallet. Recommended: set up a Polymarket proxy wallet for gasless trading.",
+                eoa_usdc
+            ),
+            steps,
+            "polymarket-plugin setup-proxy".to_string(),
+        );
+    }
+
+    // Case 5: low_balance — some USDC.e on EOA but below $5 minimum
+    if eoa_usdc > 0.0 {
+        return (
+            "low_balance",
+            format!(
+                "You have ${:.2} USDC.e on your EOA wallet — below the $5 minimum for a first deposit. Top up to at least $5.",
+                eoa_usdc
+            ),
+            vec![
+                "1. Send at least $5 USDC.e to your EOA wallet on Polygon (chain 137):".to_string(),
+                format!("   {}", eoa),
+                "2. Re-run quickstart to confirm your balance:".to_string(),
+                "   polymarket-plugin quickstart".to_string(),
+                "3. Set up the proxy wallet for gasless trading:".to_string(),
+                "   polymarket-plugin setup-proxy".to_string(),
+            ],
+            "polymarket-plugin balance".to_string(),
+        );
+    }
+
+    // Case 6: no_funds — EOA is empty
+    (
+        "no_funds",
+        "No USDC.e found on your EOA wallet. Send USDC.e to your EOA on Polygon (chain 137) to get started (minimum $5).".to_string(),
+        vec![
+            "1. Send USDC.e to your EOA wallet on Polygon (chain 137) — minimum $5:".to_string(),
+            format!("   {}", eoa),
+            "2. Re-run quickstart to confirm your balance:".to_string(),
+            "   polymarket-plugin quickstart".to_string(),
+            "3. Set up the proxy wallet for gasless trading:".to_string(),
+            "   polymarket-plugin setup-proxy".to_string(),
+            "4. Deposit USDC.e to the proxy, then place your first trade:".to_string(),
+            "   polymarket-plugin deposit --amount 5".to_string(),
+            "   polymarket-plugin buy --market-id <SLUG> --outcome yes --amount 5".to_string(),
+        ],
+        "polymarket-plugin balance".to_string(),
+    )
+}

--- a/skills/polymarket-plugin/src/main.rs
+++ b/skills/polymarket-plugin/src/main.rs
@@ -22,6 +22,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Check wallet assets and get a recommended next step (region check, balances, positions, onboarding guidance)
+    Quickstart(commands::quickstart::QuickstartArgs),
+
     /// Check whether Polymarket is accessible from your current IP (run before topping up USDC)
     CheckAccess,
 
@@ -289,6 +292,9 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
+        Commands::Quickstart(args) => {
+            commands::quickstart::run(args).await
+        }
         Commands::CheckAccess => {
             commands::check_access::run().await
         }


### PR DESCRIPTION
## Summary

Adds a `quickstart` subcommand to `polymarket-plugin` that acts as a single-call status probe: it checks CLOB region access, reads EOA + proxy balances, queries open positions, and returns a `status` + ready-to-run `next_command`. Designed as the first command an agent (or new user) runs — every other command is dispatched from its output.

- New file: `src/commands/quickstart.rs` (303 lines) with a 7-state state machine
- Wired into `src/commands/mod.rs` and `src/main.rs` (listed first in `--help`)
- `SUMMARY.md`: bold section titles → H2, Quick Start rewritten as a status-dispatched checklist
- `SKILL.md`: new `### quickstart` section with params / output fields / status table / agent flow
- Version bump: `0.4.8` → `0.4.9` (PATCH, per owner decision) across 4 files + inline SKILL.md refs

## State machine

Defaults to guiding users toward the gasless proxy flow:

| status | Condition | next_command |
|---|---|---|
| `restricted` | CLOB blocks this IP (US/OFAC) | `polymarket-plugin check-access` |
| `active` | Has open positions | `polymarket-plugin get-positions` |
| `proxy_ready` | Proxy funded ≥ $5 USDC.e | `polymarket-plugin list-markets` |
| `needs_deposit` | Proxy set up, under-funded; EOA ≥ $5 | `polymarket-plugin deposit --amount <N>` |
| `needs_setup` | EOA ≥ $5, proxy not set up | `polymarket-plugin setup-proxy` |
| `low_balance` | EOA has some USDC.e but < $5 | `polymarket-plugin balance` |
| `no_funds` | EOA empty | `polymarket-plugin balance` |

Minimum balance threshold: `$5` for both EOA and proxy. Default deposit amount: 90 % of EOA USDC.e, floored to cents, clamped ≥ $5.

## Implementation notes

- **Non-blocking RPC**: balance and position calls use `unwrap_or(...)` so a transient RPC failure doesn't abort the command — it still emits guidance based on whatever state it could resolve. Matches the `hyperliquid-plugin quickstart` pattern. Explicit code comment explains the trade-off.
- **No new external domains**: reuses existing `check_clob_access`, `get_pol_balance`, `get_usdc_balance`, `get_positions` helpers. `plugin.yaml` `api_calls` unchanged.
- **No new CI risk**: no new warnings, binary `--version` reports `0.4.9`, `quickstart --help` shows only the documented `--address` flag.

## Test plan

- [x] `cargo build` passes (0 new warnings; 17 pre-existing dead-code warnings unchanged)
- [x] `polymarket-plugin --version` → `polymarket 0.4.9`
- [x] `polymarket-plugin quickstart --help` shows `--address` parameter
- [x] `polymarket-plugin --help` lists `quickstart` as the first command
- [x] 4-file version consistency verified (plugin.yaml / SKILL.md / Cargo.toml / plugin.json)
- [x] No `0.4.8` refs remain anywhere in the skill directory
- [x] common-bugs-knowledge-base scan: GEN-001 / EVM-012 / EVM-006 / EVM-005 / api_calls all clear
- [ ] Live run of each status branch (reviewer: pls verify against a test wallet if convenient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)