### PR TITLE
[new-plugin] hl-funding-flow-hunter v1.0.0

### DIFF
--- a/skills/hl-funding-flow-hunter/.claude-plugin/plugin.json
+++ b/skills/hl-funding-flow-hunter/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "hl-funding-flow-hunter",
+  "description": "Hyperliquid funding and flow strategy scanner with guarded execution",
+  "version": "1.0.0",
+  "author": {
+    "name": "KB"
+  },
+  "license": "MIT",
+  "keywords": [
+    "hyperliquid",
+    "perpetuals",
+    "funding",
+    "trading-strategy",
+    "risk-management"
+  ]
+}

--- a/skills/hl-funding-flow-hunter/LICENSE
+++ b/skills/hl-funding-flow-hunter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/hl-funding-flow-hunter/SKILL.md
+++ b/skills/hl-funding-flow-hunter/SKILL.md
@@ -48,11 +48,13 @@ hyperliquid quickstart
 ### Scan Funding and Flow
 
 ```bash
-python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+python3 ./scripts/scan_funding.py --top 5
 ```
 
+Run this command from the `hl-funding-flow-hunter` skill directory. If the agent is operating from a plugin-store checkout, use `python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5` instead.
+
 **When to use**: When the user asks for funding candidates, flow opportunities, or a low-leverage Hyperliquid perp setup.
-**Output**: JSON with ranked candidates, suggested side, funding, volume, open interest, score, and risk flags.
+**Output**: JSON with ranked candidates, suggested side, funding, volume, open interest base, open interest notional, score, and risk flags.
 **Safety**: This command is read-only and does not prepare or submit orders.
 
 ### Get Current Price
@@ -134,7 +136,7 @@ Use this workflow when the user asks for a funding or flow strategy:
 1. Run the scanner:
 
 ```bash
-python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+python3 ./scripts/scan_funding.py --top 5
 ```
 
 2. Present the top candidates with:
@@ -144,7 +146,7 @@ python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
 - funding rate
 - estimated annualized funding
 - 24h volume
-- open interest
+- open interest base and open interest notional
 - score
 - risk flags
 
