### PR TITLE
[new-plugin] liqgrid v1.2.0

### DIFF
--- a/skills/liqgrid/.claude-plugin/plugin.json
+++ b/skills/liqgrid/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "liqgrid",
-  "description": "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin.",
-  "version": "1.0.0",
+  "description": "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin.",
+  "version": "1.1.0",
   "author": {
     "name": "dddd86971-cloud"
   },

--- a/skills/liqgrid/.claude-plugin/plugin.json
+++ b/skills/liqgrid/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "liqgrid",
   "description": "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "dddd86971-cloud"
   },

--- a/skills/liqgrid/.claude-plugin/plugin.json
+++ b/skills/liqgrid/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "liqgrid",
-  "description": "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin.",
+  "description": "AI-driven Hyperliquid grids. Deterministic binary, funding-aware sizing (±20% tilt), concentrated liquidity, 75-combo parameter optimizer, 30-day backtest. One sentence in, risk-capped plan out.",
   "version": "1.2.0",
   "author": {
     "name": "dddd86971-cloud"
   },
   "license": "MIT",
-  "keywords": ["hyperliquid", "grid", "perpetuals", "strategy", "agentic-wallet"]
+  "keywords": ["hyperliquid", "grid", "perpetuals", "strategy", "agentic-wallet", "passive-income", "automated-trading", "funding-aware", "backtest", "range-bound"]
 }

--- a/skills/liqgrid/.claude-plugin/plugin.json
+++ b/skills/liqgrid/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "liqgrid",
+  "description": "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin.",
+  "version": "1.0.0",
+  "author": {
+    "name": "dddd86971-cloud"
+  },
+  "license": "MIT",
+  "keywords": ["hyperliquid", "grid", "perpetuals", "strategy", "agentic-wallet"]
+}

--- a/skills/liqgrid/LICENSE
+++ b/skills/liqgrid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dddd86971-cloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/liqgrid/README.md
+++ b/skills/liqgrid/README.md
@@ -1,58 +1,137 @@
 # liqgrid — Plugin Store Skill
 
-Natural-language perpetual grid strategy on Hyperliquid, powered by a
-deterministic TypeScript engine.
+Natural-language perpetual grids on Hyperliquid, powered by a **deterministic
+TypeScript engine** with **funding-aware asymmetric sizing**, **concentrated-
+liquidity weighting**, and a **built-in backtest engine**.
 
 ## Install
 
