### PR TITLE
feat(pendle-plugin): add quickstart onboarding command (v0.2.8)

### DIFF
--- a/skills/pendle-plugin/.claude-plugin/plugin.json
+++ b/skills/pendle-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "pendle-plugin",
   "description": "Pendle Finance yield tokenization plugin \u2014 buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT pairs across Ethereum, Arbitrum, BSC, and Base",
-  "version": "0.2.7"
+  "version": "0.2.8"
 }

--- a/skills/pendle-plugin/CHANGELOG.md
+++ b/skills/pendle-plugin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.2.8 — 2026-04-21
+
+### Added
+
+- **`quickstart` command**: New onboarding surface that returns a `status` (`active` / `ready` /
+  `needs_gas` / `needs_funds` / `no_funds`) based on wallet gas + stablecoin balance + Pendle
+  positions, with a concrete `next_command` and `onboarding_steps` for each state. Read-only,
+  chain-aware (uses the global `--chain` flag to pick the correct USDC address and native gas
+  token). Purely additive — no existing command code was modified.
+
 ## v0.2.7 — 2026-04-17
 
 ### Changed

--- a/skills/pendle-plugin/Cargo.lock
+++ b/skills/pendle-plugin/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "pendle-plugin"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/skills/pendle-plugin/Cargo.toml
+++ b/skills/pendle-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pendle-plugin"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 [[bin]]

--- a/skills/pendle-plugin/SKILL.md
+++ b/skills/pendle-plugin/SKILL.md
@@ -4,7 +4,7 @@ description: "Pendle Finance yield tokenization plugin. Buy or sell fixed-yield 
 license: MIT
 metadata:
   author: skylavis-sky
-  version: "0.2.7"
+  version: "0.2.8"
 ---
 
 
@@ -20,7 +20,7 @@ metadata:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/pendle-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.2.7"
+LOCAL_VER="0.2.8"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -94,7 +94,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pendle-plugin@0.2.7/pendle-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pendle-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/pendle-plugin@0.2.8/pendle-plugin-${TARGET}${EXT}" -o ~/.local/bin/.pendle-plugin-core${EXT}
 chmod +x ~/.local/bin/.pendle-plugin-core${EXT}
 
 # Symlink CLI name to pendle-plugin
@@ -102,7 +102,7 @@ ln -sf "$LAUNCHER" ~/.local/bin/pendle-plugin
 
 # Register version
 mkdir -p "$HOME/.plugin-store/managed"
-echo "0.2.7" > "$HOME/.plugin-store/managed/pendle-plugin"
+echo "0.2.8" > "$HOME/.plugin-store/managed/pendle-plugin"
 ```
 
 ### Report install (auto-injected, runs once)
@@ -122,7 +122,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"pendle-plugin","version":"0.2.7"}' >/dev/null 2>&1 || true
+    -d '{"name":"pendle-plugin","version":"0.2.8"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -246,6 +246,35 @@ All write commands include `router` and `calldata` in their output for this purp
 ---
 
 ## Commands
+
+### quickstart — Onboarding Status
+
+**Trigger phrases:** "pendle quickstart", "get started with pendle", "pendle onboarding", "what can I do with pendle"
+
+```bash
+pendle-plugin --chain <CHAIN_ID> quickstart [--user <ADDR>]
+```
+
+**Parameters:**
+- `--user` — wallet address to query (defaults to the connected onchainos wallet)
+- Global `--chain` selects which chain's balances to inspect (default 42161 Arbitrum)
+
+**Output fields:** `about`, `wallet`, `chain`, `assets.{gas_symbol, gas_balance, stable_symbol, stable_balance, active_positions}`, `status`, `suggestion`, `next_command`, `onboarding_steps[]`.
+
+**Status values:** `active` (has positions), `ready` (funded, no positions), `needs_gas` (has stable, no gas), `needs_funds` (has gas, no stable), `no_funds` (neither).
+
+**Examples:**
+```bash
+# Check Arbitrum (default) onboarding status
+pendle-plugin quickstart
+
+# Check Base onboarding status for a specific wallet
+pendle-plugin --chain 8453 quickstart --user 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+Use `next_command` or `onboarding_steps` to drive the next action. Read-only — no transactions broadcast.
+
+---
 
 ### list-markets — Browse Pendle Markets
 

