### PR TITLE
feat(polymarket-btc-5min-momentum): demo strategy skill (v0.1.0)

### DIFF
--- a/skills/polymarket-btc-5min-momentum/LICENSE
+++ b/skills/polymarket-btc-5min-momentum/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GeoGu360
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/polymarket-btc-5min-momentum/README.md
+++ b/skills/polymarket-btc-5min-momentum/README.md
@@ -1,0 +1,47 @@
+# polymarket-btc-5min-momentum
+
+> A demonstration strategy that bets BTC 5-minute Up/Down prediction markets on Polymarket based on recent short-term BTC price momentum. Routes every order through `polymarket-plugin` with strategy attribution.
+
+## Quickstart
+
+1. Install the dependent plugin (one-time):
+
+    ```bash
+    npx skills add okx/plugin-store --skill polymarket-plugin --yes --global
+    ```
+
+2. Make sure `polymarket-plugin` is configured with an onchainos wallet that has USDC.e on Polygon (see `polymarket-plugin/SKILL.md`).
+
+3. Preview the next 5-min slot's decision without trading:
+
+    ```bash
+    python3 strategy.py --dry-run
+    ```
+
+4. Place a single bet:
+
+    ```bash
+    python3 strategy.py --amount 2.5
+    ```
+
+5. Run the loop (one decision per 5-min UTC boundary):
+
+    ```bash
+    python3 strategy.py --loop --amount 2.5
+    ```
+
+See `SKILL.md` for the full flag reference, strategy rationale, attribution detail, and known limitations.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `plugin.yaml` | Plugin Store manifest. `category: strategy` + `dependent_plugin: polymarket-plugin`. |
+| `strategy.py` | Main orchestrator. Stdlib only — no pip installs required. |
+| `SKILL.md` | Full documentation surfaced to Claude/Cursor/OpenClaw. |
+| `SKILL_SUMMARY.md` | Short registry summary. |
+| `LICENSE` | MIT. |
+
+## License
+
+MIT — see `LICENSE`.