-```
+```bash
 npx skills add okx/plugin-store --skill liqgrid
 ```
+
+## At a glance
+
+```
+User: "BTC 90k-95k range, $500 at 2x"
+  │
+  ▼
+liqgrid Skill  (natural-language parsing)
+  │
+  ├─► hyperliquid-plugin   →  fetch mark / funding / 1h candles
+  └─► liqgrid binary       →  deterministic grid math
+  │
+  ▼
+Dry-run Plan:
+  • 23 tick-aligned rungs (concentrated: ~$20/rung at mark, ~$3/rung at edges)
+  • funding −12% annualized  →  +6.6% notional tilt toward buy side
+  • stop-loss $87,500        →  max loss 6.9% / $34.50
+  • backtest past 7d         →  +$7.57 realized / 15 fills / 0 drawdown
+  • planHash a3f82b...       (same input → same plan, always)
+  │
+  ▼
+User: "go live"
+  │
+  ▼
+Limit orders via hyperliquid-plugin  --strategy-id liqgrid
+Stop-loss trigger  via hyperliquid-plugin  tpsl  --strategy-id liqgrid
+  │
+  ▼
+Agentic Wallet TEE signing  →  on-chain fills
+```
+
+## What liqgrid actually does for a user
+
+| Pain point | Without liqgrid | With liqgrid |
+|---|---|---|
+| Setting up 20+ tick-aligned rung prices by hand | 30 min of arithmetic, high chance of slipping | One sentence → plan in 2 seconds, math guaranteed correct |
+| Capital wasted on edge rungs that rarely fill | Uniform sizing pays ~25% of capital to fill-probability-<1% zones | Concentrated-liquidity weighting, same $300 gets denser near mark |
+| Paying funding passively | Symmetric grid eats all funding | At ≥10% annualized funding, tilt up to ±20% toward the profitable side |
+| No way to know how this parameter set would have performed | Blind decision | `liqgrid backtest` gives concrete PnL / fills / drawdown / Sharpe on real past candles |
+| LLM picks different rung prices across runs | Same prompt, different grid → plan drifts | Compiled binary, stable `planHash` fingerprint, byte-identical across models |
+| Accidental $5,000 / 50× blow-up request | Platform accepts it, you liquidate | Binary hard-caps $5k / 10× / 50 rungs / stop-loss ≤30% of notional — refused at plan stage |
+
+## Hard differentiators vs other Hyperliquid grid bots
+
+1. **Deterministic binary, not LLM math** — grid-level prices, stop-loss, and
+   sizing run in a compiled TypeScript engine. Same inputs → byte-identical
+   outputs. Other AI grid Skills leave it to the LLM and drift each call.
+
+2. **Funding rate as alpha, not drag** — liqgrid reads the live hourly funding
+   rate and tilts per-rung notional up to ±20% toward the side that *collects*
+   funding. Hyperliquid-specific feature; zero other grid Skill does this.
+
+3. **Concentrated-liquidity rung sizing** — per-rung notional weighted by
+   Gaussian fill-probability in log-price space. Center-heavy, edge-light —
+   higher expected fill density per dollar deployed than uniform spacing.
+
+4. **Built-in backtest** — `liqgrid backtest` runs the plan bar-by-bar over
+   historical candles and returns realized PnL, max DD, fill counts, Sharpe.
+   Runs in the same deterministic binary; same input candles → same numbers.
+
+## Safety (enforced in binary, not just documented)
+
+| Cap / check | Value |
+|---|---|
+| Max notional per grid | $5,000 |
+| Max leverage | 10× |
+| Max / min grid rungs | 50 / 4 |
+| Max loss at range break | 30% of notional (warning enforced) |
+| Conservative + >5× leverage | auto-downshift to 5× with warning |
+| Mark-vs-candle drift >3% | warning (volatility estimate may be stale) |
+| Mark far outside range | REFUSE (range premise is wrong) |
+| `rangeLow >= rangeHigh` | hard failure, empty plan + `INPUT:` warning |
+| Non-positive `rangeLow` / `tickSize` | hard failure |
+| Sum(sizeUsd) invariant | always equals `totalNotionalUsd` |
+
+**Behavioral:** dry-run default on every session; explicit user confirmation
+before any order batch; first-session training wheels cap $200 / 2× even if
+user asks for more.
+
+**No private keys** handled by liqgrid — all signing via Agentic Wallet TEE
+through `hyperliquid-plugin`. `api_calls: []` — binary makes zero network
+calls of its own.
+
+## When to use
+
+**Good fit:**
+- Range-bound view on a liquid Hyperliquid perp (BTC / ETH / SOL / etc.)
+- Want passive execution via limit orders working at pre-computed levels
+- Want predictable, reproducible parameters across agent sessions and models
+
+**Bad fit:**
+- Directional thesis ("BTC breaks out to 100k") — grid accumulates a losing
+  position against trends
+- Market in clear strong trend — Skill refuses with explanation
+- Want leverage > 10× or notional > $5k — hard caps, not preferences
 
 ## Requires
 
 - `onchainos` CLI + unlocked Agentic Wallet
-- `hyperliquid-plugin` (basic plugin) installed separately:
+- **`hyperliquid-plugin` ≥ 0.3.9**:
   `npx skills add okx/plugin-store --skill hyperliquid-plugin`
-- ≥ 20 USDC on your Hyperliquid perp account
-
-## Usage
-
-Once installed, talk to any Onchain-OS agent in natural language:
-
-> "BTC 90k to 95k, balanced grid, $500 at 2x"
-
-The agent will:
-1. Fetch BTC market data via the Hyperliquid basic plugin.
-2. Run `liqgrid plan` (the compiled binary shipped with this Skill) to
-   compute a deterministic grid.
-3. Show the DRY-RUN plan with grid count, stop-loss, max loss, and
-   expected fills/day.
-4. Execute only after you confirm — through the Hyperliquid basic plugin.
-
-## Safety (hardcoded in the binary)
-
-- Dry-run default
-- Max $5,000 / 10× / 50 rungs per grid
-- Max loss at range break: 30% of notional (warning enforced)
-- No private key handling — all signing via Agentic Wallet TEE
-- Binary makes no network calls (`api_calls: []`)
+- ≥ 20 USDC on your Hyperliquid perp account (for minimum collateral)
 
 ## Source
 
-The binary is TypeScript, compiled to JS, distributed via `bun install -g`
-by the Plugin Store CI. Source:
-https://github.com/dddd86971-cloud/liqgrid
+TypeScript → compiled to JS, distributed via `bun install -g` by the Plugin
+Store CI from [dddd86971-cloud/liqgrid](https://github.com/dddd86971-cloud/liqgrid)
+at a pinned commit (see `plugin.yaml` `build.source_commit`).
 
-See `SKILL.md` for the full command reference and Security Notices.
+Self-test suite: `npm test` — 26 invariants covering determinism, cap
+enforcement, funding bias noise-floor / saturation / sign, concentrated-
+liquidity sizing, backtest determinism, and input validation.
+
+## Strategy-id Attribution
+
+Every write operation carries `--strategy-id liqgrid` (or `lg-{planHash[:6]}`
+for per-plan granularity). `hyperliquid-plugin` calls
+`onchainos wallet report-plugin-info` after each successful order so OKX's
+Plugin Store Season 1 leaderboard can attribute trades to this Skill.
 
 ## License
 
 MIT — see `LICENSE`.
 
-## Season 1 Developer Challenge
-
-This Skill is submitted to the OKX Onchain OS Plugin Store Season 1
-Developer Challenge (2026-04-23 → 2026-05-07). All on-chain writes flow
-through the Hyperliquid basic plugin as required by challenge eligibility
-rules.
+See `SKILL.md` for the full command reference, error handling, and
+Security Notices. See `SUMMARY.md` for the 30-second user pitch.

--- a/skills/liqgrid/README.md
+++ b/skills/liqgrid/README.md
@@ -33,8 +33,8 @@ Dry-run Plan:
 User: "go live"
   │
   ▼
-Limit orders via hyperliquid-plugin  --strategy-id liqgrid
-Stop-loss trigger  via hyperliquid-plugin  tpsl  --strategy-id liqgrid
+Limit orders via hyperliquid-plugin  --strategy-id liqgrid1
+Stop-loss trigger  via hyperliquid-plugin  tpsl  --strategy-id liqgrid1
   │
   ▼
 Agentic Wallet TEE signing  →  on-chain fills
@@ -89,8 +89,12 @@ before any order batch; first-session training wheels cap $200 / 2× even if
 user asks for more.
 
 **No private keys** handled by liqgrid — all signing via Agentic Wallet TEE
-through `hyperliquid-plugin`. `api_calls: []` — binary makes zero network
-calls of its own.
+through `hyperliquid-plugin`. The compiled `liqgrid` binary itself makes
+**zero** network calls (no `Math.random`, no `Date.now`, no I/O). The Skill
+declares only one external endpoint in `plugin.yaml` — `api.hyperliquid.xyz`,
+the public read-only info API used to fetch the live funding rate and
+historical candles for `liqgrid backtest`. Every write operation still flows
+through `hyperliquid-plugin`.
 
 ## When to use
 
@@ -124,7 +128,7 @@ liquidity sizing, backtest determinism, and input validation.
 
 ## Strategy-id Attribution
 
-Every write operation carries `--strategy-id liqgrid` (or `lg-{planHash[:6]}`
+Every write operation carries `--strategy-id liqgrid1` (or `lg-{planHash[:5]}`
 for per-plan granularity). `hyperliquid-plugin` calls
 `onchainos wallet report-plugin-info` after each successful order so OKX's
 Plugin Store Season 1 leaderboard can attribute trades to this Skill.

--- a/skills/liqgrid/README.md
+++ b/skills/liqgrid/README.md
@@ -1,0 +1,58 @@
+# liqgrid — Plugin Store Skill
+
+Natural-language perpetual grid strategy on Hyperliquid, powered by a
+deterministic TypeScript engine.
+
+## Install
+
+```
+npx skills add okx/plugin-store --skill liqgrid
+```
+
+## Requires
+
+- `onchainos` CLI + unlocked Agentic Wallet
+- `hyperliquid-plugin` (basic plugin) installed separately:
+  `npx skills add okx/plugin-store --skill hyperliquid-plugin`
+- ≥ 20 USDC on your Hyperliquid perp account
+
+## Usage
+
+Once installed, talk to any Onchain-OS agent in natural language:
+
+> "BTC 90k to 95k, balanced grid, $500 at 2x"
+
+The agent will:
+1. Fetch BTC market data via the Hyperliquid basic plugin.
+2. Run `liqgrid plan` (the compiled binary shipped with this Skill) to
+   compute a deterministic grid.
+3. Show the DRY-RUN plan with grid count, stop-loss, max loss, and
+   expected fills/day.
+4. Execute only after you confirm — through the Hyperliquid basic plugin.
+
+## Safety (hardcoded in the binary)
+
+- Dry-run default
+- Max $5,000 / 10× / 50 rungs per grid
+- Max loss at range break: 30% of notional (warning enforced)
+- No private key handling — all signing via Agentic Wallet TEE
+- Binary makes no network calls (`api_calls: []`)
+
+## Source
+
+The binary is TypeScript, compiled to JS, distributed via `bun install -g`
+by the Plugin Store CI. Source:
+https://github.com/dddd86971-cloud/liqgrid
+
+See `SKILL.md` for the full command reference and Security Notices.
+
+## License
+
+MIT — see `LICENSE`.
+
+## Season 1 Developer Challenge
+
+This Skill is submitted to the OKX Onchain OS Plugin Store Season 1
+Developer Challenge (2026-04-23 → 2026-05-07). All on-chain writes flow
+through the Hyperliquid basic plugin as required by challenge eligibility
+rules.

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: liqgrid
 description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
-version: "1.1.0"
+version: "1.2.0"
 author: "dddd86971-cloud"
 tags:
   - hyperliquid
@@ -200,6 +200,20 @@ HTTP / RPC / any non-plugin path — every order must go through
 `hyperliquid-plugin` so it goes through the Agentic Wallet TEE and carries
 `--strategy-id liqgrid1` for leaderboard attribution.
 
+## What's new in v1.2.0
+
+- **`liqgrid quickstart`** — zero-friction first-time use. From just
+  `coin` + `totalNotionalUsd` + recent `candles` + `marketMeta`, the binary
+  derives a sensible `(rangeLow, rangeHigh, leverage, riskProfile)` and
+  returns a ready-to-pipe `PlanInput`. Use this when the user describes
+  their notional and intent ("$300 BTC grid, conservative") but doesn't
+  specify a range. Saves the agent from inventing a range.
+- **`liqgrid optimize`** — deterministic parameter sweep. Iterates 75
+  combinations (5 range widths × 5 leverages × 3 profiles), runs a
+  backtest on each over the recent window, ranks by Calmar score
+  (`realizedPnl / max(maxDD, 1)`), returns the top N. Use when the user
+  asks "what's the best parameter set" or wants a comparison.
+
 ## What's new in v1.1.0
 
 - **Funding-aware sizing.** When the current hourly funding rate is passed
@@ -222,6 +236,75 @@ otherwise-identical inputs because the sizing geometry is now concentrated
 rather than uniform.
 
 ## Commands
+
+### grid-quickstart
+
+Zero-friction first-time use. Given a coin, notional, and recent candles,
+derive a sensible plan without the user having to pick a range.
+
+**When to use:** User says something like "$300 BTC grid, conservative"
+without specifying a range, or when first-session training wheels are
+active. Always prefer `grid-quickstart` over inventing a range yourself.
+
+**Agent execution steps:**
+
+1. Fetch the live `markPrice`, `tickSize`, `minOrderSizeUsd`,
+   `maxLeverage` from `hyperliquid-plugin prices` + the static meta.
+2. Fetch ~7 days of hourly candles from `https://api.hyperliquid.xyz/info`
+   (`type: candleSnapshot`, `interval: 1h`).
+3. Pipe into `liqgrid quickstart`:
+
+   ```
+   echo '{
+     "coin": "BTC",
+     "totalNotionalUsd": 300,
+     "candles": [...],
+     "marketMeta": { "coin": "BTC", "tickSize": 1, "minOrderSizeUsd": 10,
+                     "markPrice": 77519, "maxLeverage": 40 },
+     "riskProfile": "conservative"
+   }' | liqgrid quickstart
+   ```
+
+4. The result includes a `planInput` field — pipe that **directly** into
+   `liqgrid plan` to get the full GridPlan. Show the user the
+   `recommendedRangeLow/High`, `recommendedLeverage`, and the `rationale`
+   string before running the plan.
+
+### grid-optimize
+
+Deterministic parameter sweep over (range_width, leverage, risk_profile)
+combinations on historical candles.
+
+**When to use:** User asks "what's the optimal parameters" / "find me the
+best grid" / "compare profiles", or as a sanity check before running a
+hand-picked plan ("how does my chosen params rank in the sweep?").
+
+**Agent execution steps:**
+
+1. Fetch ~30 days of hourly candles from Hyperliquid info (need
+   `> backtestWindowBars + 24` so the per-trial backtest has both history
+   and a window).
+2. Run:
+
+   ```
+   echo '{
+     "coin": "BTC",
+     "totalNotionalUsd": 300,
+     "candles": [...],
+     "marketMeta": { ... },
+     "backtestWindowBars": 168,
+     "topN": 3
+   }' | liqgrid optimize
+   ```
+
+3. Present the top-N candidates as a table: rangeWidth%, leverage,
+   profile, fills, realizedPnl, maxDD, score. **Always tell the user**:
+   "These are deterministic backtest results on past 7 days, not a
+   prediction of future performance. The top candidate is what would have
+   maximised Calmar score on recent history."
+4. If the user picks one, run `grid-plan` with those exact parameters
+   (the candidate already specifies `rangeLow`, `rangeHigh`, `leverage`,
+   `riskProfile`).
 
 ### grid-plan
 

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: liqgrid
-description: "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin."
-version: "1.0.0"
+description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
+version: "1.1.0"
 author: "dddd86971-cloud"
 tags:
   - hyperliquid