--- a/skills/pendle-plugin/SUMMARY.md
+++ b/skills/pendle-plugin/SUMMARY.md
@@ -1,18 +1,19 @@
-**Overview**
+## Overview
 
 Pendle is a yield tokenization protocol that splits yield-bearing assets into Principal Tokens (PT, fixed yield) and Yield Tokens (YT, floating yield). This skill lets you browse markets, buy/sell PT for fixed yield, buy/sell YT for floating yield, mint/redeem PT+YT pairs, and add/remove liquidity on Ethereum, Arbitrum, BSC, and Base.
 
-**Prerequisites**
+## Prerequisites
 - onchainos CLI installed and logged in
 - ETH (or BNB on BSC) for gas on the target chain
 - A stablecoin (e.g. USDC) or yield-bearing asset (e.g. weETH, wstETH) on the target chain to trade
 
-**Quick Start**
-1. Check your balance on the target chain: `onchainos wallet balance --chain 42161` (Arbitrum default; use 1 / 56 / 8453 for Ethereum / BSC / Base)
-2. Browse active markets — note `pt` address and `address` (= LP address); look for high `impliedApy` and `liquidity.usd > $1M`: `pendle-plugin --chain 42161 list-markets --active-only --limit 10`
-3. Search markets by asset (e.g. ETH-derivatives, stablecoins): `pendle-plugin --chain 42161 list-markets --search weETH --active-only`
-4. Buy PT for fixed yield — preview first (no `--confirm`): `pendle-plugin --chain 42161 buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
-5. Re-run with `--confirm` to execute: `pendle-plugin --chain 42161 --confirm buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
-6. Check your positions (allow 15–30s for the Pendle indexer): `pendle-plugin --chain 42161 get-positions`
-7. For leveraged floating yield, buy YT instead of PT: `pendle-plugin --chain 42161 --confirm buy-yt --token-in <USDC_ADDR> --amount-in 5000000 --yt-address <YT_ADDR>`
-8. Exit before expiry: `pendle-plugin --chain 42161 --confirm sell-pt --pt-address <PT_ADDR> --amount-in <PT_WEI> --token-out <USDC_ADDR>`
+## Quick Start
+1. Check your current state and get a guided next step: `pendle-plugin quickstart`
+2. If you see `status: no_funds` / `needs_gas` / `needs_funds` — fund the wallet address shown in the output (ETH for gas + USDC to trade)
+3. Browse active markets — note `pt` address and `address` (= LP address); look for high `impliedApy` and `liquidity.usd > $1M`: `pendle-plugin --chain 42161 list-markets --active-only --limit 10`
+4. Search markets by asset (e.g. ETH-derivatives, stablecoins): `pendle-plugin --chain 42161 list-markets --search weETH --active-only`
+5. Buy PT for fixed yield — preview first (no `--confirm`): `pendle-plugin --chain 42161 buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
+6. Re-run with `--confirm` to execute: `pendle-plugin --chain 42161 --confirm buy-pt --token-in <USDC_ADDR> --amount-in 5000000 --pt-address <PT_ADDR>`
+7. Check your positions (allow 15–30s for the Pendle indexer): `pendle-plugin --chain 42161 get-positions`
+8. For leveraged floating yield, buy YT instead of PT: `pendle-plugin --chain 42161 --confirm buy-yt --token-in <USDC_ADDR> --amount-in 5000000 --yt-address <YT_ADDR>`
+9. Exit before expiry: `pendle-plugin --chain 42161 --confirm sell-pt --pt-address <PT_ADDR> --amount-in <PT_WEI> --token-out <USDC_ADDR>`

--- a/skills/pendle-plugin/plugin.yaml
+++ b/skills/pendle-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: pendle-plugin
-version: "0.2.7"
+version: "0.2.8"
 description: "Pendle Finance yield tokenization plugin — buy/sell PT & YT, add/remove liquidity, mint/redeem PT+YT pairs across Ethereum, Arbitrum, BSC, and Base"
 author:
   name: skylavis-sky

--- a/skills/pendle-plugin/src/commands/mod.rs
+++ b/skills/pendle-plugin/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod quickstart;
 pub mod list_markets;
 pub mod get_market;
 pub mod get_market_info;

--- a/skills/pendle-plugin/src/commands/quickstart.rs
+++ b/skills/pendle-plugin/src/commands/quickstart.rs
@@ -1,0 +1,277 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::api;
+use crate::onchainos;
+
+const ABOUT: &str = "Pendle Finance is a yield-trading protocol that splits yield-bearing tokens \
+    into Principal Tokens (PT — fixed yield) and Yield Tokens (YT — floating yield). This skill \
+    lets you browse markets, trade PT/YT, provide liquidity, and mint/redeem PT+YT pairs across \
+    Ethereum, Arbitrum, BSC, and Base.";
+
+// USDC (or equivalent stablecoin) per supported chain — the default trading asset.
+fn usdc_address(chain_id: u64) -> Option<(&'static str, u32, &'static str)> {
+    // (address, decimals, symbol)
+    match chain_id {
+        1     => Some(("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6,  "USDC")),
+        42161 => Some(("0xaf88d065e77c8cC2239327C5EDb3A432268e5831", 6,  "USDC")),
+        8453  => Some(("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", 6,  "USDC")),
+        56    => Some(("0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", 18, "USDC")),
+        _     => None,
+    }
+}
+
+fn gas_symbol(chain_id: u64) -> &'static str {
+    match chain_id {
+        56 => "BNB",
+        _  => "ETH",
+    }
+}
+
+// Minimum thresholds: 0.0005 ETH covers a Pendle approve+swap on Arbitrum/Base; BSC uses BNB.
+const MIN_GAS_WEI: u128  = 500_000_000_000_000; // 0.0005 native token (18 dec)
+const MIN_USDC_USD: f64  = 5.0;                 // $5 minimum trade size
+
+pub async fn run(
+    user: Option<&str>,
+    chain_id: u64,
+    api_key: Option<&str>,
+) -> Result<Value> {
+    let wallet = match user {
+        Some(addr) => {
+            onchainos::validate_evm_address(addr)?;
+            addr.to_string()
+        }
+        None => {
+            let resolved = onchainos::resolve_wallet(chain_id)?;
+            if resolved.is_empty() {
+                anyhow::bail!(
+                    "Cannot resolve wallet address. Pass --user or ensure onchainos is logged in."
+                );
+            }
+            resolved
+        }
+    };
+
+    eprintln!(
+        "Checking assets for {}...",
+        &wallet[..std::cmp::min(10, wallet.len())]
+    );
+
+    let (stable_addr, stable_decimals, stable_symbol) = usdc_address(chain_id)
+        .unwrap_or(("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6, "USDC"));
+
+    // Three-way parallel fetch: native gas, stablecoin balance, Pendle positions.
+    let (gas_result, stable_result, positions_result) = tokio::join!(
+        native_balance(chain_id, &wallet),
+        onchainos::erc20_balance_of(chain_id, stable_addr, &wallet),
+        api::get_positions(&wallet, Some(0.01), api_key),
+    );
+
+    let gas_wei = gas_result.unwrap_or(0);
+    let stable_raw = stable_result.unwrap_or(0);
+    let positions_count = positions_result
+        .as_ref()
+        .ok()
+        .and_then(count_positions)
+        .unwrap_or(0);
+
+    let gas = gas_wei as f64 / 1e18;
+    let stable = stable_raw as f64 / 10f64.powi(stable_decimals as i32);
+
+    let (status, suggestion, onboarding_steps, next_command) = build_suggestion(
+        &wallet,
+        chain_id,
+        gas_wei,
+        stable,
+        positions_count,
+        stable_symbol,
+        stable_addr,
+    );
+
+    let mut out = serde_json::json!({
+        "ok": true,
+        "about": ABOUT,
+        "wallet": wallet,
+        "chain": chain_id,
+        "assets": {
+            "gas_symbol":        gas_symbol(chain_id),
+            "gas_balance":       format!("{:.6}", gas),
+            "stable_symbol":     stable_symbol,
+            "stable_balance":    format!("{:.4}", stable),
+            "active_positions":  positions_count,
+        },
+        "status":       status,
+        "suggestion":   suggestion,
+        "next_command": next_command,
+    });
+
+    if !onboarding_steps.is_empty() {
+        out["onboarding_steps"] = serde_json::json!(onboarding_steps);
+    }
+
+    Ok(out)
+}
+
+/// Query native token balance via eth_getBalance on the chain's public RPC.
+/// Returns 0 on any RPC error — quickstart is best-effort read-only guidance.
+async fn native_balance(chain_id: u64, wallet: &str) -> Result<u128> {
+    let rpc_url = onchainos::default_rpc_url(chain_id);
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_getBalance",
+        "params": [wallet, "latest"],
+        "id": 1
+    });
+    let resp: Value = reqwest::Client::new()
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+    let hex = resp["result"].as_str().unwrap_or("0x0");
+    let clean = hex.trim_start_matches("0x");
+    if clean.is_empty() {
+        return Ok(0);
+    }
+    let truncated = if clean.len() > 32 {
+        &clean[clean.len() - 32..]
+    } else {
+        clean
+    };
+    Ok(u128::from_str_radix(truncated, 16).unwrap_or(0))
+}
+
+/// Count Pendle positions from the API response. The dashboard API shape has varied
+/// across versions — probe several common paths and return 0 if none match.
+fn count_positions(resp: &Value) -> Option<usize> {
+    for key in &["openPositions", "positions", "data", "results"] {
+        if let Some(arr) = resp[*key].as_array() {
+            return Some(arr.len());
+        }
+    }
+    if let Some(n) = resp["totalOpen"].as_u64() {
+        return Some(n as usize);
+    }
+    if let Some(n) = resp["total"].as_u64() {
+        return Some(n as usize);
+    }
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_suggestion(
+    wallet: &str,
+    chain_id: u64,
+    gas_wei: u128,
+    stable: f64,
+    positions_count: usize,
+    stable_symbol: &'static str,
+    stable_addr: &'static str,
+) -> (&'static str, String, Vec<String>, String) {
+    let gas = gas_symbol(chain_id);
+
+    // Case 1: active — user already has Pendle positions
+    if positions_count > 0 {
+        return (
+            "active",
+            format!(
+                "You have {} active Pendle position(s). Review them below.",
+                positions_count
+            ),
+            vec![],
+            format!("pendle-plugin --chain {} get-positions", chain_id),
+        );
+    }
+
+    // Case 2: ready — has gas + trading asset
+    if gas_wei >= MIN_GAS_WEI && stable >= MIN_USDC_USD {
+        return (
+            "ready",
+            "Your wallet is funded. Browse active Pendle markets to find a yield opportunity."
+                .to_string(),
+            vec![
+                "1. Browse the top active markets (high TVL, high APY):".to_string(),
+                format!("   pendle-plugin --chain {} list-markets --active-only --limit 10", chain_id),
+                "2. Or search by asset (e.g. weETH, wstETH):".to_string(),
+                format!("   pendle-plugin --chain {} list-markets --search weETH --active-only", chain_id),
+                "3. Preview buying PT for fixed yield (no --confirm = preview only):".to_string(),
+                format!(
+                    "   pendle-plugin --chain {} buy-pt --token-in {} --amount-in 5000000 --pt-address <PT_ADDR>",
+                    chain_id, stable_addr
+                ),
+                "4. Re-run with --confirm to execute.".to_string(),
+            ],
+            format!(
+                "pendle-plugin --chain {} list-markets --active-only --limit 10",
+                chain_id
+            ),
+        );
+    }
+
+    // Case 3: has stable but no gas
+    if stable >= MIN_USDC_USD {
+        return (
+            "needs_gas",
+            format!(
+                "You have {} but need {} for gas. Send at least 0.0005 {} to your wallet.",
+                stable_symbol, gas, gas
+            ),
+            vec![
+                format!("1. Send at least 0.0005 {} for gas to your wallet:", gas),
+                format!("   {}", wallet),
+                "2. Run quickstart again to confirm:".to_string(),
+                format!("   pendle-plugin --chain {} quickstart", chain_id),
+            ],
+            format!("pendle-plugin --chain {} quickstart", chain_id),
+        );
+    }
+
+    // Case 4: has gas but no stable
+    if gas_wei >= MIN_GAS_WEI {
+        return (
+            "needs_funds",
+            format!(
+                "You have {} for gas but need a trading asset. Send at least $5 {} to your wallet.",
+                gas, stable_symbol
+            ),
+            vec![
+                format!("1. Send at least 5 {} to your wallet:", stable_symbol),
+                format!("   {}", wallet),
+                "2. Run quickstart again to confirm:".to_string(),
+                format!("   pendle-plugin --chain {} quickstart", chain_id),
+                "3. Then browse markets:".to_string(),
+                format!(
+                    "   pendle-plugin --chain {} list-markets --active-only --limit 10",
+                    chain_id
+                ),
+            ],
+            format!("pendle-plugin --chain {} quickstart", chain_id),
+        );
+    }
+
+    // Case 5: no funds
+    (
+        "no_funds",
+        format!(
+            "No {} or {} found. Send both to your wallet to get started.",
+            gas, stable_symbol
+        ),
+        vec![
+            format!(
+                "1. Send {} (at least 0.0005) and {} (at least 5) to your wallet:",
+                gas, stable_symbol
+            ),
+            format!("   {}", wallet),
+            "2. Run quickstart again to confirm:".to_string(),
+            format!("   pendle-plugin --chain {} quickstart", chain_id),
+            "3. Browse markets to find a yield opportunity:".to_string(),
+            format!(
+                "   pendle-plugin --chain {} list-markets --active-only --limit 10",
+                chain_id
+            ),
+        ],
+        format!("pendle-plugin --chain {} quickstart", chain_id),
+    )
+}

--- a/skills/pendle-plugin/src/main.rs
+++ b/skills/pendle-plugin/src/main.rs
@@ -34,6 +34,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Onboarding status — check gas + stable balance + active positions, then suggest the next command.
+    Quickstart {
+        /// Wallet address to query (defaults to current logged-in wallet)
+        #[arg(long)]
+        user: Option<String>,
+    },
+
     /// List active Pendle markets with APY and TVL
     ListMarkets {
         /// Filter by chain ID (omit for all chains)
@@ -333,6 +340,10 @@ async fn main() {
     let confirm = cli.confirm;
 
     let result = match cli.command {
+        Commands::Quickstart { user } => {
+            commands::quickstart::run(user.as_deref(), chain, api_key).await
+        }
+
         Commands::ListMarkets {
             chain_id,
             active_only,


### PR DESCRIPTION
## Summary

Adds a read-only `quickstart` command that mirrors the onboarding surface already shipped on `hyperliquid` and `pancakeswap-v3`. Running `pendle-plugin quickstart` inspects wallet state on the target chain and returns a concrete next step, so agents can drive users from \"nothing\" → \"first Pendle trade\" without guessing.

## Behaviour

Three-way parallel fetch:
- Native gas via `eth_getBalance`
- Stablecoin balance via ERC-20 `balanceOf` (USDC per chain)
- Pendle positions via the dashboard API

Classified into five states, each with a ready-to-run `next_command` and stepwise `onboarding_steps`:

| status | meaning |
|---|---|
| `active` | user already has Pendle positions — recommend `get-positions` |
| `ready` | funded + no positions — recommend `list-markets --active-only` |
| `needs_gas` | has stable but no native token — prompt to fund ETH/BNB |
| `needs_funds` | has gas but no stable — prompt to fund USDC |
| `no_funds` | empty wallet — prompt for both |

Chain-aware: global `--chain` flag picks the correct USDC address and native gas symbol (ETH/BNB). Supported: Ethereum (1), Arbitrum (42161, default), Base (8453), BSC (56).

## Scope / risk

**Purely additive.** Zero changes to existing commands, `api.rs`, `onchainos.rs`, or `config.rs`. All new logic (native balance helper, position counter, state classifier) lives inside `src/commands/quickstart.rs` as file-private functions.

Touched files:
- `src/commands/quickstart.rs` — new file
- `src/commands/mod.rs` — one `pub mod` line
- `src/main.rs` — one enum variant + one dispatch arm
- `SUMMARY.md` — H2 headings + Quick Start now leads with `pendle-plugin quickstart`
- `SKILL.md` — new `quickstart` command section; version bump
- `CHANGELOG.md` / `plugin.yaml` / `Cargo.toml` / `.claude-plugin/plugin.json` — version 0.2.7 → 0.2.8

## Test plan

- [x] `cargo build` clean
- [x] Binary `--version` reports `0.2.8`
- [x] `pendle-plugin --help` shows `quickstart` alongside existing commands; no existing command help changed
- [x] Live test (Vitalik address, chain 42161): returned `status: ready` with correct ETH + USDC balances
- [x] Chain switching test (chain 56 BSC): returned `gas_symbol: BNB` with BSC USDC address in onboarding steps
- [x] `api_calls` whitelist in `plugin.yaml` unchanged (all RPC + Pendle API domains already listed)
- [x] No `unwrap_or(0)` regressions introduced; quickstart tolerates transient RPC/API failures by treating them as zero-balance (classifies as `no_funds`), a safe user-visible default

🤖 Generated with [Claude Code](https://claude.com/claude-code)