### PR TITLE
feat(polymarket-plugin): strategy attribution reporting (v0.4.10)

### DIFF
--- a/skills/polymarket-plugin/.claude-plugin/plugin.json
+++ b/skills/polymarket-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polymarket-plugin",
   "description": "Trade prediction markets on Polymarket \u2014 buy and sell YES/NO outcome tokens on Polygon",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "author": {
     "name": "skylavis-sky",
     "github": "skylavis-sky"

--- a/skills/polymarket-plugin/CHANGELOG.md
+++ b/skills/polymarket-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polymarket Plugin Changelog
 
+### v0.4.10 (2026-04-22)
+
+- **feat**: Strategy attribution reporting — `buy` / `sell` / `redeem` each accept an optional `--strategy-id <id>`. When provided and non-empty, the plugin invokes `onchainos wallet report-plugin-info` after the order succeeds with a JSON payload containing `wallet`, `proxyAddress`, `order_id`, `tx_hashes`, `market_id`, `asset_id`, `side`, `amount`, `symbol`, `price`, `timestamp`, `strategy_id`, `plugin_name`. Omitting the flag skips reporting entirely. Report failures log to stderr as warnings and do not affect the trade result. `symbol` encodes the collateral / quote asset (Polymarket: `USDC.e`).
+
 ### v0.4.6 (2026-04-15)
 
 - **chore**: Version bump.

--- a/skills/polymarket-plugin/Cargo.lock
+++ b/skills/polymarket-plugin/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polymarket-plugin"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "base64",

--- a/skills/polymarket-plugin/Cargo.toml
+++ b/skills/polymarket-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-plugin"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 
 [[bin]]

--- a/skills/polymarket-plugin/SKILL.md
+++ b/skills/polymarket-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polymarket-plugin
 description: "Trade prediction markets on Polymarket - buy outcome tokens (YES/NO and categorical markets), check positions, list markets, manage orders, redeem winning tokens, and deposit funds on Polygon. Trigger phrases: buy polymarket shares, sell polymarket position, check my polymarket positions, list polymarket markets, get polymarket market, cancel polymarket order, redeem polymarket tokens, polymarket yes token, polymarket no token, prediction market trade, polymarket price, get started with polymarket, just installed polymarket, how do I use polymarket, set up polymarket, polymarket quickstart, new to polymarket, polymarket setup, help me trade on polymarket, place a bet on, buy prediction market, bet on, trade on prediction markets, prediction trading, place a prediction market bet, i want to bet on, deposit, 充值, 充钱, 转入, 打钱, fund polymarket, top up polymarket, add funds to polymarket, recharge polymarket, deposit usdc, deposit eth, polymarket deposit, BTC 5分钟, ETH 5分钟, 5分钟市场, 5min market, 五分钟市场, 短线市场, list 5-minute, BTC up or down, 找5分钟, 看5分钟, 5m updown, crypto 5m, 5分钟涨跌, 五分钟涨跌, updown market, BTC 5min, ETH 5min, SOL 5min, 5分钟预测."
-version: "0.4.9"
+version: "0.4.10"
 author: "skylavis-sky"
 tags:
   - prediction-market
@@ -25,7 +25,7 @@ tags:
 # Check for skill updates (1-hour cache)
 UPDATE_CACHE="$HOME/.plugin-store/update-cache/polymarket-plugin"
 CACHE_MAX=3600
-LOCAL_VER="0.4.9"
+LOCAL_VER="0.4.10"
 DO_CHECK=true
 
 if [ -f "$UPDATE_CACHE" ]; then
@@ -98,7 +98,7 @@ case "${OS}_${ARCH}" in
   mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
 esac
 mkdir -p ~/.local/bin
-curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.9/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/polymarket-plugin@0.4.10/polymarket-plugin-${TARGET}${EXT}" -o ~/.local/bin/.polymarket-plugin-core${EXT}
 chmod +x ~/.local/bin/.polymarket-plugin-core${EXT}
 
 # Symlink CLI name to universal launcher
@@ -126,7 +126,7 @@ if [ ! -f "$REPORT_FLAG" ]; then
   # Report to Vercel stats
   curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
     -H "Content-Type: application/json" \
-    -d '{"name":"polymarket-plugin","version":"0.4.9"}' >/dev/null 2>&1 || true
+    -d '{"name":"polymarket-plugin","version":"0.4.10"}' >/dev/null 2>&1 || true
   # Report to OKX API (with HMAC-signed device token)
   curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
     -H "Content-Type: application/json" \
@@ -309,7 +309,7 @@ The first `buy` or `sell` automatically derives your Polymarket API credentials 
 polymarket-plugin --version
 ```
 
-Expected: `polymarket-plugin 0.4.9`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
+Expected: `polymarket-plugin 0.4.10`. If missing or wrong version, run the install script in **Pre-flight Dependencies** above.
 
 ### Step 2 — Install `onchainos` CLI (required for buy/sell/cancel/redeem only)
 
@@ -594,7 +594,7 @@ polymarket-plugin get-positions --address 0xAbCd...
 ### `buy` — Buy Outcome Shares
 
 ```
-polymarket-plugin buy --market-id <id> --outcome <outcome> --amount <usdc> [--price <0-1>] [--order-type <GTC|FOK>] [--approve] [--round-up]
+polymarket-plugin buy --market-id <id> --outcome <outcome> --amount <usdc> [--price <0-1>] [--order-type <GTC|FOK>] [--approve] [--round-up] [--strategy-id <id>]
 ```
 
 > **Amount vs shares**: `buy` takes `--amount` in **USDC.e** (dollars you spend). `sell` takes `--shares` in **outcome tokens** (shares you hold). They are different units — a user saying "I want to sell $50" means sell enough shares to receive ~$50 USDC; you must first check their share balance via `get-positions` and convert using the current bid price.
@@ -614,6 +614,7 @@ polymarket-plugin buy --market-id <id> --outcome <outcome> --amount <usdc> [--pr
 | `--expires` | Unix timestamp (seconds, UTC) at which the order auto-cancels. Minimum 90 seconds in the future (CLOB enforces a "now + 1 min 30 s" security threshold). Automatically sets `order_type` to `GTD` (Good Till Date) — do not also pass `--order-type GTC`. Example: `--expires $(date -d '+1 hour' +%s)` | — |
 | `--mode` | Override trading mode for this order only: `eoa` or `proxy`. Does not change the stored default. | — |
 | `--confirm` | Confirm a previously gated action (reserved for future use) | false |
+| `--strategy-id` | Strategy ID for attribution reporting. When provided and non-empty, the plugin calls `onchainos wallet report-plugin-info` after successful order placement with order metadata (`wallet`, `proxyAddress`, `order_id`, `tx_hashes`, `market_id`, `side`, `amount`, `symbol`, `price`, `strategy_id`, `plugin_name`). `tx_hashes` is an array of on-chain settlement tx hashes — non-empty for FOK/immediate-fill orders, empty for resting GTC limits that haven't crossed yet. Omit or pass `""` to skip reporting. Failures are logged to stderr and do not affect the order result. | — |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
@@ -655,7 +656,7 @@ polymarket-plugin buy --market-id 0xabc... --outcome no --amount 100
 ### `sell` — Sell Outcome Shares
 
 ```
-polymarket-plugin sell --market-id <id> --outcome <outcome> --shares <amount> [--price <0-1>] [--order-type <GTC|FOK>] [--approve] [--dry-run]
+polymarket-plugin sell --market-id <id> --outcome <outcome> --shares <amount> [--price <0-1>] [--order-type <GTC|FOK>] [--approve] [--dry-run] [--strategy-id <id>]
 ```
 
 **Flags:**
@@ -672,6 +673,7 @@ polymarket-plugin sell --market-id <id> --outcome <outcome> --shares <amount> [-
 | `--dry-run` | Simulate without submitting the order or triggering any on-chain approval. Prints a confirmation JSON and exits. Use to verify parameters before a real sell. | false |
 | `--mode` | Override trading mode for this order only: `eoa` or `proxy`. Does not change the stored default. | — |
 | `--confirm` | Confirm a low-price market sell that was previously gated | false |
+| `--strategy-id` | Strategy ID for attribution reporting. When provided and non-empty, the plugin calls `onchainos wallet report-plugin-info` after successful order placement. Omit or pass `""` to skip reporting. Failures are logged to stderr and do not affect the order result. | — |
 
 **Auth required:** Yes — onchainos wallet; EIP-712 order signing via `onchainos sign-message --type eip712`
 
@@ -786,6 +788,7 @@ polymarket redeem --all --dry-run
 | `--market-id` | Market to redeem from: condition_id (0x-prefixed) or slug. Omit when using `--all`. |
 | `--all` | Discover and redeem **all** redeemable positions across EOA and proxy wallets in one pass, sequentially with on-chain confirmation between each. |
 | `--dry-run` | Preview without submitting: shows which wallets/markets will be redeemed and estimated POL gas cost |
+| `--strategy-id` | Strategy ID for attribution reporting. When provided and non-empty, after each redeem tx confirms the plugin calls `onchainos wallet report-plugin-info` with `side=REDEEM` and the confirmed tx hashes. Omit or pass `""` to skip reporting. Failures log to stderr and do not affect the redeem result. |
 
 **Auth required:** onchainos wallet (for signing the on-chain tx). No CLOB credentials needed.
 
@@ -1142,4 +1145,4 @@ Fees are deducted by the exchange from the received amount. The `feeRateBps` fie
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.4.6** (2026-04-14).
+See [CHANGELOG.md](CHANGELOG.md) for full version history. Current version: **0.4.10** (2026-04-22).

--- a/skills/polymarket-plugin/plugin.yaml
+++ b/skills/polymarket-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: polymarket-plugin
-version: "0.4.9"
+version: "0.4.10"
 description: "Trade prediction markets on Polymarket — buy and sell YES/NO outcome tokens on Polygon"
 author:
   name: skylavis-sky

--- a/skills/polymarket-plugin/src/commands/buy.rs
+++ b/skills/polymarket-plugin/src/commands/buy.rs
@@ -31,6 +31,7 @@ pub async fn run(
     expires: Option<u64>,
     mode_override: Option<&str>,
     token_id_fast: Option<&str>,
+    strategy_id: Option<&str>,
 ) -> Result<()> {
     // Parse USDC amount early so we can enforce the minimum order size
     // check even on dry-run (the agent needs to know before placing).
@@ -484,6 +485,32 @@ pub async fn run(
         bail!("Order placement failed: {}", msg);
     }
 
+    let actual_shares = taker_amount_raw as f64 / 1_000_000.0;
+    if let Some(sid) = strategy_id.filter(|s| !s.is_empty()) {
+        let ts_now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let report_payload = serde_json::json!({
+            "wallet": signer_addr,
+            "proxyAddress": creds.proxy_wallet.as_deref().unwrap_or(""),
+            "order_id": resp.order_id.clone().unwrap_or_default(),
+            "tx_hashes": resp.tx_hashes,
+            "market_id": condition_id,
+            "asset_id": token_id,
+            "side": "BUY",
+            "amount": format!("{}", actual_shares),
+            "symbol": "USDC.e",
+            "price": format!("{}", limit_price),
+            "timestamp": ts_now,
+            "strategy_id": sid,
+            "plugin_name": "polymarket-plugin",
+        });
+        if let Err(e) = crate::onchainos::report_plugin_info(&report_payload).await {
+            eprintln!("[polymarket] Warning: report-plugin-info failed: {}", e);
+        }
+    }
+
     let result = serde_json::json!({
         "ok": true,
         "data": {
@@ -497,7 +524,7 @@ pub async fn run(
             "limit_price": limit_price,
             "usdc_amount": actual_usdc,
             "usdc_requested": usdc_amount,
-            "shares": taker_amount_raw as f64 / 1_000_000.0,
+            "shares": actual_shares,
             "rounded_up": round_up && actual_usdc > usdc_amount + 1e-6,
             "post_only": post_only,
             "expires": if expiration > 0 { serde_json::Value::Number(expiration.into()) } else { serde_json::Value::Null },

--- a/skills/polymarket-plugin/src/commands/redeem.rs
+++ b/skills/polymarket-plugin/src/commands/redeem.rs
@@ -17,6 +17,54 @@ const REDEEM_WAIT_SECS: u64 = 45;
 /// to absorb gas price spikes.
 const POL_PER_REDEEM: f64 = 0.015;
 
+/// Fire `onchainos wallet report-plugin-info` with a REDEEM payload.
+/// No-op when strategy_id is missing/empty or no tx hashes are available.
+async fn report_redeem(
+    strategy_id: Option<&str>,
+    eoa: &str,
+    proxy: Option<&str>,
+    condition_id: &str,
+    result: &serde_json::Value,
+) {
+    let sid = match strategy_id.filter(|s| !s.is_empty()) {
+        Some(s) => s,
+        None => return,
+    };
+    let mut tx_hashes: Vec<String> = Vec::new();
+    if let Some(t) = result.get("eoa_tx").and_then(|v| v.as_str()) {
+        tx_hashes.push(t.to_string());
+    }
+    if let Some(t) = result.get("proxy_tx").and_then(|v| v.as_str()) {
+        tx_hashes.push(t.to_string());
+    }
+    if tx_hashes.is_empty() {
+        return;
+    }
+    let ts_now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let cid_display = format!("0x{}", condition_id.trim_start_matches("0x"));
+    let payload = serde_json::json!({
+        "wallet": eoa,
+        "proxyAddress": proxy.unwrap_or(""),
+        "order_id": tx_hashes[0],
+        "tx_hashes": tx_hashes,
+        "market_id": cid_display,
+        "asset_id": "",
+        "side": "REDEEM",
+        "amount": "",
+        "symbol": "USDC.e",
+        "price": "",
+        "timestamp": ts_now,
+        "strategy_id": sid,
+        "plugin_name": "polymarket-plugin",
+    });
+    if let Err(e) = crate::onchainos::report_plugin_info(&payload).await {
+        eprintln!("[polymarket] Warning: report-plugin-info failed: {}", e);
+    }
+}
+
 /// Resolve (condition_id, neg_risk, question) from a market_id (condition_id or slug).
 async fn resolve_market(client: &Client, market_id: &str) -> Result<(String, bool, String)> {
     if market_id.starts_with("0x") {
@@ -190,7 +238,7 @@ async fn check_pol_budget(eoa_addr: &str, tx_count: usize) -> Result<f64> {
 }
 
 /// Redeem a single market by market_id (condition_id or slug).
-pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
+pub async fn run(market_id: &str, dry_run: bool, strategy_id: Option<&str>) -> Result<()> {
     let client = Client::new();
 
     let (condition_id, neg_risk, question) = match resolve_market(&client, market_id).await {
@@ -260,6 +308,7 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
 
     match redeem_one(&client, &condition_id, &question, &eoa_addr, proxy_addr.as_deref()).await {
         Ok(result) => {
+            report_redeem(strategy_id, &eoa_addr, proxy_addr.as_deref(), &condition_id, &result).await;
             println!(
                 "{}",
                 serde_json::to_string_pretty(&serde_json::json!({
@@ -276,7 +325,7 @@ pub async fn run(market_id: &str, dry_run: bool) -> Result<()> {
 }
 
 /// Redeem ALL redeemable positions across EOA and proxy wallets in one pass.
-pub async fn run_all(dry_run: bool) -> Result<()> {
+pub async fn run_all(dry_run: bool, strategy_id: Option<&str>) -> Result<()> {
     let client = Client::new();
     let eoa_addr = match get_wallet_address().await {
         Ok(a) => a,
@@ -392,7 +441,10 @@ pub async fn run_all(dry_run: bool) -> Result<()> {
             title
         );
         match redeem_one(&client, cid, title, &eoa_addr, proxy_addr.as_deref()).await {
-            Ok(r) => results.push(r),
+            Ok(r) => {
+                report_redeem(strategy_id, &eoa_addr, proxy_addr.as_deref(), cid, &r).await;
+                results.push(r);
+            }
             Err(e) => {
                 eprintln!("[polymarket] Error redeeming {}: {:#}", cid, e);
                 let classified: serde_json::Value = serde_json::from_str(

--- a/skills/polymarket-plugin/src/commands/sell.rs
+++ b/skills/polymarket-plugin/src/commands/sell.rs
@@ -31,6 +31,7 @@ pub async fn run(
     expires: Option<u64>,
     mode_override: Option<&str>,
     token_id_fast: Option<&str>,
+    strategy_id: Option<&str>,
 ) -> Result<()> {
     // Parse shares and validate order flags up front (before any network calls).
     let share_amount: f64 = shares.parse().context("invalid shares amount")?;
@@ -460,6 +461,32 @@ pub async fn run(
         bail!("Order placement failed: {}", msg);
     }
 
+    let shares_filled = maker_amount_raw as f64 / 1_000_000.0;
+    if let Some(sid) = strategy_id.filter(|s| !s.is_empty()) {
+        let ts_now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let report_payload = serde_json::json!({
+            "wallet": signer_addr,
+            "proxyAddress": creds.proxy_wallet.as_deref().unwrap_or(""),
+            "order_id": resp.order_id.clone().unwrap_or_default(),
+            "tx_hashes": resp.tx_hashes,
+            "market_id": condition_id,
+            "asset_id": token_id,
+            "side": "SELL",
+            "amount": format!("{}", shares_filled),
+            "symbol": "USDC.e",
+            "price": format!("{}", limit_price),
+            "timestamp": ts_now,
+            "strategy_id": sid,
+            "plugin_name": "polymarket-plugin",
+        });
+        if let Err(e) = crate::onchainos::report_plugin_info(&report_payload).await {
+            eprintln!("[polymarket] Warning: report-plugin-info failed: {}", e);
+        }
+    }
+
     let result = serde_json::json!({
         "ok": true,
         "data": {
@@ -471,7 +498,7 @@ pub async fn run(
             "side": "SELL",
             "order_type": effective_order_type.to_uppercase(),
             "limit_price": limit_price,
-            "shares": maker_amount_raw as f64 / 1_000_000.0,
+            "shares": shares_filled,
             "usdc_out": taker_amount_raw as f64 / 1_000_000.0,
             "post_only": post_only,
             "expires": if expiration > 0 { serde_json::Value::Number(expiration.into()) } else { serde_json::Value::Null },

--- a/skills/polymarket-plugin/src/main.rs
+++ b/skills/polymarket-plugin/src/main.rs
@@ -135,6 +135,10 @@ enum Commands {
         /// Skip market lookup — use a known token ID directly (from get-series or get-market output).
         #[arg(long)]
         token_id: Option<String>,
+
+        /// Strategy ID for attribution — reported to OKX backend alongside the order
+        #[arg(long)]
+        strategy_id: Option<String>,
     },
 
     /// Sell YES or NO shares in a market (signs via onchainos wallet)
@@ -190,6 +194,10 @@ enum Commands {
         /// Skip market lookup — use a known token ID directly (from get-series or get-market output).
         #[arg(long)]
         token_id: Option<String>,
+
+        /// Strategy ID for attribution — reported to OKX backend alongside the order
+        #[arg(long)]
+        strategy_id: Option<String>,
     },
 
     /// Create a Polymarket proxy wallet and switch to gasless POLY_PROXY trading mode.
@@ -256,6 +264,10 @@ enum Commands {
         /// Preview the redemption call without submitting the transaction
         #[arg(long)]
         dry_run: bool,
+
+        /// Strategy ID for attribution — reported to OKX backend after successful redeem
+        #[arg(long)]
+        strategy_id: Option<String>,
     },
 
     /// Cancel a single open order by order ID (signs via onchainos wallet)
@@ -327,8 +339,9 @@ async fn main() {
             mode,
             confirm: _confirm,
             token_id,
+            strategy_id,
         } => {
-            commands::buy::run(market_id.as_deref(), &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, mode.as_deref(), token_id.as_deref()).await
+            commands::buy::run(market_id.as_deref(), &outcome, &amount, price, &order_type, approve, dry_run, round_up, post_only, expires, mode.as_deref(), token_id.as_deref(), strategy_id.as_deref()).await
         }
         Commands::Sell {
             market_id,
@@ -343,8 +356,9 @@ async fn main() {
             mode,
             confirm: _confirm,
             token_id,
+            strategy_id,
         } => {
-            commands::sell::run(market_id.as_deref(), &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, mode.as_deref(), token_id.as_deref()).await
+            commands::sell::run(market_id.as_deref(), &outcome, &shares, price, &order_type, approve, dry_run, post_only, expires, mode.as_deref(), token_id.as_deref(), strategy_id.as_deref()).await
         }
         Commands::SetupProxy { dry_run } => {
             commands::setup_proxy::run(dry_run).await
@@ -358,11 +372,11 @@ async fn main() {
         Commands::SwitchMode { mode } => {
             commands::switch_mode::run(&mode).await
         }
-        Commands::Redeem { market_id, all, dry_run } => {
+        Commands::Redeem { market_id, all, dry_run, strategy_id } => {
             if all {
-                commands::redeem::run_all(dry_run).await
+                commands::redeem::run_all(dry_run, strategy_id.as_deref()).await
             } else if let Some(mid) = market_id {
-                commands::redeem::run(&mid, dry_run).await
+                commands::redeem::run(&mid, dry_run, strategy_id.as_deref()).await
             } else {
                 eprintln!("Error: provide --market-id <ID> or --all");
                 std::process::exit(1);

--- a/skills/polymarket-plugin/src/onchainos.rs
+++ b/skills/polymarket-plugin/src/onchainos.rs
@@ -1179,6 +1179,34 @@ pub async fn get_chain_balances(chain: &str) -> Vec<ChainTokenBalance> {
         .collect()
 }
 
+/// Report plugin-level order metadata to the OKX backend for strategy attribution.
+///
+/// Serializes `payload` to a JSON string and passes it as `--plugin-parameter`.
+/// Non-fatal at the call site: the trade has already succeeded before this is invoked,
+/// so callers should log and continue on error rather than propagate.
+pub async fn report_plugin_info(payload: &Value) -> Result<()> {
+    let payload_str = serde_json::to_string(payload)
+        .context("serializing report-plugin-info payload")?;
+    let output = tokio::process::Command::new("onchainos")
+        .args([
+            "wallet", "report-plugin-info",
+            "--plugin-parameter", &payload_str,
+            "--chain", CHAIN,
+        ])
+        .output()
+        .await
+        .context("Failed to spawn onchainos wallet report-plugin-info")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "onchainos report-plugin-info failed ({}): {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+    Ok(())
+}
+
 pub async fn is_ctf_approved_for_all(owner: &str, operator: &str) -> Result<bool> {
     use crate::config::{Contracts, Urls};
     // isApprovedForAll(address,address) selector = 0xe985e9c5


### PR DESCRIPTION
## Summary

Add optional `--strategy-id` flag to `buy` / `sell` / `redeem` commands. When provided and non-empty, the plugin pushes an order-level attribution payload to the OKX backend via `onchainos wallet report-plugin-info` after the order succeeds. The backend uses this to do strategy-level PnL attribution across Polymarket (and future Hyperliquid) events.

## Payload shape

```json
{
  "wallet":       "0x... (EOA)",
  "proxyAddress": "0x... (Polymarket POLY_PROXY; empty in EOA mode)",
  "order_id":     "CLOB taker_order_id for BUY/SELL; redeem tx_hash for REDEEM",
  "tx_hashes":    ["on-chain settlement tx hashes"],
  "market_id":    "Polymarket conditionId",
  "asset_id":     "outcome token_id (empty for REDEEM)",
  "side":         "BUY | SELL | REDEEM",
  "amount":       "shares filled",
  "symbol":       "USDC.e",
  "price":        "limit price",
  "timestamp":    1776847128,
  "strategy_id":  "<user-provided>",
  "plugin_name":  "polymarket-plugin"
}
```

## Behavior

- **Opt-in**: omitting `--strategy-id` (or passing `""`) skips reporting entirely. No change to default command behavior.
- **Non-fatal**: if `onchainos wallet report-plugin-info` fails (subcommand not installed, backend unreachable, error response), the plugin logs a `Warning` to stderr and returns the normal order-success JSON on stdout. The order is already settled on-chain by the time the report fires — reporting failures must not affect trade results.
- **REDEEM aggregation**: when a redeem touches both EOA and proxy wallets (rare), both tx hashes are merged into a single REDEEM report's `tx_hashes` array.

## Files changed (11 files, +177 / −22)

- `src/onchainos.rs` — new `report_plugin_info()` wrapper shelling out to `onchainos wallet report-plugin-info`
- `src/main.rs` — `--strategy-id` flag added to Buy / Sell / Redeem subcommands
- `src/commands/buy.rs` / `sell.rs` — payload construction + call after successful `post_order`
- `src/commands/redeem.rs` — new `report_redeem()` helper; called after both single-market and `--all` paths
- `SKILL.md` / `CHANGELOG.md` / version files — docs + version bump to 0.4.10

## Test plan

- [x] `cargo build --release` — clean
- [x] `polymarket buy --help` / `sell --help` / `redeem --help` all show `--strategy-id`
- [x] Local trade without `--strategy-id` behaves unchanged (no report, no warning)
- [x] Local trade with `--strategy-id` produces correct payload structure (verified via end-to-end against real BTC-5m BUY + subgraph confirmation of orderFilledEvents indexing)
- [x] Failure path tested: running against `onchainos` v2.2.9 (no `report-plugin-info` subcommand) → Warning logged, order still succeeds
- [ ] End-to-end backend integration: pending beta endpoint availability (handed off separately)