@@ -169,6 +169,27 @@ described here. Under no circumstances should the agent call Hyperliquid
 directly via HTTP, RPC, or any other non-plugin path — all on-chain writes
 must go through the Hyperliquid basic plugin.
 
+## What's new in v1.1.0
+
+- **Funding-aware sizing.** When the current hourly funding rate is passed
+  in `marketMeta.fundingRateHourly`, the grid tilts per-rung notional
+  asymmetrically (up to ±20%) to collect funding as alpha. Symmetric when
+  funding is missing or below the 10% annualized noise floor.
+- **Concentrated-liquidity grid.** Each rung's notional is weighted by its
+  estimated one-day fill probability under a log-normal price-move model.
+  Rungs near the mark get more capital; rungs at the edges get less. Same
+  total notional, higher expected fills per deployed dollar.
+- **`liqgrid backtest`.** New binary subcommand that simulates the plan
+  candle-by-candle over a historical window and reports realized PnL, max
+  drawdown, fill counts, and a Sharpe approximation. Use it before
+  `grid-open` to show the user what the current parameters would have
+  produced on recent history.
+
+All three upgrades run inside the compiled TypeScript binary — same inputs
+still produce byte-identical outputs. `planHash` will differ from v1.0 for
+otherwise-identical inputs because the sizing geometry is now concentrated
+rather than uniform.
+
 ## Commands
 
 ### grid-plan
@@ -193,6 +214,15 @@ for a grid, or asks "what would a grid look like for X". Always run before
 
 1. Call the Hyperliquid basic plugin to fetch market metadata for
    `instrument`: `tickSize`, `minOrderSizeUsd`, `markPrice`, `maxLeverage`.
+   **Also fetch the current funding rate for `instrument` if the basic plugin
+   exposes it** (Hyperliquid publishes hourly funding on its `info`
+   endpoint — the basic plugin's `prices` or `get-meta` command may return
+   it). Pass it through as `marketMeta.fundingRateHourly` (fraction, e.g.
+   0.00003 = 3bp/hour ≈ 26% annualized). **v1.1**: when annualized funding
+   exceeds 10%, liqgrid tilts per-rung notional asymmetrically (up to ±20%)
+   to collect funding as alpha — sell rungs get extra weight under positive
+   funding, buy rungs under negative. If the basic plugin does not expose
+   funding, omit the field; the engine falls back to a symmetric grid.
 2. Call the Hyperliquid basic plugin to fetch recent hourly candles.
    Prefer the last 168 (7 days) for a stable volatility estimate;
    accept as few as 24 (1 day) if that's all the basic plugin returns.
@@ -245,6 +275,62 @@ values. Always use the output from `liqgrid plan` verbatim.**
 breakdown with the fields above already formatted. Useful when the
 user asks "explain this plan in normal English" or when the raw JSON
 is unwieldy.
+
+### grid-backtest
+
+Simulate the plan over historical candles and report what it would have
+produced on recent history. **Does not place any orders.**
+
+**When to use:** Before `grid-open`, whenever the user asks "how would
+this grid have done over the last week / month" or you want to show them
+expected fill counts and PnL-range under the same parameters.
+
+**Agent execution steps:**
+
+1. Fetch a longer hourly-candle window from the Hyperliquid basic plugin
+   than you would for planning alone. Recommended: at least 24h of history
+   bars (for the volatility estimate) + the backtest window. Example: 1h
+   candles for the last 30 days (720 bars total), with
+   `backtestWindowBars: 168` to simulate the most recent 7 days.
+2. Run `liqgrid backtest`, passing the same inputs as `liqgrid plan` plus
+   one extra integer field `backtestWindowBars`:
+
+   ```
+   echo '{
+     "coin": "BTC",
+     "rangeLow": 90000, "rangeHigh": 95000,
+     "totalNotionalUsd": 300, "leverage": 2,
+     "riskProfile": "balanced",
+     "marketMeta": { ... from basic plugin ... },
+     "candles": [ ... 720 hourly bars ... ],
+     "backtestWindowBars": 168
+   }' | liqgrid backtest
+   ```
+
+3. Present the `BacktestResult` JSON to the user, clearly labeled as a
+   **simulation of past performance on historical data, not a prediction**.
+   Include: `fills` (buy/sell split), `realizedPnlUsd`, `unrealizedPnlUsd`,
+   `totalPnlUsd`, `maxDrawdownUsd`, `sharpeApprox`, and `hitStopLoss`.
+   Always accompany with: "Past performance does not indicate future
+   results. Backtest uses a conservative fill model (full-rung fills only,
+   no partials); real execution may have different slippage and timing."
+
+4. If the user then says "open it", proceed to `grid-open` with the same
+   parameters. `planHash` in the backtest result will match the live plan
+   as long as the inputs match.
+
+**Fill model notes:**
+
+- A rung fills when a bar's price range (`[low, high]`) touches the rung's
+  price. No partial fills — each rung either fills entirely or waits.
+- Buys are processed before sells within the same bar (conservative — biases
+  realized PnL lower).
+- Stop-loss triggers when a bar's low (for long-bias plans) crosses the
+  stop price; simulation ends immediately and realizes the loss on all
+  remaining inventory at the trigger price.
+- Short-side grids are not simulated in v1.1 — only buy-first, pair-to-sell.
+  If the plan is short-biased (`stopLossSide === "short"`), backtest still
+  runs but fill counts may under-represent real activity.
 
 ### grid-open
 

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -138,16 +138,21 @@ Before using this Skill, the agent must verify:
 ## Attribution Rule
 
 Every write operation routed to the Hyperliquid basic plugin must include
-the strategy tag `liqgrid` in whatever tag/cloid/strategy-id field the
+the strategy tag `liqgrid1` in whatever tag/cloid/strategy-id field the
 basic plugin exposes:
 
 - If the basic plugin accepts a `strategy_id`, `tag`, or `clientOrderId`
