### PR TITLE
feat(defi-starter): new bundle skill to onboard new onchainos users to top DeFi plugins

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3,6 +3,31 @@
   "stats_url": "https://plugin-store-dun.vercel.app",
   "plugins": [
     {
+      "name": "defi-starter",
+      "version": "1.0.0",
+      "description": "Quick-start bundle for new onchainos users — installs the top featured DeFi plugins (Hyperliquid perps + Polymarket prediction markets) and guides you to your first trade",
+      "author": {
+        "name": "okx",
+        "github": "okx"
+      },
+      "license": "MIT",
+      "category": "defi-protocol",
+      "tags": [
+        "bundle",
+        "featured",
+        "starter",
+        "onboarding"
+      ],
+      "type": "official",
+      "components": {
+        "skill": {
+          "dir": "."
+        }
+      },
+      "api_calls": [],
+      "link": "https://github.com/okx/plugin-store"
+    },
+    {
       "name": "aave-v3-plugin",
       "version": "0.2.7",
       "description": "Lend and borrow crypto assets on Aave V3 — the leading decentralized liquidity protocol. Trigger phrases: supply to aave, deposit to aave, borrow from aave, repay aave loan, aave health factor, my aave positions, aave interest rates, enable emode, disable collateral, claim aave rewards.",
@@ -250,6 +275,7 @@
       "license": "MIT",
       "category": "defi-protocol",
       "tags": [
+        "featured",
         "perpetuals",
         "trading",
         "hyperliquid",
@@ -853,6 +879,7 @@
       "license": "MIT",
       "category": "defi-protocol",
       "tags": [
+        "featured",
         "prediction-market",
         "polymarket",
         "polygon",

--- a/skills/defi-starter/SKILL.md
+++ b/skills/defi-starter/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: defi-starter
+description: "Quick-start bundle for new onchainos users. Installs top featured DeFi plugins and guides you to your first on-chain trade. Trigger phrases: just installed onchainos, get started with DeFi, new to onchainos, what plugins should I install, recommend me plugins, help me get started, I want to try DeFi, what can I do with onchainos, I just set up onchainos, install top plugins, what are the best plugins, 刚安装了onchainos, 怎么开始, 推荐插件, 新用户, 帮我开始, 有什么好用的插件."
+version: "1.0.0"
+author: okx
+license: MIT
+---
+
+
+## Pre-flight Dependencies (auto-injected by Plugin Store CI)
+
+> Run once per session before first use. These checks ensure required tools are installed.
+
+### Install onchainos CLI + Skills (auto-injected)
+
+```bash
+# 1. Install onchainos CLI
+onchainos --version 2>/dev/null || curl -fsSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
+
+# 2. Install onchainos skills (enables AI agent to use onchainos commands)
+npx skills add okx/onchainos-skills --yes --global
+
+# 3. Install plugin-store skills (enables plugin discovery and management)
+npx skills add okx/plugin-store --skill plugin-store --yes --global
+```
+
+---
+
+
+# DeFi Starter Bundle
+
+A one-command quick-start for new onchainos users. Installs the top featured DeFi plugins and walks you through your first trade.
+
+## Proactive Onboarding
+
+When this skill is loaded — **immediately, without waiting for the user to ask** — run the following sequence:
+
+### Step 1 — Install featured plugins
+
+Run these back-to-back. Skip any that are already installed (check `plugin-store installed` first if unsure).
+
+```bash
+plugin-store install hyperliquid-plugin --yes
+plugin-store install polymarket-plugin --yes
+```
+
+After each install completes, immediately read the installed skill:
+```
+Read file: ~/.claude/skills/hyperliquid-plugin/SKILL.md
+Read file: ~/.claude/skills/polymarket-plugin/SKILL.md
+```
+
+### Step 2 — Present what was installed
+
+Tell the user (in their language) what is now available:
+
+> **Installed and ready:**
+>
+> | Plugin | What it does | First command |
+> |--------|--------------|---------------|
+> | **Hyperliquid** | Trade perpetuals (BTC, ETH, SOL…) with leverage on Hyperliquid's L1 DEX. Deposit USDC from Arbitrum. | `hyperliquid quickstart` |
+> | **Polymarket** | Trade prediction markets — buy YES/NO outcome tokens on Polygon. | `polymarket quickstart` |
+
+### Step 3 — Route to the chosen plugin
+
+Ask: **"Which would you like to start with — Hyperliquid or Polymarket?"**
+
+Then follow that plugin's Quickstart flow without further prompting:
+- Hyperliquid → run `hyperliquid quickstart`, follow the Hyperliquid SKILL.md proactive onboarding
+- Polymarket → run `polymarket quickstart`, follow the Polymarket SKILL.md proactive onboarding
+
+---
+
+## Quickstart
+
+```bash
+# Install featured plugins in one step
+plugin-store install hyperliquid-plugin --yes
+plugin-store install polymarket-plugin --yes
+```
+
+---
+
+## Plugin Overview
+
+### Hyperliquid — Perpetuals DEX
+
+High-performance on-chain perpetuals on its own L1, settling in USDC.
+
+**Best for:** Leveraged trading on BTC, ETH, SOL and 100+ other assets with tight spreads and no gas fees on trades.
+
+**Prerequisites:**
+- USDC on Arbitrum to deposit into Hyperliquid
+- Small amount of ETH on Arbitrum for bridging gas
+
+**Key commands:**
+- `hyperliquid quickstart` — check wallet state, get guided next step
+- `hyperliquid deposit --amount 50 --confirm` — bridge USDC from Arbitrum
+- `hyperliquid order --coin BTC --side buy --size 0.001 --leverage 5 --confirm` — place a leveraged order
+- `hyperliquid positions` — view open positions and P&L
+
+### Polymarket — Prediction Markets
+
+Trade YES/NO outcome tokens on real-world events (elections, sports, crypto prices) on Polygon.
+
+**Best for:** Taking positions on events, earning on prediction accuracy, trading market sentiment.
+
+**Prerequisites:**
+- USDC on Ethereum or Polygon
+- Small amount of ETH/MATIC for gas
+
+**Key commands:**
+- `polymarket quickstart` — check wallet and get guided next step
+- `polymarket list-markets --limit 10` — browse open markets
+- `polymarket buy --market <id> --outcome YES --amount 10 --confirm` — buy outcome tokens
+- `polymarket positions` — view current holdings
+
+---
+
+## Keeping the Bundle Current
+
+The set of featured plugins is maintained in the plugin-store registry. To see the current featured list:
+
+```bash
+plugin-store search featured
+```
+
+To update all installed plugins to the latest versions:
+
+```bash
+plugin-store update --all
+```
+
+---
+
+<rules>
+<must>
+  - On load, immediately install featured plugins without waiting for the user to ask
+  - After each plugin install, read its SKILL.md before presenting it to the user
+  - Ask which plugin the user wants to start with, then follow that plugin's own onboarding flow
+  - Respond in the user's language (English or Chinese)
+</must>
+<should>
+  - If a featured plugin is already installed, skip its install step and note it's already ready
+  - After routing to a plugin, hand off fully to that plugin's SKILL.md instructions — do not duplicate its onboarding here
+</should>
+<never>
+  - Never leave the user at a blank prompt after install — always present next steps
+  - Never attempt to manually construct transactions or sign messages — always use the plugin's own commands
+</never>
+</rules>

--- a/skills/defi-starter/SUMMARY.md
+++ b/skills/defi-starter/SUMMARY.md
@@ -1,0 +1,13 @@
+## Overview
+
+One-command quick-start for new onchainos users — installs the top featured DeFi plugins and walks you through your first trade on Hyperliquid (perps) or Polymarket (prediction markets).
+
+## Prerequisites
+- onchainos agentic wallet connected
+- plugin-store installed (`npx skills add okx/plugin-store --skill plugin-store`)
+
+## How it Works
+1. **Install the bundle**: Installs all currently featured DeFi plugins in one step. `plugin-store install defi-starter --yes`
+2. **Choose your first protocol**:
+   - **Hyperliquid** — trade perpetuals (BTC, ETH, SOL, etc.) with leverage, deposit from Arbitrum. `hyperliquid quickstart`
+   - **Polymarket** — trade prediction markets (YES/NO outcome tokens) on Polygon. `polymarket quickstart`

--- a/skills/defi-starter/plugin.yaml
+++ b/skills/defi-starter/plugin.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+name: defi-starter
+version: "1.0.0"
+description: "Quick-start bundle for new onchainos users — installs the top featured DeFi plugins and guides you to your first trade"
+author:
+  name: okx
+  github: okx
+category: defi-protocol
+tags:
+  - bundle
+  - featured
+  - starter
+  - onboarding
+  - hyperliquid
+  - polymarket
+license: MIT
+components:
+  skill:
+    dir: .
+api_calls: []

--- a/skills/plugin-store/SKILL.md
+++ b/skills/plugin-store/SKILL.md
@@ -141,6 +141,7 @@ Parse the output and present it to the user as a clean table (name, category, do
 
 | User Intent | Action |
 |---|---|
+| "just installed onchainos" / "new to onchainos" / "get started" / "刚安装了onchainos" / "新用户" / "怎么开始" | Run `plugin-store install defi-starter --yes` — installs featured plugins and triggers onboarding |
 | "What dapps / strategies / skills are available?" | Run `plugin-store list`, present results as a table |
 | "What can you do?" / capability discovery | Run `plugin-store list`, explain capabilities based on live output |
 | "Plugin商店有什么" / "有什么Plugin" / "有什么项目" | Run `plugin-store list`, present results as a table |
@@ -189,6 +190,26 @@ Parse the output and present it to the user as a clean table (name, category, do
 ---
 
 ## Operation Flow
+
+### Intent: New onchainos user / "just installed" / "get started"
+
+When the user signals they are new to onchainos or has no DeFi plugins yet:
+
+1. Check installed plugins:
+   ```bash
+   plugin-store installed
+   ```
+2. If no DeFi plugins are installed, say:
+   > "Welcome! I'll set you up with the top DeFi plugins in one step."
+3. Install the starter bundle:
+   ```bash
+   plugin-store install defi-starter --yes
+   ```
+4. After install, read the defi-starter SKILL.md and follow its onboarding flow:
+   ```
+   Read file: ~/.claude/skills/defi-starter/SKILL.md
+   ```
+5. If some DeFi plugins are already installed, skip to capability discovery below.
 
 ### Intent: Strategy / DApp / Capability Discovery
 


### PR DESCRIPTION
## Summary

New **defi-starter** bundle skill that reduces friction for new onchainos users getting into DeFi plugins.

### Problem
New onchainos users face multiple manual steps to discover and install DeFi plugins. There's no guided path from "just installed onchainos" to "first trade".

### Solution — Combined approach

**1. New `skills/defi-starter/` bundle skill (Type A — pure skill, no binary)**
- When installed, the agent immediately runs `plugin-store install hyperliquid-plugin --yes` + `plugin-store install polymarket-plugin --yes`
- Presents what was installed as a table, asks which to start with, then hands off to that plugin's own quickstart flow
- Trigger phrases in description cover "just installed onchainos", "get started with DeFi", "new to onchainos", "recommend me plugins", etc.

**2. `registry.json` changes**
- Added `defi-starter` entry (`type: official`, tags: `bundle`, `featured`, `starter`, `onboarding`)
- Added `featured` tag to `hyperliquid-plugin` and `polymarket-plugin` — this tag is what marks plugins as part of the bundle; updating the featured set in future only requires changing these tags, not defi-starter itself

**3. `skills/plugin-store/SKILL.md` changes**
- Added routing row: "just installed onchainos" / "new user" → `plugin-store install defi-starter --yes`
- Added "Intent: New onchainos user" operation flow that checks installed plugins, then installs defi-starter if nothing DeFi is installed yet

### User flow

```
New user installs onchainos
  → tells Claude "I just installed onchainos" or "help me get started"
  → plugin-store SKILL.md routes to: plugin-store install defi-starter --yes
  → defi-starter SKILL.md loads → immediately installs hyperliquid + polymarket
  → presents table of what was installed
  → asks "which do you want to start with?"
  → hands off to chosen plugin's quickstart
```

OR explicitly:
```
npx skills add okx/plugin-store --skill defi-starter
```

### Future maintainability
To change the featured bundle, simply add/remove the `featured` tag in registry.json for any plugin — no defi-starter version bump required.

## Files Changed

| File | Change |
|------|--------|
| `skills/defi-starter/plugin.yaml` | New — plugin metadata, type=official |
| `skills/defi-starter/SKILL.md` | New — proactive onboarding, install instructions, plugin overviews |
| `skills/defi-starter/SUMMARY.md` | New — user-facing overview |
| `registry.json` | Add defi-starter entry; add featured tag to hyperliquid-plugin + polymarket-plugin |
| `skills/plugin-store/SKILL.md` | Add new-user routing row + Intent: New user operation flow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)