@@ -170,7 +172,7 @@ python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
 ```text
 Top candidate: <COIN>
 Suggested side: SELL
-Reason: positive funding, sufficient volume, acceptable open interest
+Reason: positive funding, sufficient volume, acceptable open interest notional
 Leverage: 2x isolated
 Estimated notional: <USDC>
 Estimated margin: <USDC>
@@ -192,7 +194,7 @@ Reply confirm to dry-run, alternatives to see more candidates, or skip.
 - Default to 1-2x leverage; do not exceed 3x.
 - Suggested single-coin margin cap: 20% of account equity.
 - Suggested session risk budget: 5% of account equity.
-- Exclude or warn on low 24h volume, low open interest, thin liquidity, or fast funding reversals.
+- Exclude or warn on low 24h volume, low open interest notional, thin liquidity, or fast funding reversals.
 - Always run a dry-run before live execution.
 - Never support unlimited autonomous trading.
 - Never ask for private keys, seed phrases, API secrets, or email OTP codes.
@@ -205,7 +207,7 @@ User: "Find the best Hyperliquid funding setup under 500 USDC margin."
 
 Agent:
 
-1. Runs `python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5`.
+1. Runs `python3 ./scripts/scan_funding.py --top 5` from the skill directory.
 2. Shows the top 3 candidates and risk flags.
 3. Asks the user to choose one.
 4. Gets current price and calculates size.

--- a/skills/hl-funding-flow-hunter/SKILL.md
+++ b/skills/hl-funding-flow-hunter/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: hl-funding-flow-hunter
+description: "Hyperliquid funding and flow strategy scanner with guarded execution"
+version: "1.0.0"
+author: "KB"
+tags:
+  - hyperliquid
+  - perpetuals
+  - funding
+  - trading-strategy
+  - risk-management
+---
+
+# HL Funding Flow Hunter
+
+## Overview
+
+This skill scans Hyperliquid perpetual markets for funding-rate and flow opportunities, then helps the user prepare guarded low-leverage execution through `hyperliquid-plugin`. The bundled scanner is read-only: it queries public Hyperliquid market data and never places orders.
+
+Live trading must always use `hyperliquid order` or `hyperliquid close` from `hyperliquid-plugin`, and every write command must include `--strategy-id hl-funding-flow-hunter`.
+
+## Pre-flight Checks
+
+Before using this skill:
+
+1. Install the dependency:
+
+```bash
+npx skills add okx/plugin-store --skill hyperliquid-plugin --yes
+```
+
+2. Ensure the Hyperliquid account is registered:
+
+```bash
+hyperliquid register
+```
+
+3. Check setup and balances:
+
+```bash
+hyperliquid quickstart
+```
+
+4. Explain that perpetual futures can lose more than the expected funding benefit, especially when leverage is used.
+
+## Commands
+
+### Scan Funding and Flow
+
+```bash
+python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+```
+
+**When to use**: When the user asks for funding candidates, flow opportunities, or a low-leverage Hyperliquid perp setup.
+**Output**: JSON with ranked candidates, suggested side, funding, volume, open interest, score, and risk flags.
+**Safety**: This command is read-only and does not prepare or submit orders.
+
+### Get Current Price
+
+```bash
+hyperliquid prices --coin ETH
+```
+
+**When to use**: Before sizing an order, setting stop loss, or setting take profit.
+**Output**: Current Hyperliquid price information for the selected coin.
+
+### Dry-run Order
+
+```bash
+hyperliquid order \
+  --coin <COIN> \
+  --side sell \
+  --size <SIZE> \
+  --type market \
+  --leverage 2 \
+  --isolated \
+  --sl-px <STOP_LOSS_PRICE> \
+  --tp-px <TAKE_PROFIT_PRICE> \
+  --dry-run \
+  --strategy-id hl-funding-flow-hunter
+```
+
+**When to use**: Before any live order, after the user chooses a candidate, direction, size, leverage, stop loss, and take profit.
+**Output**: A preview of the order without placing a real trade.
+**Required**: Use `--strategy-id hl-funding-flow-hunter` on every dry-run and live write command.
+
+### Confirmed Order
+
+```bash
+hyperliquid order \
+  --coin <COIN> \
+  --side sell \
+  --size <SIZE> \
+  --type market \
+  --leverage 2 \
+  --isolated \
+  --sl-px <STOP_LOSS_PRICE> \
+  --tp-px <TAKE_PROFIT_PRICE> \
+  --confirm \
+  --strategy-id hl-funding-flow-hunter
+```
+
+**When to use**: Only after the user explicitly confirms the coin, side, size, leverage, stop loss, take profit, and risk budget.
+**Output**: A Hyperliquid order result from the dependency plugin.
+
+### Dry-run Close
+
+```bash
+hyperliquid close \
+  --coin <COIN> \
+  --dry-run \
+  --strategy-id hl-funding-flow-hunter
+```
+
+**When to use**: Before closing a live position.
+**Output**: A preview of the close action without placing a real trade.
+
+### Confirmed Close
+
+```bash
+hyperliquid close \
+  --coin <COIN> \
+  --confirm \
+  --strategy-id hl-funding-flow-hunter
+```
+
+**When to use**: Only after the user explicitly confirms the close.
+**Output**: A Hyperliquid close result from the dependency plugin.
+
+## Strategy Workflow
+
+Use this workflow when the user asks for a funding or flow strategy:
+
+1. Run the scanner:
+
+```bash
+python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+```
+
+2. Present the top candidates with:
+
+- coin
+- suggested side
+- funding rate
+- estimated annualized funding
+- 24h volume
+- open interest
+- score
+- risk flags
+
+3. Ask the user to choose a candidate or request alternatives.
+4. Get current price with `hyperliquid prices --coin <COIN>`.
+5. Convert the user's intended USDC notional into coin size. Hyperliquid `--size` is the coin quantity, not USDC amount.
+6. Propose conservative risk parameters:
+
+- isolated margin
+- 1-2x leverage by default
+- maximum 3x leverage
+- stop loss before live execution
+- take profit or funding-normalization exit rule
+- maximum holding time
+
+7. Run a dry-run order first.
+8. Ask for explicit confirmation.
+9. If confirmed, execute the live order with `--confirm --strategy-id hl-funding-flow-hunter`.
+10. Track the planned exit conditions and use `hyperliquid close` only after confirmation.
+
+## Candidate Presentation Template
+
+```text
+Top candidate: <COIN>
+Suggested side: SELL
+Reason: positive funding, sufficient volume, acceptable open interest
+Leverage: 2x isolated
+Estimated notional: <USDC>
+Estimated margin: <USDC>
+Coin size: <SIZE>
+Stop loss: <SL>
+Take profit: <TP>
+Exit conditions: funding normalizes, stop loss hits, take profit hits, or max holding time is reached
+Strategy ID: hl-funding-flow-hunter
+
+Reply confirm to dry-run, alternatives to see more candidates, or skip.
+```
+
+## Guardrails
+
+- The scanner is read-only and must never call Hyperliquid exchange order APIs directly.
+- Live orders must go through `hyperliquid-plugin`.
+- Every order and close command must include `--strategy-id hl-funding-flow-hunter`.
+- Default to isolated margin.
+- Default to 1-2x leverage; do not exceed 3x.
+- Suggested single-coin margin cap: 20% of account equity.
+- Suggested session risk budget: 5% of account equity.
+- Exclude or warn on low 24h volume, low open interest, thin liquidity, or fast funding reversals.
+- Always run a dry-run before live execution.
+- Never support unlimited autonomous trading.
+- Never ask for private keys, seed phrases, API secrets, or email OTP codes.
+
+## Examples
+
+### Scan and Prepare a Candidate
+
+User: "Find the best Hyperliquid funding setup under 500 USDC margin."
+
+Agent:
+
+1. Runs `python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5`.
+2. Shows the top 3 candidates and risk flags.
+3. Asks the user to choose one.
+4. Gets current price and calculates size.
+5. Runs a dry-run order only after the user accepts the proposed parameters.
+6. Runs the live order only after explicit confirmation.
+
+### Live Order After Confirmation
+
+```bash
+hyperliquid order \
+  --coin ETH \
+  --side sell \
+  --size <SIZE> \
+  --type market \
+  --leverage 2 \
+  --isolated \
+  --sl-px <STOP_LOSS_PRICE> \
+  --tp-px <TAKE_PROFIT_PRICE> \
+  --confirm \
+  --strategy-id hl-funding-flow-hunter
+```
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `hyperliquid_api_unavailable` | Public Hyperliquid info API failed or timed out | Wait and retry, or lower `--top`; do not trade without fresh data |
+| `unexpected_hyperliquid_response` | API response shape changed | Report the raw error and avoid live execution until the scanner is updated |
+| No candidates | Filters removed all markets | Relax read-only filters or ask the user to try later |
+| Invalid size | Hyperliquid size is coin quantity, not USDC notional | Recalculate size from current price and coin decimals |
+| Missing confirmation | Live write has not been approved | Ask the user to confirm coin, side, size, leverage, stop loss, take profit, and risk budget |
+| Insufficient margin | Account lacks available USDC | Ask the user whether they want deposit/setup guidance from `hyperliquid quickstart` |
+
+## Security Notices
+
+- This is a standard-risk trading strategy skill for perpetual futures.
+- Funding can reverse quickly, and price movement can overwhelm expected funding income.
+- Leverage increases liquidation risk.
+- The scanner only reads public market data from `https://api.hyperliquid.xyz`.
+- This skill must never request or store private keys, seed phrases, API secrets, or OTP codes.
+- This skill is a guarded trading co-pilot, not an unattended trading bot.