-  parameter, pass `liqgrid` (or `lg-{planHash[:6]}` for per-plan
+  parameter, pass `liqgrid1` (or `lg-{planHash[:5]}` for per-plan
   granularity).
 - If the basic plugin exposes a `--strategy-id` CLI flag, append
-  `--strategy-id liqgrid`.
-- If no such field exists, embed `liqgrid` in any free-form order-label
+  `--strategy-id liqgrid1`.
+- If no such field exists, embed `liqgrid1` in any free-form order-label
   field available.
+
+> **Why 8 characters?** OKX Plugin Store Season 1 strategy-id field is
+> sized for 8 characters. `liqgrid` (the plugin name, 7 chars) is fine
+> as the plugin's filesystem identifier; `liqgrid1` is the strategy-id
+> string passed on every write operation for leaderboard attribution.
 
 Read-only market inspection (getting mark price, candles, meta) does not
 need tagging.
@@ -262,7 +267,7 @@ for a grid, or asks "what would a grid look like for X". Always run before
      extends close to this estimate, surface that explicitly.
    - Any warnings from `plan.warnings`
    - `plan.planHash` (present as a short identifier, e.g. the first 6
-     characters — matching the `lg-{hash[:6]}` form used in the
+     characters — matching the `lg-{hash[:5]}` form used in the
      strategy tag so users see consistent identifiers across the plan
      view and their order tags). `planHash` is stable across identical
      inputs and can be referenced for support.
@@ -374,14 +379,14 @@ order-placing tool with:
 - `order_type = "limit"`
 - `post_only = true`
 - `reduce_only = false`
-- **strategy tag**: `lg-{planHash[:6]}` (see Attribution Rule).
+- **strategy tag**: `lg-{planHash[:5]}` (see Attribution Rule).
   This is what makes the orders attributable to this Skill on the
   Plugin Store leaderboard.
 
 After all limit orders succeed, call the Hyperliquid basic plugin's
 trigger-order tool to install a stop-market at
 `plan.stopLossTriggerPrice` with `reduce_only = true` **and the same
-strategy tag** `lg-{planHash[:6]}`.
+strategy tag** `lg-{planHash[:5]}`.
 
 If any single order is rejected (insufficient margin, price band, rate
 limit), stop immediately, quote the exact error from the basic plugin, and
@@ -400,7 +405,7 @@ grids (across different coins or replaced plans), ask them which by
 disambiguation needed.
 
 **Execution:** Call the Hyperliquid basic plugin to fetch open orders
-(filter by strategy tag `lg-{planHash[:6]}` if supported), account
+(filter by strategy tag `lg-{planHash[:5]}` if supported), account
 state, and fills since the grid was opened. Return: filled count,
 realized PnL from filled pairs, unrealized PnL on current position,
 distance to stop-loss in absolute price and percentage.
@@ -440,11 +445,11 @@ Cancel all open grid orders and optionally flatten the position.
 
 1. Call the Hyperliquid basic plugin to cancel all open orders for the
    instrument. If the basic plugin supports tag-scoped cancellation,
-   prefer canceling only orders tagged with `lg-{planHash[:6]}`,
+   prefer canceling only orders tagged with `lg-{planHash[:5]}`,
    so other non-liqgrid orders the user might have are preserved.
 2. If the user explicitly asks to flatten, call the basic plugin to place
    a market order in the opposite direction of the current position with
-   `reduce_only = true` **and strategy tag** `lg-{planHash[:6]}`.
+   `reduce_only = true` **and strategy tag** `lg-{planHash[:5]}`.
    Warn the user briefly that a market-order flatten on a large
    leveraged position can have meaningful slippage.
 3. Confirm completion and report final realized PnL.

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -162,17 +162,43 @@ correctly attribute trades to this Skill. Untagged trades may be
 aggregated to the generic `hyperliquid-plugin` and not counted toward
 liqgrid's leaderboard position.
 
-## Tool Name Adaptation
+## Hyperliquid basic-plugin command map
 
-This Skill refers to Hyperliquid basic-plugin operations by their semantic
-purpose (`get_market_meta`, `get_candles`, `place_order`,
-`place_trigger_order`, `cancel_all_orders`, `get_open_orders`,
-`get_user_state`, `get_user_fills`). If the basic plugin exposes these
-under different names at runtime, the agent should map to the real names
-using the basic plugin's own documentation while preserving the semantics
-described here. Under no circumstances should the agent call Hyperliquid
-directly via HTTP, RPC, or any other non-plugin path — all on-chain writes
-must go through the Hyperliquid basic plugin.
+This Skill is built against `hyperliquid-plugin` **v0.3.9** (the version
+pinned in `dependent_plugin` in `plugin.yaml`). Concrete commands the agent
+calls:
+
+| Semantic purpose | hyperliquid-plugin command |
+|---|---|
+| Get current mid price for a coin | `hyperliquid-plugin prices --coin <COIN>` |
+| Place a perp limit / market order | `hyperliquid-plugin order --coin <COIN> --side buy\|sell --size <COIN_QTY> --price <PRICE> --order-type limit\|market --strategy-id liqgrid1 --confirm` |
+| Place a stop-loss bracket on a position | `hyperliquid-plugin tpsl --coin <COIN> --sl-px <PRICE> --strategy-id liqgrid1 --confirm` |
+| Close a position at market | `hyperliquid-plugin close --coin <COIN> --strategy-id liqgrid1 --confirm` |
+| Cancel a single resting order | `hyperliquid-plugin cancel --order-id <OID> --confirm` |
+| Cancel many in one signed request | `hyperliquid-plugin cancel-batch --order-ids <OID,OID,...> --confirm` |
+| List open orders for the wallet | `hyperliquid-plugin orders` |
+| List open positions + margin summary | `hyperliquid-plugin positions` |
+| Place many limit orders in one signed batch | `hyperliquid-plugin order-batch --orders <FILE> --strategy-id liqgrid1 --confirm` |
+
+**Funding rate (used for v1.1 funding-aware bias)** is **not** exposed by
+hyperliquid-plugin v0.3.9. The agent reads it directly from Hyperliquid's
+public read-only info endpoint (declared in `plugin.yaml` `api_calls`):
+
+```bash
+curl -s -X POST https://api.hyperliquid.xyz/info \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"metaAndAssetCtxs"}' \
+  | jq '.[1] | .[<universe-index-of-coin>] | .funding'
+```
+
+Pass that hourly funding rate (a fraction, e.g. `0.000019`) into the binary
+as `marketMeta.fundingRateHourly`. If the call fails or the value is missing,
+omit the field — liqgrid falls back to a symmetric grid.
+
+Under no circumstances should the agent call Hyperliquid for **writes** via
+HTTP / RPC / any non-plugin path — every order must go through
+`hyperliquid-plugin` so it goes through the Agentic Wallet TEE and carries
+`--strategy-id liqgrid1` for leaderboard attribution.
 
 ## What's new in v1.1.0
 
@@ -367,26 +393,39 @@ context.
 
 **Execution:**
 
-For each level in `plan.levels`, call the Hyperliquid basic plugin's
-order-placing tool with:
-- `coin = plan.coin`
-- `side = level.side` (`"buy"` or `"sell"`)
-- `price = level.price`
-- `size = level.sizeCoin` — Hyperliquid's order API takes contract
-  quantity, not USD notional. Use `sizeCoin`. `sizeUsd` in the plan is
-  only for human-readable display and must not be passed as the order
-  size.
-- `order_type = "limit"`
-- `post_only = true`
-- `reduce_only = false`
-- **strategy tag**: `lg-{planHash[:5]}` (see Attribution Rule).
-  This is what makes the orders attributable to this Skill on the
-  Plugin Store leaderboard.
+For each level in `plan.levels`, run:
 
-After all limit orders succeed, call the Hyperliquid basic plugin's
-trigger-order tool to install a stop-market at
-`plan.stopLossTriggerPrice` with `reduce_only = true` **and the same
-strategy tag** `lg-{planHash[:5]}`.
+```bash
+hyperliquid-plugin order \
+  --coin <plan.coin> \
+  --side <level.side> \
+  --size <level.sizeCoin> \
+  --price <level.price> \
+  --order-type limit \
+  --strategy-id liqgrid1 \
+  --confirm
+```
+
+Notes:
+
+- **`--size` is `level.sizeCoin`** (contract quantity), NOT `level.sizeUsd`.
+  `sizeUsd` is for human-readable display only.
+- **Always pass `--price`** — without it, market orders use unbounded
+  slippage. liqgrid always places resting limit orders at the planned price.
+- For per-plan granularity, use `--strategy-id lg-<planHash[:5]>` instead
+  (8 chars total; SKILL.md Attribution Rule documents both forms).
+- For high-rung-count plans, prefer `hyperliquid-plugin order-batch`
+  (single signed request for many orders) to stay under the rate limit.
+
+After all limit orders succeed, install the stop-loss bracket:
+
+```bash
+hyperliquid-plugin tpsl \
+  --coin <plan.coin> \
+  --sl-px <plan.stopLossTriggerPrice> \
+  --strategy-id liqgrid1 \
+  --confirm
+```
 
 If any single order is rejected (insufficient margin, price band, rate
 limit), stop immediately, quote the exact error from the basic plugin, and

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -1,0 +1,506 @@
+---
+name: liqgrid
+description: "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin."
+version: "1.0.0"
+author: "dddd86971-cloud"
+tags:
+  - hyperliquid
+  - grid
+  - perpetuals
+  - strategy
+  - agentic-wallet
+---
+
+# liqgrid
+
+## Overview
+
+`liqgrid` turns a trader's one-sentence view on a Hyperliquid perpetual —
+"BTC will chop between 90k and 95k, aggressive grid, $3000 at 5x" — into a
+fully specified, risk-capped grid strategy.
+
+What makes liqgrid different from plain Skill-based grids:
+
+- A **deterministic TypeScript engine** (the `liqgrid` binary, shipped with
+  this Skill) computes the grid plan. Same inputs → same output, every
+  time, across runs and models.
+- The LLM agent handles **natural-language parsing** and **live market
+  data fetching** (through the Hyperliquid basic plugin). The engine
+  handles **math**. Clear separation of responsibilities.
+- All on-chain writes go through the **Hyperliquid basic plugin**, inside
+  the Agentic Wallet. liqgrid never bypasses it.
+
+**Risk level: `advanced`.** This Skill places and manages multiple live
+perpetual orders. Read Security Notices before using it with real funds.
+
+## When to Use
+
+Use this Skill when the user:
+
+- has a **range-bound view** on a liquid Hyperliquid perpetual — i.e.
+  expects the price to oscillate inside a band over hours or days,
+  rather than trending strongly
+- wants **passive execution** (limit orders working at pre-computed
+  levels) rather than active discretionary entries
+- wants **predictable, deterministic** grid parameters rather than
+  LLM-guessed levels
+- is comfortable with multiple simultaneous open orders and has enough
+  collateral for the chosen notional and leverage
+
+Do **not** use this Skill when:
+
+- the user describes a directional thesis ("BTC will break out to
+  100k") — a grid will accumulate a losing position against a trend;
+  direct them to a directional Skill instead
+- the market is in a clear strong trend — the Skill should refuse and
+  explain why, not silently build a plan that will bleed
+- the user wants leverage above 10× or notional above $5,000 — those
+  are hard caps, not soft preferences
+
+## Profile Selection Rules
+
+The three risk profiles control grid density and stop-loss width.
+When the user doesn't specify one, choose using these rules:
+
+Default to `conservative` when:
+
+- the user is new to liqgrid (first session, no prior grids)
+- the user expresses caution, mentions "small", "safe", or doesn't
+  specify a notional larger than $500
+- the user chose leverage ≥ 5× (compound aggressive-leverage and
+  aggressive-density = unnecessary risk)
+- the market's recent realized volatility is unusually high (>5% daily)
+
+Use `balanced` when:
+
+- the user has run liqgrid before without issue
+- the user specifies "normal", "balanced", "medium", or doesn't signal
+  caution
+- leverage ≤ 5× and notional is in the $500–$2,000 range
+
+Use `aggressive` when:
+
+- the user explicitly says "aggressive", "max out", "as many fills as
+  possible", or asks for a dense grid
+- the user has previously used `balanced` successfully
+- the range is wide (>15% of mid-price) — a dense grid has room to
+  breathe without crowding ticks
+
+These are defaults. The user can always override by stating the profile
+directly.
+
+## First Session Flow
+
+When this Skill has never been used by the current user (no prior
+liqgrid-tagged fills in account history), prefer this introduction:
+
+1. Start in **dry-run** with `conservative` profile regardless of what
+   the user typed, unless they explicitly demanded otherwise.
+2. Build a grid with ≤ $200 notional and ≤ 2× leverage even if the user
+   asked for more — frame it as a "let's see how it looks first" plan.
+3. Present the dry-run plan with the `planHash` prefix, the stop-loss,
+   the expected fills/day, and the approximate liquidation buffer.
+4. Explicitly tell the user: "This is a preview. Nothing is placed. If
+   you're comfortable, say 'go live' and I'll place it. If you want the
+   larger plan you originally described, say 'larger' and I'll rebuild."
+5. Only after the user has successfully completed one `conservative`
+   grid (opened and closed at least one), follow their requested
+   profile and size without this training-wheels adjustment.
+
+## Pre-flight Checks
+
+Before using this Skill, the agent must verify:
+
+1. The `onchainos` CLI is installed and the Agentic Wallet is unlocked.
+2. The **Hyperliquid basic plugin** is installed. If not, instruct the user:
+   `npx skills add okx/plugin-store --skill hyperliquid-plugin`
+3. The `liqgrid` binary is available on PATH (installed automatically when
+   this Skill is installed via `npx skills add okx/plugin-store --skill
+   liqgrid`). Verify with `liqgrid --version`.
+4. The user has funded their Hyperliquid perp account with at least the
+   minimum collateral for the chosen instrument (typically ≥ 20 USDC).
+5. **No existing active liqgrid grid on the same instrument.** Call the
+   Hyperliquid basic plugin to check open orders; if any orders tagged
+   as liqgrid (see Attribution Rule below) are open on the requested
+   instrument, refuse to open a second grid there unless the user
+   explicitly says "replace the existing grid". Stacking multiple
+   liqgrid grids on the same instrument can produce offsetting orders
+   and unpredictable P&L.
+6. **Circuit-breaker state is clear.** Call the Hyperliquid basic plugin
+   to fetch the user's fills from the last 24 hours. If cumulative
+   realized PnL from liqgrid-tagged trades is worse than −2% of
+   account equity, refuse to open a new grid until the next UTC day.
+   Tell the user why and when they can retry.
+7. **Dry-run mode is the default.** Every new session starts in dry-run.
+   Live execution requires an explicit user confirmation in natural
+   language ("go live", "place real orders", etc.).
+
+## Attribution Rule
+
+Every write operation routed to the Hyperliquid basic plugin must include
+the strategy tag `liqgrid` in whatever tag/cloid/strategy-id field the
+basic plugin exposes:
+
+- If the basic plugin accepts a `strategy_id`, `tag`, or `clientOrderId`
+  parameter, pass `liqgrid` (or `lg-{planHash[:6]}` for per-plan
+  granularity).
+- If the basic plugin exposes a `--strategy-id` CLI flag, append
+  `--strategy-id liqgrid`.
+- If no such field exists, embed `liqgrid` in any free-form order-label
+  field available.
+
+Read-only market inspection (getting mark price, candles, meta) does not
+need tagging.
+
+This tagging is what lets the Plugin Store Season 1 Challenge leaderboard
+correctly attribute trades to this Skill. Untagged trades may be
+aggregated to the generic `hyperliquid-plugin` and not counted toward
+liqgrid's leaderboard position.
+
+## Tool Name Adaptation
+
+This Skill refers to Hyperliquid basic-plugin operations by their semantic
+purpose (`get_market_meta`, `get_candles`, `place_order`,
+`place_trigger_order`, `cancel_all_orders`, `get_open_orders`,
+`get_user_state`, `get_user_fills`). If the basic plugin exposes these
+under different names at runtime, the agent should map to the real names
+using the basic plugin's own documentation while preserving the semantics
+described here. Under no circumstances should the agent call Hyperliquid
+directly via HTTP, RPC, or any other non-plugin path — all on-chain writes
+must go through the Hyperliquid basic plugin.
+
+## Commands
+
+### grid-plan
+
+Build a `GridPlan` from the user's natural-language description.
+**Does not place any orders.**
+
+**When to use:** Whenever the user describes a range-bound view and asks
+for a grid, or asks "what would a grid look like for X". Always run before
+`grid-open`.
+
+**Inputs parsed from natural language:**
+
+- `instrument` — e.g. `BTC`, `ETH`, `SOL` (perpetual)
+- `range_low`, `range_high` — user's expected price band (USD)
+- `risk_profile` — `conservative` | `balanced` | `aggressive`
+  (default: `conservative`)
+- `total_notional_usd` — total capital to commit
+- `leverage` — integer, default 2
+
+**Agent execution steps:**
+
+1. Call the Hyperliquid basic plugin to fetch market metadata for
+   `instrument`: `tickSize`, `minOrderSizeUsd`, `markPrice`, `maxLeverage`.
+2. Call the Hyperliquid basic plugin to fetch recent hourly candles.
+   Prefer the last 168 (7 days) for a stable volatility estimate;
+   accept as few as 24 (1 day) if that's all the basic plugin returns.
+   Fewer than 24 → abort and tell the user volatility can't be
+   estimated reliably.
+3. **Run `liqgrid plan`**, passing a JSON input with the parsed user
+   parameters + market meta + candles. Example:
+   ```
+   echo '{
+     "coin": "BTC",
+     "rangeLow": 90000,
+     "rangeHigh": 95000,
+     "totalNotionalUsd": 300,
+     "leverage": 2,
+     "riskProfile": "conservative",
+     "marketMeta": { ... from basic plugin ... },
+     "candles": [ ... from basic plugin ... ]
+   }' | liqgrid plan
+   ```
+4. Parse the returned JSON `GridPlan`. Present it to the user, clearly
+   labeled **DRY-RUN PLAN — no orders placed**. Include:
+   - Grid count
+   - **Both** `plan.totalNotionalUsd` (the full exposure) **and**
+     `plan.marginRequiredUsd` (actual USDC margin the user needs =
+     notional / leverage). These are different numbers — the agent must
+     label them clearly. A $5000 notional plan at 10× only needs $500
+     margin; a user who doesn't understand this might fund the wrong
+     amount.
+   - Leverage
+   - Stop-loss trigger price
+   - Expected fills/day (from realized volatility)
+   - Max loss at range break (absolute and as % of notional)
+   - `plan.liquidationDistancePct` — present as **"approx. liquidation
+     buffer: X%"** and append the disclaimer: "This is an estimate from
+     liqgrid; the authoritative liquidation price will be computed by
+     Hyperliquid's risk engine at order time." If the user's grid
+     extends close to this estimate, surface that explicitly.
+   - Any warnings from `plan.warnings`
+   - `plan.planHash` (present as a short identifier, e.g. the first 6
+     characters — matching the `lg-{hash[:6]}` form used in the
+     strategy tag so users see consistent identifiers across the plan
+     view and their order tags). `planHash` is stable across identical
+     inputs and can be referenced for support.
+
+**Critical: the agent must never fabricate grid levels or stop-loss
+values. Always use the output from `liqgrid plan` verbatim.**
+
+**Tip:** For a human-readable summary of any plan, the agent can run
+`liqgrid explain --input <plan.json>` — it returns a plain-English
+breakdown with the fields above already formatted. Useful when the
+user asks "explain this plan in normal English" or when the raw JSON
+is unwieldy.
+
+### grid-open
+
+Execute the plan produced by `grid-plan` by opening all grid orders
+through the Hyperliquid basic plugin.
+
+**When to use:** Only after `grid-plan` has been shown to the user in the
+same session and the user has explicitly confirmed ("yes open it", "go
+live", or equivalent). Never run without an immediately-prior plan in
+context.
+
+**Mandatory pre-execution checks (abort if any fails):**
+
+1. Dry-run flag off (user explicitly went live this session).
+2. The `GridPlan` was produced by `liqgrid plan` in this session — never
+   hand-constructed.
+3. If `plan.warnings` contains a stop-loss warning (e.g. "stop-loss would
+   allow loss of X% > 30% cap"), the agent must:
+   - Quote the warning to the user verbatim — do not paraphrase away
+     the number.
+   - Ask neutrally: "The stop-loss on this plan would allow a larger
+     loss than liqgrid's 30% default threshold. Reply **'yes, I'm OK
+     with that'** to continue, or **'safer'** to rebuild with lower
+     leverage or a tighter range."
+   - Only proceed after the user explicitly accepts the risk.
+4. Present a **final one-line confirmation** and wait for a clear "yes":
+   > Opening {gridCount} {coin}-PERP limit orders, total ${totalNotional}
+   > at {leverage}x, stop-loss at {stopLossTriggerPrice}. Confirm?
+
+**Execution:**
+
+For each level in `plan.levels`, call the Hyperliquid basic plugin's
+order-placing tool with:
+- `coin = plan.coin`
+- `side = level.side` (`"buy"` or `"sell"`)
+- `price = level.price`
+- `size = level.sizeCoin` — Hyperliquid's order API takes contract
+  quantity, not USD notional. Use `sizeCoin`. `sizeUsd` in the plan is
+  only for human-readable display and must not be passed as the order
+  size.
+- `order_type = "limit"`
+- `post_only = true`
+- `reduce_only = false`
+- **strategy tag**: `lg-{planHash[:6]}` (see Attribution Rule).
+  This is what makes the orders attributable to this Skill on the
+  Plugin Store leaderboard.
+
+After all limit orders succeed, call the Hyperliquid basic plugin's
+trigger-order tool to install a stop-market at
+`plan.stopLossTriggerPrice` with `reduce_only = true` **and the same
+strategy tag** `lg-{planHash[:6]}`.
+
+If any single order is rejected (insufficient margin, price band, rate
+limit), stop immediately, quote the exact error from the basic plugin, and
+ask the user how to proceed. Do not silently retry. Do not silently skip.
+
+### grid-status
+
+Query the current state of an open grid.
+
+**When to use:** User asks "how is my grid doing", "what's my PnL", "how
+many fills so far".
+
+**Identifying the right grid:** If the user has multiple active liqgrid
+grids (across different coins or replaced plans), ask them which by
+`planHash` (6-char prefix) or by coin. If only one grid is active, no
+disambiguation needed.
+
+**Execution:** Call the Hyperliquid basic plugin to fetch open orders
+(filter by strategy tag `lg-{planHash[:6]}` if supported), account
+state, and fills since the grid was opened. Return: filled count,
+realized PnL from filled pairs, unrealized PnL on current position,
+distance to stop-loss in absolute price and percentage.
+
+### grid-resume
+
+Reattach to an existing liqgrid grid across sessions.
+
+**When to use:** User comes back after closing their session and asks
+"how is my liqgrid grid doing", or wants to manage a grid they don't
+remember exactly. Or: a new agent instance needs to take over an
+existing grid placed earlier.
+
+**Execution:**
+
+1. Call the Hyperliquid basic plugin to fetch all open orders for the
+   user's Hyperliquid account.
+2. Filter orders whose strategy tag starts with `lg-` — these are
+   liqgrid-tagged orders.
+3. Group by the tag suffix (the 6-char planHash prefix). Each group
+   represents one active grid.
+4. Present the list to the user: `coin`, `planHash[:6]`, count of open
+   orders, current mark price. Let them pick which grid to manage.
+5. Once identified, run `grid-status` or `grid-close` as requested.
+
+Note: liqgrid is stateless — the source of truth for any active grid
+is the open orders on Hyperliquid, not local storage. The strategy tag
+is what makes grids re-discoverable across sessions.
+
+### grid-close
+
+Cancel all open grid orders and optionally flatten the position.
+
+**When to use:** User asks to stop, close, take profit, or cut losses.
+
+**Execution:**
+
+1. Call the Hyperliquid basic plugin to cancel all open orders for the
+   instrument. If the basic plugin supports tag-scoped cancellation,
+   prefer canceling only orders tagged with `lg-{planHash[:6]}`,
+   so other non-liqgrid orders the user might have are preserved.
+2. If the user explicitly asks to flatten, call the basic plugin to place
+   a market order in the opposite direction of the current position with
+   `reduce_only = true` **and strategy tag** `lg-{planHash[:6]}`.
+   Warn the user briefly that a market-order flatten on a large
+   leveraged position can have meaningful slippage.
+3. Confirm completion and report final realized PnL.
+
+## Examples
+
+### Example 1 — Balanced ETH grid, dry-run
+
+**User:** "Plan me a balanced ETH grid between 3200 and 3400, $500 at 2x"
+
+**Agent:**
+
+1. Fetch ETH market meta and candles via Hyperliquid basic plugin.
+2. Run `liqgrid plan` with those inputs.
+3. Return the plan labeled "DRY-RUN PLAN".
+4. End with: "No orders have been placed. Reply 'go live' to execute."
+
+### Example 2 — Aggressive BTC grid with 10× (triggers safety warning)
+
+**User:** "BTC 85k–100k, aggressive, $5000 at 10x, go live"
+
+**Agent:**
+
+1. Run `liqgrid plan`. Output includes warning:
+   `stop-loss would allow loss of 52.7% > 30% cap; widen range or tighten
+   risk_profile`.
+2. Present the full plan. Quote the warning verbatim — do not paraphrase
+   away the number.
+3. Ask neutrally: "At 10× leverage across this range, a stop-out would
+   cost about 53% of your margin. liqgrid's default threshold for an
+   automatic proceed is 30%. Reply **'yes, I'm OK with that'** to
+   continue as planned, or **'safer'** to get the same plan with lower
+   leverage."
+4. Only if the user explicitly accepts the risk: present the final
+   one-line confirmation and then execute via the basic plugin.
+5. If user replies "safer": re-run `liqgrid plan` with `leverage: 5` (or
+   one step down from the user's original) and loop back to step 1.
+
+### Example 3 — User asks for something beyond all caps
+
+**User:** "Open a 50x BTC grid with $50,000"
+
+**Agent:**
+
+1. Refuse silently clamping. Explain: leverage capped at 10x by liqgrid,
+   notional capped at $5000 by liqgrid.
+2. Offer: "I can open up to a 10x $5000 grid. That's the hard safety
+   ceiling of liqgrid v1.0.0. Want to proceed at 10x $5000?"
+3. Never compute or execute a plan above the caps — the binary would
+   clamp them silently and produce a warning, but the agent must stop
+   before even running `liqgrid plan` in this case.
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| "Hyperliquid basic plugin not installed" | Basic plugin missing | Tell user to run `npx skills add okx/plugin-store --skill hyperliquid-plugin` |
+| "liqgrid: command not found" | Binary not on PATH | Re-install this Skill via `npx skills add okx/plugin-store --skill liqgrid`; verify `liqgrid --version` |
+| `liqgrid error: ...` | Invalid input JSON, missing fields | Show the binary's error verbatim; ask the user to rephrase or correct the input |
+| Plan has `warnings` about notional clamp | User asked for > $5000 | Surface the warning; confirm user wants to proceed at the clamped cap |
+| Plan has `warnings` about leverage clamp | User asked for > 10× | Surface the warning; confirm user wants to proceed at 10× |
+| Plan has `warnings` about "auto-downshifted" to 5× | User requested conservative + leverage > 5× | Explain: conservative profile caps leverage at 5× for safety; if they want higher leverage, suggest switching to balanced or aggressive and re-plan |
+| Plan has `warnings` about stop-loss > 30% | High leverage + loose range | See Example 2 above — require explicit "yes, I'm OK with that" before executing |
+| Plan has `warnings` starting with **REFUSE** | User's range premise contradicts the live mark price | Hard refuse — do **not** execute. Tell the user their range appears stale or wrong and ask them to recheck before re-planning |
+| Plan has `warnings` about mark/candle drift | Mark price drifted >3% from last candle close | Surface the warning. Either refetch fresh candles and re-plan, or ask the user to confirm they understand the volatility estimate may be stale |
+| Plan has `warnings` about candle gaps | Hyperliquid basic plugin returned a non-contiguous candle series | Refetch candles. If the gap persists, note it in the user-facing plan and add caution about the fills/day estimate |
+| Plan has `warnings` about per-level size below market min | Notional too small for grid_count + price | Reduce grid_count (e.g. switch from aggressive to balanced) OR increase notional. Rerun `liqgrid plan` |
+| Plan has empty `levels` array | Invalid range, price band too tight | Quote the warning; ask user to widen the range |
+| `planHash` differs between two runs | Candles or marketMeta changed between fetches | Expected behavior — `planHash` hashes over the full plan output including levels derived from live data. If the user wants the *same* plan as before, use the same market snapshot (cached); otherwise explain that prices moved, so the plan is legitimately different. |
+| "Insufficient margin" from basic plugin | Account balance too low | Show `plan.marginRequiredUsd` (not notional) as the amount the user needs to deposit; do not silently reduce order sizes |
+| "Order rejected by Hyperliquid" | Price band / post-only / rate limit | Quote the basic plugin's exact error; stop; ask user how to proceed |
+| "Rate limited" from basic plugin | Too many orders too quickly | Wait 2 seconds; continue with remaining levels; never drop orders to stay under the rate limit |
+| "Price moved during placement" | Mark drifted mid-execution | Pause; report the drift; ask the user whether to continue, adjust, or cancel |
+
+## Security Notices
+
+**Risk level: advanced.** This Skill places and manages live perpetual
+orders on Hyperliquid. Perpetual futures are leveraged instruments. Losses
+can equal or, in adverse conditions, exceed the collateral committed.
+
+**Hard safety limits built into the `liqgrid` binary:**
+
+- Maximum **$5,000** total notional per grid.
+- Maximum **10×** leverage.
+- Maximum **50** grid rungs.
+- Stop-loss sized to bound worst-case loss at **≤ 30%** of notional (when
+  this cap would be breached, the binary emits a warning and this Skill
+  requires explicit user acknowledgment before executing).
+
+These limits are enforced in the binary's source code
+(`src/types.ts:CAPS`). They cannot be overridden from within this Skill.
+A user who wants higher limits must use a different Skill.
+
+**Behavioral safety:**
+
+- **Dry-run mode by default.** Every new session starts in dry-run.
+- **Explicit final confirmation** required before any order batch.
+- **Deterministic planning.** The grid math is done in a compiled binary,
+  not by the LLM — so the same inputs always produce the same plan. The
+  agent cannot silently fabricate or alter grid levels.
+
+**Circuit breakers (enforced by this Skill's pre-flight — see Pre-flight
+Checks §6):**
+
+- **Same-instrument lockout.** If the user already has an active liqgrid
+  grid on the same coin, refuse to open a second one unless the user
+  explicitly replaces it.
+- **Daily loss stop.** If cumulative realized PnL from liqgrid-tagged
+  trades over the last 24 hours is worse than −2% of the user's account
+  equity, refuse to open a new grid until the next UTC day.
+- **Consecutive loss stop.** If the user's last two liqgrid-tagged grid
+  closures both resulted in net realized loss, refuse to open a new grid
+  and recommend they pause liqgrid for the day and reassess the market
+  before continuing.
+
+These are risk guardrails, not regulatory limits — the Skill should
+explain clearly *why* it is refusing and what would need to change to
+retry, not just block silently.
+
+**What this Skill does not do:**
+
+- It does not hold or touch private keys. All signing happens inside the
+  Agentic Wallet's Trusted Execution Environment, via the Hyperliquid
+  basic plugin.
+- It does not collect, store, or transmit user wallet addresses, balances,
+  or trade history to any external server.
+- It makes no external API calls outside the Hyperliquid basic plugin
+  tool surface (`api_calls: []` in `plugin.yaml`).
+- The binary itself makes no network calls — it is a pure compute step.
+
+**Disclaimer:** Grid strategies assume mean-reverting, range-bound price
+action. In a trending or breakout market, a grid accumulates a losing
+position against the trend; the stop-loss mitigates but does not
+eliminate this risk. Leverage amplifies both gains and losses. Nothing in
+this Skill is financial, investment, or trading advice. You are
+responsible for your own sizing, risk management, and decision to trade.
+
+## Skill Routing
+
+- **For on-chain Hyperliquid operations only (single orders, no strategy
+  wrapper)** → use the Hyperliquid basic plugin (`hyperliquid-plugin`)
+  directly.
+- **For portfolio / balance overview across chains** → use OKX's portfolio
+  skills from Onchain OS.
+- **For DEX swaps on other chains** → use OKX DEX skills from Onchain OS.

--- a/skills/liqgrid/SKILL.md
+++ b/skills/liqgrid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: liqgrid
-description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
+description: "AI-driven Hyperliquid grids. Deterministic binary, funding-aware sizing (±20% tilt), concentrated liquidity, 75-combo parameter optimizer, 30-day backtest. One sentence in, risk-capped plan out."
 version: "1.2.0"
 author: "dddd86971-cloud"
 tags:
@@ -9,6 +9,11 @@ tags:
   - perpetuals
   - strategy
   - agentic-wallet
+  - passive-income
+  - automated-trading
+  - funding-aware
+  - backtest
+  - range-bound
 ---
 
 # liqgrid

--- a/skills/liqgrid/SUMMARY.md
+++ b/skills/liqgrid/SUMMARY.md
@@ -17,7 +17,47 @@ Core operations:
 - Execute all limit orders + the stop-loss trigger through the Hyperliquid basic plugin
 - Resume, inspect, or close an existing grid across sessions via a stable strategy tag
 
-Tags: `hyperliquid` `grid` `perpetuals` `strategy` `agentic-wallet`
+Tags: `hyperliquid` `grid` `perpetuals` `strategy` `agentic-wallet` `passive-income` `automated-trading` `funding-aware` `backtest` `range-bound`
+
+## How It Works
+
+```
+User: "BTC 90k-95k range, $300 at 2x"
+   ↓
+liqgrid Skill (natural-language parsing)
+   ↓
+   ├─► hyperliquid-plugin            → mark price + 1h candles
+   ├─► api.hyperliquid.xyz/info      → live funding rate (read-only)
+   └─► liqgrid binary                → deterministic plan
+   ↓
+Dry-run plan + 7-day backtest preview:
+   • 23 tick-aligned rungs, concentrated near mark
+   • funding-tilted ±20% (collects funding as alpha)
+   • stop-loss + max-loss bound, hard caps enforced
+   • realized PnL / max DD / fills on past 7 days
+   ↓
+User: "go live"
+   ↓
+hyperliquid-plugin order ... --strategy-id liqgrid1
+hyperliquid-plugin tpsl  ... --strategy-id liqgrid1
+   ↓
+Agentic Wallet TEE signing → on-chain fills
+```
+
+Five steps, deterministic at each layer. The compiled binary makes the math
+reproducible (same inputs → same plan, byte-identical); the agent layer
+handles natural-language parsing and orchestration; all on-chain writes flow
+through `hyperliquid-plugin` so signing stays inside the Agentic Wallet TEE.
+
+Two helper subcommands beyond the core flow:
+
+- **`liqgrid quickstart`** — given just `coin` + `notional` + recent candles,
+  the binary derives sensible `(rangeLow, rangeHigh, leverage, riskProfile)`
+  from the recent vol regime. Use this when the user doesn't pick a range.
+- **`liqgrid optimize`** — sweeps 75 (range × leverage × profile) combinations
+  on past 30 days, ranks by Calmar score (`realizedPnl / max(maxDD, 1)`),
+  returns the top N. Use this to compare hand-picked params to the
+  historically-best ones.
 
 ## Prerequisites
 

--- a/skills/liqgrid/SUMMARY.md
+++ b/skills/liqgrid/SUMMARY.md
@@ -47,7 +47,7 @@ Tags: `hyperliquid` `grid` `perpetuals` `strategy` `agentic-wallet`
 3. **Go live only after explicit confirmation**
    Reply "go live" (or "place real orders") to execute. The agent places
    limit orders and the stop-loss trigger through the Hyperliquid basic
-   plugin, tagged `lg-{planHash[:6]}` so every fill is attributable to
+   plugin with `--strategy-id liqgrid1` so every fill is attributable to
    this Skill on the Plugin Store leaderboard. If any plan warning
    would allow a loss above the 30% of-notional threshold, the agent
    quotes the warning verbatim and waits for "yes, I'm OK with that"

--- a/skills/liqgrid/SUMMARY.md
+++ b/skills/liqgrid/SUMMARY.md
@@ -1,0 +1,62 @@
+# liqgrid
+
+## Overview
+
+liqgrid turns a trader's one-sentence view on a Hyperliquid perpetual
+("BTC 90k–95k, balanced, $500 at 5x") into a deterministic, risk-capped
+grid strategy. A compiled TypeScript engine computes the full grid plan
+(levels, stop-loss, expected fills, margin required) so the math is
+reproducible across runs and models; all on-chain writes flow through
+the Hyperliquid basic plugin inside the Agentic Wallet.
+
+Core operations:
+
+- Parse a natural-language range-bound view into a dry-run GridPlan
+- Compute deterministic grid levels (log-spaced, tick-aligned, dedupe-safe)
+- Compute stop-loss trigger price + worst-case-loss bound
+- Execute all limit orders + the stop-loss trigger through the Hyperliquid basic plugin
+- Resume, inspect, or close an existing grid across sessions via a stable strategy tag
+
+Tags: `hyperliquid` `grid` `perpetuals` `strategy` `agentic-wallet`
+
+## Prerequisites
+
+- No IP restrictions beyond those imposed by Hyperliquid itself
+- Supported chain: Hyperliquid L1 (perpetual DEX)
+- Supported instruments: liquid Hyperliquid perpetuals (BTC-PERP, ETH-PERP, SOL-PERP, etc.)
+- onchainos CLI installed and Agentic Wallet unlocked
+- Hyperliquid basic plugin installed: `npx skills add okx/plugin-store --skill hyperliquid-plugin`
+- A funded Hyperliquid perp account with ≥ 20 USDC collateral for the chosen notional and leverage
+
+## Quick Start
+
+1. **Describe your range-bound view in natural language**
+   Tell the agent what you expect the market to do. For example:
+   "plan a balanced ETH grid between 3200 and 3400, $500 at 2x". liqgrid
+   starts every session in dry-run by default — nothing is placed yet.
+
+2. **Review the dry-run plan**
+   The agent fetches live market metadata and recent hourly candles
+   through the Hyperliquid basic plugin, runs the bundled `liqgrid plan`
+   binary, and returns a full breakdown: grid count, total notional vs.
+   margin required (they differ — margin = notional / leverage), leverage,
+   stop-loss trigger price, expected fills/day, approximate liquidation
+   buffer, and any safety warnings. Each plan has a stable `planHash` so
+   you can reference it later; same inputs always produce the same hash.
+
+3. **Go live only after explicit confirmation**
+   Reply "go live" (or "place real orders") to execute. The agent places
+   limit orders and the stop-loss trigger through the Hyperliquid basic
+   plugin, tagged `lg-{planHash[:6]}` so every fill is attributable to
+   this Skill on the Plugin Store leaderboard. If any plan warning
+   would allow a loss above the 30% of-notional threshold, the agent
+   quotes the warning verbatim and waits for "yes, I'm OK with that"
+   before continuing.
+
+4. **Monitor, resume, or close**
+   Ask "how is my grid doing" for filled count and realized/unrealized PnL.
+   Grids are identified by their strategy tag, so you can resume a grid
+   from a new session — liqgrid reads open orders back from Hyperliquid
+   and reattaches without any local state. Say "close" to cancel all
+   liqgrid-tagged orders and, optionally, flatten the residual position
+   with a reduce-only market order.

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -29,7 +29,7 @@ components:
 build:
   lang: typescript
   source_repo: "dddd86971-cloud/liqgrid"
-  source_commit: "4b089a6e6940b4ffdd6846cdc3b1b01fb35a8a78"
+  source_commit: "0c34b3c634bb6f84c607cab4f8d509be6dab3320"
   source_dir: "."
   binary_name: "liqgrid"
   main: "dist/index.js"

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: liqgrid
-version: "1.1.0"
+version: "1.2.0"
 description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
 author:
   name: "dddd86971-cloud"
@@ -29,7 +29,7 @@ components:
 build:
   lang: typescript
   source_repo: "dddd86971-cloud/liqgrid"
-  source_commit: "0c34b3c634bb6f84c607cab4f8d509be6dab3320"
+  source_commit: "0837e8c9111bc90eacda6f061e2edc6921bbd08b"
   source_dir: "."
   binary_name: "liqgrid"
   main: "dist/index.js"

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: liqgrid
-version: "1.0.0"
-description: "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin."
+version: "1.1.0"
+description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
 author:
   name: "dddd86971-cloud"
   github: "dddd86971-cloud"
@@ -29,7 +29,7 @@ components:
 build:
   lang: typescript
   source_repo: "dddd86971-cloud/liqgrid"
-  source_commit: "40bf29530aedabd2966aa46c785277a76069cb90"
+  source_commit: "4b089a6e6940b4ffdd6846cdc3b1b01fb35a8a78"
   source_dir: "."
   binary_name: "liqgrid"
   main: "dist/index.js"

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: liqgrid
 version: "1.2.0"
-description: "Natural-language perpetual grids on Hyperliquid with funding-aware asymmetric sizing, concentrated-liquidity weighting, and a deterministic backtest engine — all on top of hyperliquid-plugin."
+description: "AI-driven Hyperliquid grids. Deterministic binary, funding-aware sizing (±20% tilt), concentrated liquidity, 75-combo parameter optimizer, 30-day backtest. One sentence in, risk-capped plan out."
 author:
   name: "dddd86971-cloud"
   github: "dddd86971-cloud"
@@ -13,6 +13,11 @@ tags:
   - perpetuals
   - strategy
   - agentic-wallet
+  - passive-income
+  - automated-trading
+  - funding-aware
+  - backtest
+  - range-bound
 
 dependent_plugin:
   - name: hyperliquid-plugin

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+name: liqgrid
+version: "1.0.0"
+description: "Natural-language perpetual grids on Hyperliquid. Deterministic TypeScript engine computes levels, stop-loss, and caps; executes through the Hyperliquid basic plugin."
+author:
+  name: "dddd86971-cloud"
+  github: "dddd86971-cloud"
+license: MIT
+category: trading-strategy
+tags:
+  - hyperliquid
+  - grid
+  - perpetuals
+  - strategy
+  - agentic-wallet
+
+components:
+  skill:
+    dir: "."
+
+build:
+  lang: typescript
+  source_repo: "dddd86971-cloud/liqgrid"
+  source_commit: "40bf29530aedabd2966aa46c785277a76069cb90"
+  source_dir: "."
+  binary_name: "liqgrid"
+  main: "dist/index.js"
+
+api_calls: []

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -6,13 +6,21 @@ author:
   name: "dddd86971-cloud"
   github: "dddd86971-cloud"
 license: MIT
-category: trading-strategy
+category: strategy
 tags:
   - hyperliquid
   - grid
   - perpetuals
   - strategy
   - agentic-wallet
+
+dependent_plugin:
+  - name: hyperliquid-plugin
+    version: "^0.3.9"
+
+risk_level: advanced
+supported_venues:
+  - hyperliquid
 
 components:
   skill:

--- a/skills/liqgrid/plugin.yaml
+++ b/skills/liqgrid/plugin.yaml
@@ -34,4 +34,8 @@ build:
   binary_name: "liqgrid"
   main: "dist/index.js"
 
-api_calls: []
+api_calls:
+  # Read-only public endpoint: agent fetches funding rate + candles from
+  # Hyperliquid's info API for v1.1 funding-aware bias and `liqgrid backtest`.
+  # All write operations still go through hyperliquid-plugin (Agentic Wallet TEE).
+  - "https://api.hyperliquid.xyz"


### PR DESCRIPTION
# [new-plugin] liqgrid v1.0.0

**Season 1 Developer Challenge submission — expedited review requested.**

## Summary

`liqgrid` turns a trader's one-sentence view on a Hyperliquid perpetual
("BTC 90k–95k, balanced, $500 at 5x") into a deterministic, risk-capped
grid strategy. Submitted as a **binary plugin (Mode B)** — the TypeScript
engine lives in [`<YOUR_GITHUB_USERNAME>/liqgrid`](https://github.com/<YOUR_GITHUB_USERNAME>/liqgrid)
and is pinned to a specific commit.

Pipeline on every use:

1. Agent parses natural language → `(coin, range, notional, leverage, profile)`.
2. Agent fetches live market meta + candles via the **Hyperliquid basic plugin**.
3. Agent runs `liqgrid plan` (the bundled binary) to compute the grid.
4. Agent presents the dry-run plan to the user.
5. On explicit user confirmation, agent executes each order
   **through the Hyperliquid basic plugin**.

All on-chain writes flow through the Hyperliquid basic plugin. liqgrid does
not bypass it at any point.

## Why binary instead of Skill-only

Grid math must be deterministic — same inputs → same plan, every run. Pure
Skill-markdown implementations leave the math to the LLM, producing
different grid levels across models and across calls. A compiled binary
guarantees consistency, which matters both for user trust and for safety
invariants (stop-loss never silently drifts).

The binary is a pure compute step — it makes no network calls, handles no
keys, has no dependencies at runtime.

## Safety posture (advanced risk level)

Enforced in the binary (`src/types.ts:CAPS`):

- **Dry-run by default.** Every session starts in dry-run.
- **Max $5,000 total notional per grid.**
- **Max 10× leverage.**
- **Max 50 grid rungs.**
- **Stop-loss bound** — worst-case loss >30% of notional emits a warning
  that the Skill requires explicit user acknowledgment to override.
- **Explicit final confirmation** before any order batch.
- **No private key handling** — all signing via Agentic Wallet TEE.
- **No external API calls** (`api_calls: []`) — binary + Skill are a pure
  compute + orchestration layer on top of the Hyperliquid basic plugin.

## Source code

- Repo: `<YOUR_GITHUB_USERNAME>/liqgrid`
- Language: TypeScript (compiled to JS, distributed via `bun install -g`)
- Pinned commit: see `build.source_commit` in `plugin.yaml`
- Self-tests: `npm test` — 19 invariants covering determinism,
  cap enforcement, tick alignment, risk-profile monotonicity, input
  validation, dedupe-safe sizing, and planHash stability
- License: MIT

## Pre-submission checklist

- [x] `plugin.yaml`, `.claude-plugin/plugin.json`, `SKILL.md` present and consistent
- [x] `name` = `liqgrid`, lowercase, 7 chars (within 2–40)
- [x] `version` = `1.0.0` in all three files
- [x] `author.github` matches my GitHub username
- [x] `license` = MIT (valid SPDX)
- [x] `category` = `trading-strategy`
- [x] `description` = 165 chars (within 200)
- [x] `api_calls: []` — no external APIs from the Skill or binary
- [x] `build.lang` = typescript
- [x] `build.source_repo` in `owner/repo` format
- [x] `build.source_commit` is full 40-char hex SHA
- [x] `build.main` = `dist/index.js` (compiled JS, shebang present)
- [x] `build.binary_name` = `liqgrid`
- [x] Source repo has `dist/` pre-compiled (required for TS per docs)
- [x] `package.json` has `bin` field pointing to `dist/index.js`
- [x] `dist/index.js` first line is `#!/usr/bin/env node`
- [x] SKILL.md has frontmatter with name/description/version/author
- [x] SKILL.md has Overview, Pre-flight Checks, Commands, Error Handling, Security Notices
- [x] No hardcoded credentials anywhere
- [x] No pre-compiled binaries in the Skill submission (only in source repo)
- [x] LICENSE file present in both repos
- [x] PR only modifies files in `skills/liqgrid/`
- [x] Advanced risk requirements met: dry-run / stop-loss / max caps / risk disclaimer
- [x] Local lint passes