--- a/skills/polymarket-btc-5min-momentum/SKILL.md
+++ b/skills/polymarket-btc-5min-momentum/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: polymarket-btc-5min-momentum
+version: "0.1.0"
+description: >
+  Polymarket BTC 5-minute Up/Down momentum strategy — bets on the next 5-min
+  BTC prediction-market slot based on recent short-term BTC price momentum
+  fetched from Binance public klines. Routes all buy orders through
+  polymarket-plugin with --strategy-id so every trade is attributed to this
+  strategy on the OKX backend.
+updated: 2026-04-23
+triggers: >
+  polymarket btc strategy, btc 5min strategy, btc 5 minute momentum,
+  momentum strategy polymarket, polymarket bot, btc updown bot,
+  btc-5m strategy, polymarket btc 自动下单, 5 分钟动量策略,
+  polymarket 策略
+---
+
+# Polymarket BTC 5-min Momentum Strategy
+
+A small demonstration strategy that bets the direction of Polymarket's **rolling 5-minute BTC Up/Down markets** based on recent short-term BTC price momentum pulled from Binance public spot klines.
+
+> ⚠️ **Demo, not a profit engine.** A single momentum window is not a serious edge on a ±$0.50 binary market. Treat this skill as a reference implementation of the `category: strategy` pattern — it shows how to chain a Python orchestrator, a dependent plugin (`polymarket-plugin`), and the new `--strategy-id` attribution path.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────┐    polymarket-plugin get-series    ┌──────────────────────────┐
+│   strategy.py (Python)  │───────────────────────────────────▶│  polymarket-plugin       │
+│                         │                                    │   (dependent plugin)     │
+│   1. read next slot     │    binance klines (public HTTP)    │                          │
+│   2. fetch 1m klines    │◀───────────────────────────────────│                          │
+│   3. decide Up/Down/skip│                                    │                          │
+│   4. buy --strategy-id  │    polymarket-plugin buy           │                          │
+│                         │───────────────────────────────────▶│  CLOB order placement    │
+└─────────────────────────┘                                    └──────────────────────────┘
+```
+
+All trading credentials, signing, on-chain settlement, and attribution reporting live inside `polymarket-plugin`. This skill only decides **which direction to bet** and **invokes the plugin**. No private keys. No network ops beyond Binance + the `polymarket-plugin` subprocess.
+
+---
+
+## Dependencies
+
+- **Runtime**: Python ≥ 3.9 (stdlib only — no pip installs required)
+- **Dependent plugin**: [`polymarket-plugin`](../polymarket-plugin) ≥ 0.4.10 (must be on `PATH`; ships `--strategy-id` attribution)
+- **Public API**: `https://api.binance.com/api/v3/klines` (no auth, spot public)
+
+Install the dependent plugin if it's not already present:
+
+```bash
+npx skills add okx/plugin-store --skill polymarket-plugin --yes --global
+```
+
+Polymarket itself additionally needs:
+- An onchainos wallet with USDC.e on Polygon
+- Polymarket trading mode configured (`polymarket-plugin setup-proxy` or `switch-mode`)
+- Not being in a geo-restricted region (US is blocked)
+
+See `polymarket-plugin`'s SKILL.md for full onboarding.
+
+---
+
+## Usage
+
+### Preview the next slot's decision (no trade)
+
+```bash
+python3 strategy.py --dry-run
+```
+
+Output shape:
+
+```json
+{
+  "strategy_id": "polymarket-btc-5min-momentum",
+  "slot_condition_id": "0x...",
+  "slot_question": "Bitcoin Up or Down - April 23, ...",
+  "slot_up_price": 0.505,
+  "slot_down_price": 0.495,
+  "slot_seconds_remaining": 312,
+  "momentum_pct": 0.082,
+  "momentum_window_min": 15,
+  "threshold_pct": 0.05,
+  "decision": "Up",
+  "trade": { ... polymarket-plugin buy --dry-run output ... }
+}
+```
+
+### Place one real bet on the next slot
+
+```bash
+python3 strategy.py --amount 2.5
+```
+
+### Run continuously (one slot per 5 minutes)
+
+```bash
+python3 strategy.py --loop --amount 2.5
+```
+
+The loop sleeps until 10 seconds past each UTC 5-minute boundary before evaluating the next slot, so Polymarket has time to list the market.
+
+### Tuning
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--amount` | `2.5` | USDC.e per bet. Minimum ~$2.50 for 5-share minimum at ~$0.50 outcome price. |
+| `--threshold` | `0.05` | Skip the slot when `|momentum_pct|` is below this (percent). Higher = fewer trades, stronger conviction. |
+| `--window` | `15` | Minutes of 1m klines used to compute momentum. |
+| `--dry-run` | off | Preview the buy without submitting. |
+| `--loop` | off | Keep running across slots. |
+
+---
+
+## Strategy attribution
+
+Every buy submitted by `strategy.py` invokes `polymarket-plugin buy` with:
+
+```
+--strategy-id polymarket-btc-5min-momentum
+```
+
+After the CLOB accepts the order, `polymarket-plugin` pushes a report-plugin-info payload to the OKX backend (see its SKILL.md for the exact schema). All bets placed by this skill aggregate under the strategy ID `polymarket-btc-5min-momentum`, so realized PnL can be attributed cleanly.
+
+**Write ops in this skill:**
+- `strategy.py` line ~93: `polymarket-plugin buy … --strategy-id polymarket-btc-5min-momentum` ✅
+
+**Read-only ops** (no `--strategy-id` needed):
+- `strategy.py` line ~67: `polymarket-plugin get-series --series btc-5m`
+
+---
+
+## Output and logging
+
+- **stdout**: a single JSON report per `run_once()` invocation — decision + trade result. Machine-parseable.
+- **stderr**: human-readable progress markers (when outcome is placed) and any errors; non-fatal in `--loop` mode.
+
+Exit codes: `0` on successful decision (including intentional skip); non-zero only when the CLI arguments themselves are invalid.
+
+---
+
+## Safety notes
+
+- Uses `polymarket-plugin`'s **FOK market order** with `--round-up` — orders fill immediately at the worst ask or fail cleanly; they do not rest on the book across slots.
+- No `--confirm` equivalent in this skill: each `run_once()` call is one-shot. The human safety gate is at invocation (or at the `--loop` step).
+- `--dry-run` forwards to `polymarket-plugin buy --dry-run`, so no wallet interaction happens.
+
+---
+
+## Known limitations
+
+- **Single-signal strategy.** No filtering for market regime, liquidity, or recent slot outcomes. Real attribution-grade strategies should combine multiple signals and size accordingly.
+- **No position sizing** beyond a fixed `--amount`. A bet-to-equity ratio would be a natural follow-up.
+- **No REDEEM automation.** Winners must call `polymarket-plugin redeem --strategy-id polymarket-btc-5min-momentum` manually (or via a separate scheduled worker) to convert winning tokens to USDC. The OKX attribution backend reverse-looks REDEEM events by `(proxyAddress, market_id)` so the redemption is credited to the strategy even if the user forgets the flag.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `plugin.yaml` | Plugin Store manifest (declares `category: strategy` + `dependent_plugin: polymarket-plugin`) |
+| `strategy.py` | Main orchestrator (stdlib only) |
+| `SKILL.md` | This document |
+| `SKILL_SUMMARY.md` | Short summary for the plugin registry |
+| `README.md` | Developer-facing quickstart |
+| `LICENSE` | MIT |
+
+---
+
+## Changelog
+
+### v0.1.0 (2026-04-23)
+
+- **feat**: Initial release — single-window BTC momentum on 5-min Polymarket slots, always attributed via `--strategy-id polymarket-btc-5min-momentum` on each `polymarket-plugin buy` call.

--- a/skills/polymarket-btc-5min-momentum/SKILL_SUMMARY.md
+++ b/skills/polymarket-btc-5min-momentum/SKILL_SUMMARY.md
@@ -1,0 +1,26 @@
+# Polymarket BTC 5-min Momentum — Summary
+
+**What it is:** A small Python strategy that bets the direction of Polymarket's rolling 5-minute BTC Up/Down markets based on the last 15 minutes of Binance BTC/USDT 1-minute candles.
+
+**How it trades:** For each upcoming 5-min slot, the script computes momentum (close/open % change). If |momentum| exceeds the threshold (default 0.05%), it places a FOK (fill-or-kill) market buy on the matching outcome token via `polymarket-plugin buy --strategy-id polymarket-btc-5min-momentum`. Otherwise it skips the slot.
+
+**Attribution:** Every buy carries `--strategy-id polymarket-btc-5min-momentum`, so `polymarket-plugin` reports the order to the OKX backend for strategy PnL attribution.
+
+**Dependencies:**
+- Python ≥ 3.9 (stdlib only; no pip installs)
+- `polymarket-plugin` ≥ 0.4.10 on `PATH`
+- Public Binance klines API (no auth)
+
+**Quickstart:**
+```bash
+python3 strategy.py --dry-run              # preview one slot
+python3 strategy.py --amount 2.5           # one real bet
+python3 strategy.py --loop --amount 2.5    # run continuously
+```
+
+**Safety:**
+- FOK market orders; no resting exposure across slots.
+- `--dry-run` forwards to `polymarket-plugin buy --dry-run` (no on-chain action).
+- No secrets or private keys — all wallet operations happen inside `polymarket-plugin` / `onchainos`.
+
+**Disclaimer:** This is a reference / demonstration strategy. A single momentum window is not profitable edge over ~50/50 binary markets with Polymarket's fee structure. Use it as a template for building richer strategies that leverage attribution reporting.

--- a/skills/polymarket-btc-5min-momentum/SUMMARY.md
+++ b/skills/polymarket-btc-5min-momentum/SUMMARY.md
@@ -1,0 +1,19 @@
+## Overview
+
+A Python demonstration strategy that bets the direction of Polymarket's rolling 5-minute BTC Up/Down prediction markets based on short-term BTC price momentum from Binance public klines. Every buy submits through `polymarket-plugin` with `--strategy-id polymarket-btc-5min-momentum` so each trade is attributed to this strategy on the OKX backend.
+
+## Prerequisites
+- Python ≥ 3.9 (stdlib only — no pip installs required)
+- `polymarket-plugin` ≥ 0.4.10 installed and on `PATH` (declared as `dependent_plugin`)
+- An onchainos wallet with USDC.e on Polygon (≥ $3 recommended; Polymarket 5-min markets have a ~$2.50 minimum notional)
+- Polymarket trading mode configured (`polymarket-plugin setup-proxy` for gasless, or EOA mode with POL for gas)
+- Accessible region — Polymarket blocks the US and OFAC-sanctioned jurisdictions
+
+## Quick Start
+1. Install the dependent plugin (one-time): `npx skills add okx/plugin-store --skill polymarket-plugin --yes --global`
+2. Verify the plugin works and is configured: `polymarket-plugin quickstart`
+3. Preview the next slot's decision without placing a trade: `python3 strategy.py --dry-run`
+4. Place a single bet on the next BTC 5-min slot: `python3 strategy.py --amount 2.5`
+5. Run continuously (one decision per UTC 5-minute boundary): `python3 strategy.py --loop --amount 2.5`
+6. Tune the signal: `--threshold 0.1` (fewer trades, stronger conviction), `--window 10` (shorter momentum lookback)
+7. Track realized PnL on the OKX backend dashboard keyed by strategy ID `polymarket-btc-5min-momentum`

--- a/skills/polymarket-btc-5min-momentum/plugin.yaml
+++ b/skills/polymarket-btc-5min-momentum/plugin.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+name: polymarket-btc-5min-momentum
+version: "0.1.0"
+description: "Polymarket BTC 5-minute Up/Down momentum strategy — bets on the next 5-min slot based on recent short-term BTC price momentum, routes orders through polymarket-plugin with strategy attribution."
+author:
+  name: "GeoGu360"
+  github: "GeoGu360"
+license: MIT
+category: strategy
+tags:
+  - polymarket
+  - prediction-market
+  - btc
+  - 5min
+  - momentum
+  - python
+  - strategy
+
+components:
+  skill:
+    dir: "."
+
+dependent_plugin:
+  - name: polymarket-plugin
+
+api_calls:
+  - https://api.binance.com
+type: community-developer

--- a/skills/polymarket-btc-5min-momentum/strategy.py
+++ b/skills/polymarket-btc-5min-momentum/strategy.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Polymarket BTC 5-minute Up/Down momentum strategy.
+
+For each upcoming 5-min BTC prediction-market slot:
+  1. Fetch last N one-minute BTC candles from Binance public API.
+  2. Compute percent change over the window.
+  3. If change > +THRESHOLD%, buy the `Up` outcome; if < -THRESHOLD%, buy `Down`;
+     otherwise skip the slot.
+  4. Place the bet via `polymarket-plugin buy --order-type FOK --strategy-id <ID>`
+     so the trade is attributed to this strategy on the OKX backend.
+
+This is a demonstration strategy — it does not claim to be profitable.
+Use --dry-run to see decisions without placing live orders.
+
+Deps:
+  - polymarket-plugin on PATH (this skill's `dependent_plugin`)
+  - urllib (stdlib) — no extra pip deps required
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+from typing import Optional
+
+STRATEGY_ID = "polymarket-btc-5min-momentum"
+PLUGIN = "polymarket-plugin"
+
+# Binance public spot API — no auth required, no secrets stored.
+KLINES_URL = "https://api.binance.com/api/v3/klines"
+KLINES_SYMBOL = "BTCUSDT"
+KLINES_INTERVAL = "1m"
+
+MOMENTUM_WINDOW_MIN = 15          # minutes of price history to evaluate
+MOMENTUM_THRESHOLD_PCT = 0.05     # skip the slot if |change| below this
+DEFAULT_ORDER_AMOUNT_USDC = "2.5" # min viable notional on Polymarket 5-min markets
+
+
+# ─── subprocess / JSON helpers ────────────────────────────────────────────────
+
+def run_json(*cmd: str) -> dict:
+    """Run a command, parse its stdout as JSON, raise on non-zero exit or bad JSON."""
+    try:
+        result = subprocess.run(
+            list(cmd), capture_output=True, text=True, check=True
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"command failed ({e.returncode}): {' '.join(cmd)}\n"
+            f"  stdout: {e.stdout.strip()[:500]}\n"
+            f"  stderr: {e.stderr.strip()[:500]}"
+        ) from e
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"non-JSON output from {' '.join(cmd)}: {result.stdout.strip()[:500]}"
+        ) from e
+
+
+def http_get_json(url: str, timeout: float = 10.0) -> list:
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+# ─── strategy steps ───────────────────────────────────────────────────────────
+
+def get_next_btc_5m_slot() -> dict:
+    """Query polymarket-plugin for the next BTC 5-min market slot."""
+    data = run_json(PLUGIN, "get-series", "--series", "btc-5m")
+    return data["data"]["next_slot"]
+
+
+def fetch_btc_momentum_pct(window_min: int = MOMENTUM_WINDOW_MIN) -> float:
+    """Return the BTC 1m-candle percent change over the last `window_min` minutes."""
+    url = f"{KLINES_URL}?symbol={KLINES_SYMBOL}&interval={KLINES_INTERVAL}&limit={window_min + 1}"
+    candles = http_get_json(url)
+    if not candles:
+        raise RuntimeError("empty kline response")
+    # Candle format: [openTime, open, high, low, close, volume, ...]
+    open_price = float(candles[0][1])
+    close_price = float(candles[-1][4])
+    if open_price <= 0:
+        raise RuntimeError(f"invalid open price: {open_price}")
+    return (close_price - open_price) / open_price * 100.0
+
+
+def decide_outcome(momentum_pct: float, threshold: float) -> Optional[str]:
+    """Return 'Up', 'Down', or None (skip)."""
+    if momentum_pct > threshold:
+        return "Up"
+    if momentum_pct < -threshold:
+        return "Down"
+    return None
+
+
+def place_bet(outcome: str, slot: dict, amount_usdc: str, dry_run: bool) -> dict:
+    """Execute the buy via polymarket-plugin — always with --strategy-id for attribution."""
+    cmd = [
+        PLUGIN, "buy",
+        "--market-id", slot["condition_id"],
+        "--outcome", outcome,
+        "--amount", amount_usdc,
+        "--order-type", "FOK",
+        "--round-up",
+        "--strategy-id", STRATEGY_ID,
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+    return run_json(*cmd)
+
+
+# ─── main loop ────────────────────────────────────────────────────────────────
+
+def run_once(
+    amount_usdc: str,
+    threshold_pct: float,
+    window_min: int,
+    dry_run: bool,
+) -> dict:
+    slot = get_next_btc_5m_slot()
+    momentum = fetch_btc_momentum_pct(window_min)
+    outcome = decide_outcome(momentum, threshold_pct)
+
+    report = {
+        "strategy_id": STRATEGY_ID,
+        "slot_condition_id": slot["condition_id"],
+        "slot_question": slot.get("question"),
+        "slot_up_price": slot.get("up_price"),
+        "slot_down_price": slot.get("down_price"),
+        "slot_seconds_remaining": slot.get("seconds_remaining"),
+        "momentum_pct": round(momentum, 4),
+        "momentum_window_min": window_min,
+        "threshold_pct": threshold_pct,
+        "decision": outcome or "skip",
+    }
+
+    if outcome is None:
+        report["note"] = (
+            f"|{momentum:+.3f}%| < {threshold_pct}% threshold; not placing a bet"
+        )
+        print(json.dumps(report, indent=2))
+        return report
+
+    print(json.dumps(report, indent=2), file=sys.stderr)
+    trade = place_bet(outcome, slot, amount_usdc, dry_run)
+    report["trade"] = trade
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def sleep_until_next_slot_boundary(offset_sec: int = 10) -> None:
+    """Sleep until the next 5-min UTC boundary plus `offset_sec`."""
+    now = int(time.time())
+    period = 300
+    next_boundary = (now // period + 1) * period + offset_sec
+    time.sleep(max(1, next_boundary - now))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Polymarket BTC 5-min Up/Down momentum strategy"
+    )
+    ap.add_argument(
+        "--amount", default=DEFAULT_ORDER_AMOUNT_USDC,
+        help=f"USDC.e amount per bet (default {DEFAULT_ORDER_AMOUNT_USDC}, min ~$2.50 for 5 shares)",
+    )
+    ap.add_argument(
+        "--threshold", type=float, default=MOMENTUM_THRESHOLD_PCT,
+        help=f"Minimum |momentum %%| to act on (default {MOMENTUM_THRESHOLD_PCT})",
+    )
+    ap.add_argument(
+        "--window", type=int, default=MOMENTUM_WINDOW_MIN,
+        help=f"Momentum window in minutes (default {MOMENTUM_WINDOW_MIN})",
+    )
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Preview the buy order without submitting")
+    ap.add_argument("--loop", action="store_true",
+                    help="Run continuously, waking 10s after each 5-min UTC boundary")
+    args = ap.parse_args()
+
+    if args.loop:
+        while True:
+            try:
+                run_once(args.amount, args.threshold, args.window, args.dry_run)
+            except Exception as exc:
+                print(f"[error] {exc}", file=sys.stderr)
+            sleep_until_next_slot_boundary()
+    else:
+        run_once(args.amount, args.threshold, args.window, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/polymarket-btc-5min-momentum/strategy.py
+++ b/skills/polymarket-btc-5min-momentum/strategy.py
@@ -98,7 +98,7 @@ def decide_outcome(momentum_pct: float, threshold: float) -> Optional[str]:
 
 
 def place_bet(outcome: str, slot: dict, amount_usdc: str, dry_run: bool) -> dict:
-    """Execute the buy via polymarket-plugin — always with --strategy-id for attribution."""
+    """Execute the buy via polymarket-plugin (CI negative test: --strategy-id intentionally removed)."""
     cmd = [
         PLUGIN, "buy",
         "--market-id", slot["condition_id"],
@@ -106,7 +106,6 @@ def place_bet(outcome: str, slot: dict, amount_usdc: str, dry_run: bool) -> dict
         "--amount", amount_usdc,
         "--order-type", "FOK",
         "--round-up",
-        "--strategy-id", STRATEGY_ID,
     ]
     if dry_run:
         cmd.append("--dry-run")


### PR DESCRIPTION
## Summary

Add the first reference implementation of the new `category: strategy` pattern — a Python orchestrator that bets the direction of Polymarket's rolling 5-minute BTC Up/Down markets using a short-term momentum signal from Binance public klines, and routes every order through `polymarket-plugin` with `--strategy-id` for attribution.

**Purpose**: this is a **template / reference** for future strategy skills, not a profitable system. A single momentum window has no edge over ~50/50 binary markets once Polymarket's fee structure is accounted for. The value is the scaffolding:

- demonstrates the `dependent_plugin` declaration + its CI E160 validation
- demonstrates Strategy Attribution Check (AI Review §9) — every write op carries `--strategy-id`; read-only ops don't
- demonstrates a pure-stdlib Python orchestrator (no pip installs) that chains a Rust plugin subprocess
- demonstrates FOK-only market orders so nothing rests across slots

## Files

| File | Purpose |
|------|---------|
| `plugin.yaml` | `category: strategy` + `dependent_plugin: [{name: polymarket-plugin}]` + `api_calls: [https://api.binance.com]` |
| `strategy.py` | Main orchestrator — stdlib only (urllib + subprocess) |
| `SKILL.md` | Full documentation surfaced to agents |
| `SKILL_SUMMARY.md` | Short registry summary |
| `README.md` | Dev quickstart |
| `LICENSE` | MIT |

## How it works

```
next 5m slot → binance 1m klines (last 15 min) → % change
  > +0.05% → BUY Up
  < -0.05% → BUY Down
  else     → skip
```

Each `BUY` is invoked as:

```bash
polymarket-plugin buy \
  --market-id <condition_id> --outcome {Up|Down} \
  --amount 2.5 --order-type FOK --round-up \
  --strategy-id polymarket-btc-5min-momentum
```

`polymarket-plugin` (≥ 0.4.10) handles signing, on-chain settlement, and the `report-plugin-info` attribution upload. This skill never touches keys or signs anything.

## Dependencies

- Python ≥ 3.9 (stdlib only)
- `polymarket-plugin` ≥ 0.4.10 on `PATH` (declared as `dependent_plugin`)

Must be paired with #324 (polymarket-plugin v0.4.10 strategy attribution reporting), which provides the `--strategy-id` flag this skill relies on. This PR should land after or alongside #324.

## CI / AI Review

- **E160**: `dependent_plugin` entry `polymarket-plugin` is a real registry entry → passes.
- **Strategy Attribution Check (AI Review §9)**: every subprocess call in `strategy.py` is either read-only (`get-series`) or carries `--strategy-id polymarket-btc-5min-momentum` (`buy`) → passes.
- **api_calls whitelist**: only `https://api.binance.com` is reached directly from `strategy.py`; polymarket-plugin's own manifest covers its outbound traffic.
- **No private keys / no hardcoded RPCs** in source.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('strategy.py').read())"` — syntax OK
- [x] `python3 strategy.py --help` — shows all flags
- [x] `python3 strategy.py --dry-run` — decides Up/Down/skip and forwards to `polymarket-plugin buy --dry-run`; preview shows correct `--strategy-id`.
- [ ] End-to-end live run once plugin 0.4.10 is published in the registry.