--- a/skills/hl-funding-flow-hunter/SKILL.md
+++ b/skills/hl-funding-flow-hunter/SKILL.md
@@ -11,6 +11,74 @@ tags:
   - risk-management
 ---
 
+
+## Pre-flight Dependencies (auto-injected by Plugin Store CI)
+
+> Run once per session before first use. These checks ensure required tools are installed.
+
+### Version check (auto-injected)
+
+> **AI Agent Instruction**: Run this version check before executing any commands from this skill. If an update is applied, re-read this SKILL.md before proceeding — the instructions may have changed.
+
+```bash
+# Check for skill updates (1-hour cache)
+UPDATE_CACHE="$HOME/.plugin-store/update-cache/hl-funding-flow-hunter"
+CACHE_MAX=3600
+LOCAL_VER="1.0.0"
+DO_CHECK=true
+
+if [ -f "$UPDATE_CACHE" ]; then
+  CACHE_MOD=$(stat -f %m "$UPDATE_CACHE" 2>/dev/null || stat -c %Y "$UPDATE_CACHE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  AGE=$(( NOW - CACHE_MOD ))
+  [ "$AGE" -lt "$CACHE_MAX" ] && DO_CHECK=false
+fi
+
+if [ "$DO_CHECK" = true ]; then
+  REMOTE_VER=$(curl -sf --max-time 3 "https://raw.githubusercontent.com/okx/plugin-store/main/skills/hl-funding-flow-hunter/plugin.yaml" | grep '^version' | head -1 | tr -d '"' | awk '{print $2}')
+  if [ -n "$REMOTE_VER" ]; then
+    mkdir -p "$HOME/.plugin-store/update-cache"
+    echo "$REMOTE_VER" > "$UPDATE_CACHE"
+  fi
+fi
+
+REMOTE_VER=$(cat "$UPDATE_CACHE" 2>/dev/null || echo "$LOCAL_VER")
+if [ "$REMOTE_VER" != "$LOCAL_VER" ]; then
+  echo "Update available: hl-funding-flow-hunter v$LOCAL_VER -> v$REMOTE_VER. Updating..."
+  npx skills add okx/plugin-store --skill hl-funding-flow-hunter --yes --global 2>/dev/null || true
+  echo "Updated hl-funding-flow-hunter to v$REMOTE_VER. Please re-read this SKILL.md."
+fi
+```
+
+### Report install (auto-injected, runs once)
+
+```bash
+REPORT_FLAG="$HOME/.plugin-store/reported/hl-funding-flow-hunter"
+if [ ! -f "$REPORT_FLAG" ]; then
+  mkdir -p "$HOME/.plugin-store/reported"
+  # Device fingerprint → SHA256 → 32-char device ID
+  DEV_RAW="$(hostname):$(uname -s):$(uname -m):$HOME"
+  DEV_ID=$(echo -n "$DEV_RAW" | shasum -a 256 | head -c 32)
+  # HMAC signature (obfuscated key, same as CLI binary)
+  _K=$(echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | base64 -d 2>/dev/null || echo 'OE9nNWFRUFdfSVJkektrMExOV2RNeTIzV2JibXo3ZWNTbExJUDFIWnVoZw==' | openssl base64 -d)
+  HMAC_SIG=$(echo -n "${_K}${DEV_ID}" | shasum -a 256 | head -c 8)
+  DIV_ID="${DEV_ID}${HMAC_SIG}"
+  unset _K
+  # Report to Vercel stats
+  curl -s -X POST "https://plugin-store-dun.vercel.app/install" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"hl-funding-flow-hunter","version":"1.0.0"}' >/dev/null 2>&1 || true
+  # Report to OKX API (with HMAC-signed device token)
+  curl -s -X POST "https://www.okx.com/priapi/v1/wallet/plugins/download/report" \
+    -H "Content-Type: application/json" \
+    -d '{"pluginName":"hl-funding-flow-hunter","divId":"'"$DIV_ID"'"}' >/dev/null 2>&1 || true
+  touch "$REPORT_FLAG"
+fi
+```
+
+---
+
+
 # HL Funding Flow Hunter
 
 ## Overview

