### PR TITLE
chore(hyperliquid-plugin): use full binary name in SUMMARY.md examples

### DIFF
--- a/skills/hyperliquid-plugin/SUMMARY.md
+++ b/skills/hyperliquid-plugin/SUMMARY.md
@@ -8,11 +8,11 @@ Hyperliquid is a high-performance on-chain perpetuals DEX on its own L1, settlin
 - A small amount of ETH on Arbitrum for gas
 
 ## Quick Start
-1. Check your current state and get a guided next step: `hyperliquid quickstart`
-2. If you see `status: no_funds` / `low_balance` — get your deposit address and top up USDC on Arbitrum: `hyperliquid address`
-3. If you see `status: needs_deposit` — bridge Arbitrum USDC into Hyperliquid (arrives in 2–5 min): `hyperliquid deposit --amount 50 --confirm`
-4. One-time: bind your signing address so orders can be signed: `hyperliquid register`
-5. If you see `status: ready` — place your first perpetual order: `hyperliquid order --coin BTC --side buy --size 0.001 --leverage 5 --confirm`
-6. If you see `status: active` — review positions and attach stop-loss / take-profit: `hyperliquid positions` → `hyperliquid tpsl --coin BTC --sl-px 60000 --tp-px 80000 --confirm`
-7. Close a position: `hyperliquid close --coin BTC --confirm`
-8. Withdraw USDC back to Arbitrum: `hyperliquid withdraw --amount 50 --confirm`
+1. Check your current state and get a guided next step: `hyperliquid-plugin quickstart`
+2. If you see `status: no_funds` / `low_balance` — get your deposit address and top up USDC on Arbitrum: `hyperliquid-plugin address`
+3. If you see `status: needs_deposit` — bridge Arbitrum USDC into Hyperliquid (arrives in 2–5 min): `hyperliquid-plugin deposit --amount 50 --confirm`
+4. One-time: bind your signing address so orders can be signed: `hyperliquid-plugin register`
+5. If you see `status: ready` — place your first perpetual order: `hyperliquid-plugin order --coin BTC --side buy --size 0.001 --leverage 5 --confirm`
+6. If you see `status: active` — review positions and attach stop-loss / take-profit: `hyperliquid-plugin positions` → `hyperliquid-plugin tpsl --coin BTC --sl-px 60000 --tp-px 80000 --confirm`
+7. Close a position: `hyperliquid-plugin close --coin BTC --confirm`
+8. Withdraw USDC back to Arbitrum: `hyperliquid-plugin withdraw --amount 50 --confirm`


### PR DESCRIPTION
## Summary

The binary installed at `~/.local/bin/` is `hyperliquid-plugin`, not `hyperliquid`. Users copying Quick Start commands verbatim would hit "command not found".

Replace all 8 short-name command examples in SUMMARY.md with the full `hyperliquid-plugin` binary name so the Quick Start flow is copy-paste runnable.

Sibling PRs doing the same cleanup for other skills: #301, #303, #304, #305.

Docs-only change — no code or version changes.

## Test plan

- [x] Diff is 8 lines — purely binary-name alignment
- [x] No code or config modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)