### PR TITLE
[new-plugin] bad-arb-strategy v1.0.0 — INTENTIONALLY BROKEN for CI test

### DIFF
--- a/skills/bad-poly-arb/.claude-plugin/plugin.json
+++ b/skills/bad-poly-arb/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{"name":"bad-poly-arb","description":"Broken strategy","version":"1.0.0","author":{"name":"yz06276"},"license":"MIT"}

--- a/skills/bad-poly-arb/LICENSE
+++ b/skills/bad-poly-arb/LICENSE
@@ -1,0 +1,1 @@
+MIT License. Copyright (c) 2026 yz06276.

--- a/skills/bad-poly-arb/plugin.yaml
+++ b/skills/bad-poly-arb/plugin.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+name: bad-poly-arb
+version: "1.0.0"
+description: "Broken strategy — missing --strategy-id + fake dependency + secrets"
+author:
+  name: "yz06276"
+  github: "yz06276"
+license: MIT
+category: strategy
+tags: [strategy]
+dependent_plugin:
+  - name: polymarket-plugin
+    version: "^0.4.0"
+  - name: does-not-exist-plugin
+    version: "^1.0.0"
+risk_level: high
+supported_venues: [polymarket]
+components:
+  skill:
+    dir: skills/bad-poly-arb
+api_calls: []

--- a/skills/bad-poly-arb/scripts/bad.py
+++ b/skills/bad-poly-arb/scripts/bad.py
@@ -1,0 +1,24 @@
+import subprocess
+# BUG 1: Hardcoded private key
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+# BUG 2: Hardcoded RPC URL
+RPC = "https://mainnet.infura.io/v3/abc123secret"
+# BUG 3: API key in plaintext
+API_KEY = "sk-proj-secretkey123456"
+
+def buy(market_id, amount):
+    # BUG 4: MISSING --strategy-id on write operation
+    subprocess.run(["polymarket-plugin", "buy", "--market-id", market_id, "--amount", str(amount), "--confirm"])
+
+def sell(market_id, amount):
+    # BUG 5: MISSING --strategy-id on write operation
+    subprocess.run(["polymarket-plugin", "sell", "--market-id", market_id, "--amount", str(amount)])
+
+def check():
+    # OK: read-only, no --strategy-id needed
+    subprocess.run(["polymarket-plugin", "list-markets", "--query", "BTC"], capture_output=True)
+
+if __name__ == "__main__":
+    check()
+    buy("abc", 100)
+    sell("abc", 50)

--- a/skills/bad-poly-arb/skills/bad-poly-arb/SKILL.md
+++ b/skills/bad-poly-arb/skills/bad-poly-arb/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: bad-poly-arb
+description: "Broken strategy for CI testing"
+version: "1.0.0"
+author: "yz06276"
+tags: [strategy]
+---
+# bad-poly-arb
+## Overview
+Intentionally broken strategy.
+## Pre-flight Checks
+1. polymarket-plugin installed
+## Commands
+### Run
+```bash
+python3 scripts/bad.py
+```
+## Error Handling
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| "Error" | Bug | Fix |

--- a/skills/bad-poly-arb/skills/bad-poly-arb/SUMMARY.md
+++ b/skills/bad-poly-arb/skills/bad-poly-arb/SUMMARY.md
@@ -1,0 +1,8 @@
+# bad-poly-arb
+## Overview
+Broken strategy for testing.
+Tags: `strategy`
+## Prerequisites
+- polymarket-plugin installed
+## Quick Start
+1. Run `python3 scripts/bad.py`


### PR DESCRIPTION
Testing CI error detection:
- E160: fake-plugin-not-exist not in registry (Phase 1 should catch)
- Missing --strategy on buy/sell (Phase 3 AI should flag)
- Hardcoded private key, RPC URL, API key (Phase 3 AI should flag)