--- a/skills/hl-funding-flow-hunter/SUMMARY.md
+++ b/skills/hl-funding-flow-hunter/SUMMARY.md
@@ -1,0 +1,60 @@
+# hl-funding-flow-hunter
+
+## Overview
+
+HL Funding Flow Hunter is a guarded Hyperliquid strategy scanner for funding-rate and flow-based perpetual futures setups.
+
+Core operations:
+
+- Scan public Hyperliquid market data for funding, volume, and open interest candidates
+- Rank candidates with risk flags
+- Prepare low-leverage isolated order previews
+- Execute only through `hyperliquid-plugin` after explicit confirmation
+- Attribute every write operation with `--strategy-id hl-funding-flow-hunter`
+
+## Prerequisites
+
+- `hyperliquid-plugin` installed from the OKX Plugin Store
+- Python 3 for the read-only scanner script
+- A registered Hyperliquid account
+- Available USDC margin on Hyperliquid
+- User-defined risk budget, stop loss, take profit, and maximum holding time
+
+## Quick Start
+
+Install the dependency:
+
+```bash
+npx skills add okx/plugin-store --skill hyperliquid-plugin --yes
+```
+
+Register and check setup:
+
+```bash
+hyperliquid register
+hyperliquid quickstart
+```
+
+Scan funding candidates:
+
+```bash
+python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+```
+
+Preview a guarded order:
+
+```bash
+hyperliquid order --coin <COIN> --side sell --size <SIZE> --type market --leverage 2 --isolated --sl-px <SL> --tp-px <TP> --dry-run --strategy-id hl-funding-flow-hunter
+```
+
+Execute only after explicit user confirmation:
+
+```bash
+hyperliquid order --coin <COIN> --side sell --size <SIZE> --type market --leverage 2 --isolated --sl-px <SL> --tp-px <TP> --confirm --strategy-id hl-funding-flow-hunter
+```
+
+Close only after explicit user confirmation:
+
+```bash
+hyperliquid close --coin <COIN> --confirm --strategy-id hl-funding-flow-hunter
+```

--- a/skills/hl-funding-flow-hunter/SUMMARY.md
+++ b/skills/hl-funding-flow-hunter/SUMMARY.md
@@ -6,7 +6,7 @@ HL Funding Flow Hunter is a guarded Hyperliquid strategy scanner for funding-rat
 
 Core operations:
 
-- Scan public Hyperliquid market data for funding, volume, and open interest candidates
+- Scan public Hyperliquid market data for funding, volume, and open interest notional candidates
 - Rank candidates with risk flags
 - Prepare low-leverage isolated order previews
 - Execute only through `hyperliquid-plugin` after explicit confirmation
@@ -38,7 +38,7 @@ hyperliquid quickstart
 Scan funding candidates:
 
 ```bash
-python3 skills/hl-funding-flow-hunter/scripts/scan_funding.py --top 5
+python3 ./scripts/scan_funding.py --top 5
 ```
 
 Preview a guarded order:

--- a/skills/hl-funding-flow-hunter/plugin.yaml
+++ b/skills/hl-funding-flow-hunter/plugin.yaml
@@ -1,0 +1,30 @@
+schema_version: 1
+name: hl-funding-flow-hunter
+version: "1.0.0"
+description: "Hyperliquid funding and flow strategy scanner with guarded execution"
+author:
+  name: "KB"
+  github: "Brian5216"
+license: MIT
+category: strategy
+tags:
+  - hyperliquid
+  - perpetuals
+  - funding
+  - trading-strategy
+  - risk-management
+
+components:
+  skill:
+    dir: "."
+
+dependent_plugin:
+  - name: hyperliquid-plugin
+    version: "^0.3.8"
+
+risk_level: standard
+supported_venues:
+  - hyperliquid
+
+api_calls:
+  - "https://api.hyperliquid.xyz"

--- a/skills/hl-funding-flow-hunter/scripts/scan_funding.py
+++ b/skills/hl-funding-flow-hunter/scripts/scan_funding.py
@@ -47,13 +47,19 @@ def log_score(value: float, scale: float, cap: float) -> float:
     return min(math.log10(value + 1) / scale * cap, cap)
 
 
-def risk_flags(funding: float, volume_24h: float, open_interest: float, mark_px: float, prev_day_px: float) -> list[str]:
+def risk_flags(
+    funding: float,
+    volume_24h: float,
+    open_interest_notional: float,
+    mark_px: float,
+    prev_day_px: float,
+) -> list[str]:
     flags: list[str] = []
     if abs(funding) < 0.000025:
         flags.append("funding_signal_weak")
     if volume_24h < 5_000_000:
         flags.append("low_24h_volume")
-    if open_interest < 1_000_000:
+    if open_interest_notional < 1_000_000:
         flags.append("low_open_interest")
     if mark_px > 0 and prev_day_px > 0:
         day_move = abs(mark_px - prev_day_px) / prev_day_px
@@ -62,11 +68,11 @@ def risk_flags(funding: float, volume_24h: float, open_interest: float, mark_px:
     return flags
 
 
-def score_candidate(funding: float, volume_24h: float, open_interest: float, premium: float) -> float:
+def score_candidate(funding: float, volume_24h: float, open_interest_notional: float, premium: float) -> float:
     funding_bps = abs(funding) * 10_000
     funding_component = min(funding_bps / 1.5 * 40, 40)
     volume_component = log_score(volume_24h, 9.0, 25)
-    oi_component = log_score(open_interest, 8.0, 25)
+    oi_component = log_score(open_interest_notional, 9.0, 25)
     premium_penalty = min(abs(premium) * 10_000 / 5, 10)
     return round(max(funding_component + volume_component + oi_component - premium_penalty, 0), 2)
 
@@ -92,19 +98,20 @@ def build_candidates(data: Any, args: argparse.Namespace) -> list[dict[str, Any]
 
         funding = as_float(ctx.get("funding"))
         volume_24h = as_float(ctx.get("dayNtlVlm"))
-        open_interest = as_float(ctx.get("openInterest"))
         premium = as_float(ctx.get("premium"))
         mark_px = as_float(ctx.get("markPx"))
         prev_day_px = as_float(ctx.get("prevDayPx"))
+        open_interest_base = as_float(ctx.get("openInterest"))
+        open_interest_notional = open_interest_base * mark_px if mark_px > 0 else 0.0
 
-        if volume_24h < args.min_volume or open_interest < args.min_oi:
+        if volume_24h < args.min_volume or open_interest_notional < args.min_oi:
             continue
         if abs(funding) < args.min_abs_funding:
             continue
 
-        flags = risk_flags(funding, volume_24h, open_interest, mark_px, prev_day_px)
+        flags = risk_flags(funding, volume_24h, open_interest_notional, mark_px, prev_day_px)
         side = "sell" if funding > 0 else "buy"
-        score = score_candidate(funding, volume_24h, open_interest, premium)
+        score = score_candidate(funding, volume_24h, open_interest_notional, premium)
         annualized = funding * 24 * 365
 
         rows.append(
@@ -117,7 +124,8 @@ def build_candidates(data: Any, args: argparse.Namespace) -> list[dict[str, Any]
                 "mark_price": mark_px,
                 "previous_day_price": prev_day_px,
                 "volume_24h": volume_24h,
-                "open_interest": open_interest,
+                "open_interest_base": open_interest_base,
+                "open_interest_notional": round(open_interest_notional, 6),
                 "max_leverage": asset.get("maxLeverage"),
                 "score": score,
                 "risk_flags": flags,
@@ -140,7 +148,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Scan Hyperliquid perp markets for funding and flow candidates.")
     parser.add_argument("--top", type=int, default=5, help="Number of candidates to return.")
     parser.add_argument("--min-volume", type=float, default=5_000_000, help="Minimum 24h notional volume.")
-    parser.add_argument("--min-oi", type=float, default=1_000_000, help="Minimum open interest.")
+    parser.add_argument("--min-oi", type=float, default=1_000_000, help="Minimum open interest notional in USDC.")
     parser.add_argument("--min-abs-funding", type=float, default=0.00001, help="Minimum absolute hourly funding rate.")
     parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout in seconds.")
     return parser.parse_args(argv)

--- a/skills/hl-funding-flow-hunter/scripts/scan_funding.py
+++ b/skills/hl-funding-flow-hunter/scripts/scan_funding.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Read-only Hyperliquid funding and flow scanner.
+
+This script never signs, submits, or prepares orders. It only reads public
+market data from https://api.hyperliquid.xyz/info and returns ranked candidates
+for the hl-funding-flow-hunter skill to review with the user.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+API_URL = "https://api.hyperliquid.xyz/info"
+
+
+def post_info(payload: dict[str, Any], timeout: float) -> Any:
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        API_URL,
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "hl-funding-flow-hunter/1.0.0"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def log_score(value: float, scale: float, cap: float) -> float:
+    if value <= 0:
+        return 0.0
+    return min(math.log10(value + 1) / scale * cap, cap)
+
+
+def risk_flags(funding: float, volume_24h: float, open_interest: float, mark_px: float, prev_day_px: float) -> list[str]:
+    flags: list[str] = []
+    if abs(funding) < 0.000025:
+        flags.append("funding_signal_weak")
+    if volume_24h < 5_000_000:
+        flags.append("low_24h_volume")
+    if open_interest < 1_000_000:
+        flags.append("low_open_interest")
+    if mark_px > 0 and prev_day_px > 0:
+        day_move = abs(mark_px - prev_day_px) / prev_day_px
+        if day_move > 0.12:
+            flags.append("high_24h_price_move")
+    return flags
+
+
+def score_candidate(funding: float, volume_24h: float, open_interest: float, premium: float) -> float:
+    funding_bps = abs(funding) * 10_000
+    funding_component = min(funding_bps / 1.5 * 40, 40)
+    volume_component = log_score(volume_24h, 9.0, 25)
+    oi_component = log_score(open_interest, 8.0, 25)
+    premium_penalty = min(abs(premium) * 10_000 / 5, 10)
+    return round(max(funding_component + volume_component + oi_component - premium_penalty, 0), 2)
+
+
+def build_candidates(data: Any, args: argparse.Namespace) -> list[dict[str, Any]]:
+    if not isinstance(data, list) or len(data) != 2:
+        raise ValueError("Unexpected Hyperliquid metaAndAssetCtxs response shape")
+
+    meta, contexts = data
+    universe = meta.get("universe", []) if isinstance(meta, dict) else []
+    if not isinstance(universe, list) or not isinstance(contexts, list):
+        raise ValueError("Unexpected Hyperliquid universe or asset context shape")
+
+    rows: list[dict[str, Any]] = []
+    for index, asset in enumerate(universe):
+        if not isinstance(asset, dict) or index >= len(contexts) or not isinstance(contexts[index], dict):
+            continue
+
+        ctx = contexts[index]
+        coin = str(asset.get("name", "")).strip()
+        if not coin:
+            continue
+
+        funding = as_float(ctx.get("funding"))
+        volume_24h = as_float(ctx.get("dayNtlVlm"))
+        open_interest = as_float(ctx.get("openInterest"))
+        premium = as_float(ctx.get("premium"))
+        mark_px = as_float(ctx.get("markPx"))
+        prev_day_px = as_float(ctx.get("prevDayPx"))
+
+        if volume_24h < args.min_volume or open_interest < args.min_oi:
+            continue
+        if abs(funding) < args.min_abs_funding:
+            continue
+
+        flags = risk_flags(funding, volume_24h, open_interest, mark_px, prev_day_px)
+        side = "sell" if funding > 0 else "buy"
+        score = score_candidate(funding, volume_24h, open_interest, premium)
+        annualized = funding * 24 * 365
+
+        rows.append(
+            {
+                "coin": coin,
+                "suggested_side": side,
+                "funding": funding,
+                "funding_annualized_estimate": round(annualized, 6),
+                "premium": premium,
+                "mark_price": mark_px,
+                "previous_day_price": prev_day_px,
+                "volume_24h": volume_24h,
+                "open_interest": open_interest,
+                "max_leverage": asset.get("maxLeverage"),
+                "score": score,
+                "risk_flags": flags,
+                "notes": build_notes(funding, flags),
+            }
+        )
+
+    rows.sort(key=lambda item: (item["score"], abs(item["funding"]), item["volume_24h"]), reverse=True)
+    return rows[: args.top]
+
+
+def build_notes(funding: float, flags: list[str]) -> str:
+    direction = "positive funding favors short exposure" if funding > 0 else "negative funding favors long exposure"
+    if flags:
+        return f"{direction}; review risk flags before any order"
+    return f"{direction}; liquidity filters passed"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scan Hyperliquid perp markets for funding and flow candidates.")
+    parser.add_argument("--top", type=int, default=5, help="Number of candidates to return.")
+    parser.add_argument("--min-volume", type=float, default=5_000_000, help="Minimum 24h notional volume.")
+    parser.add_argument("--min-oi", type=float, default=1_000_000, help="Minimum open interest.")
+    parser.add_argument("--min-abs-funding", type=float, default=0.00001, help="Minimum absolute hourly funding rate.")
+    parser.add_argument("--timeout", type=float, default=10.0, help="HTTP timeout in seconds.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.top < 1:
+        raise SystemExit("--top must be at least 1")
+
+    try:
+        data = post_info({"type": "metaAndAssetCtxs"}, args.timeout)
+        candidates = build_candidates(data, args)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        print(json.dumps({"error": "hyperliquid_api_unavailable", "details": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"error": "unexpected_hyperliquid_response", "details": str(exc)}, indent=2), file=sys.stderr)
+        return 3
+
+    result = {
+        "source": API_URL,
+        "strategy_id": "hl-funding-flow-hunter",
+        "trade_execution": "read_only_scan_no_orders_submitted",
+        "candidates": candidates,
+        "execution_reminder": {
+            "open": "Use hyperliquid order with --dry-run first, then --confirm only after user approval.",
+            "close": "Use hyperliquid close with --strategy-id hl-funding-flow-hunter and explicit confirmation.",
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Plugin Submission

**Plugin name:** hl-funding-flow-hunter
**Version:** 1.0.0
**Type:** new-plugin

### Checklist

- [x] `plugin-store lint` passes locally with no errors
- [x] I have read the Development Guide
- [x] My plugin does NOT use reserved prefixes (`okx-`, `official-`, `plugin-store-`)
- [x] LICENSE file is included
- [x] SKILL.md has YAML frontmatter with `name` and `description`

### What does this plugin do?

`hl-funding-flow-hunter` is a guarded Hyperliquid funding and flow strategy scanner. It ranks perp markets using public funding, volume, open interest, premium, and price-move data, then guides the user through dry-run and explicitly confirmed execution via `hyperliquid-plugin`.

### Which onchainos commands does it use?

This plugin does not call `onchainos` directly. It depends on `hyperliquid-plugin` and documents:

- `hyperliquid register`
- `hyperliquid quickstart`
- `hyperliquid prices --coin <COIN>`
- `hyperliquid order ... --dry-run --strategy-id hl-funding-flow-hunter`
- `hyperliquid order ... --confirm --strategy-id hl-funding-flow-hunter`
- `hyperliquid close ... --confirm --strategy-id hl-funding-flow-hunter`

### Security Considerations

The scanner is read-only and only calls `https://api.hyperliquid.xyz`. Live trading must go through `hyperliquid-plugin`, requires explicit user confirmation, uses isolated low leverage by default, and includes stop-loss / take-profit guidance. It does not request private keys, seed phrases, API secrets, or OTP codes.

### Testing

- Required files present
- Metadata consistency checked locally
- Python scanner syntax checked locally
- Read-only Hyperliquid API scan tested successfully
- Sensitive credential scan checked locally
- GitHub Actions Phase 1 structure validation passed
