### PR TITLE
[new-plugin] pmclock v1.0.0

### DIFF
--- a/skills/pmclock/.claude-plugin/plugin.json
+++ b/skills/pmclock/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "pmclock",
+  "description": "5-minute crypto Up/Down arbitrage scanner for Polymarket. Compares CEX-implied probability vs PM ask, deploys risk-bounded buys via polymarket-plugin when edge >= 1.5%.",
+  "version": "1.0.0",
+  "author": {
+    "name": "dddd86971-cloud"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/dddd86971-cloud/pmclock",
+  "repository": "https://github.com/dddd86971-cloud/pmclock",
+  "keywords": ["polymarket", "prediction-market", "arbitrage", "5min", "latency-arb", "crypto", "automated-trading", "passive-income", "agentic-wallet", "strategy"]
+}

--- a/skills/pmclock/LICENSE
+++ b/skills/pmclock/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dddd86971-cloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/pmclock/README.md
+++ b/skills/pmclock/README.md
@@ -1,0 +1,165 @@
+# pmclock — Plugin Store Skill
+
+5-minute crypto Up/Down arbitrage scanner for Polymarket, powered by a
+**deterministic TypeScript binary**. Compares CEX-implied GBM
+probability to live Polymarket YES/NO ask, deploys risk-bounded maker
+buys via `polymarket-plugin` only when net edge ≥ 1.5%.
+
+## Install
+
+```bash
+npx skills add okx/plugin-store --skill pmclock
+```
+
+## At a glance
+
+```
+User: "Scan BTC 5min arb, $50 budget, balanced"
+  │
+  ▼
+pmclock Skill (natural-language parsing)
+  │
+  ├─► api.binance.com /ticker/price  →  live BTC spot
+  ├─► api.binance.com /klines (1m, 60) →  realized daily vol from past hour
+  ├─► polymarket-plugin list-5m        →  next 5 BTC Up/Down markets
+  ├─► polymarket-plugin get-market     →  per-market YES/NO ask + book depth
+  └─► pmclock binary                   →  deterministic GBM probability +
+                                          Kelly-fractional sizing per market
+  │
+  ▼
+Dry-run plan:
+  • Markets considered : 5
+  • Decisions          : 1  (4 rejected: 3 below-edge, 1 low-liquidity)
+  • Decision detail    : NO $7.50 @ 0.610  edge 38.90%
+                         (CEX 99.9% above 78,000 vs PM 61.0%)
+  • Total deployed     : $7.50 of $50 budget
+  • planHash           : a3f82b...   (same inputs → same plan, always)
+  │
+  ▼
+User: "place it"
+  │
+  ▼
+polymarket-plugin buy --market-id <id> --outcome no --amount 7.5 \
+   --price 0.610 --post-only --order-type GTC \
+   --expires <closesAt-30s> --strategy-id pmclock --confirm
+  │
+  ▼
+Maker-side rebate fill → wait until 5-min resolution → polymarket-plugin redeem
+```
+
+## What pmclock actually does for a user
+
+| Pain point | Without pmclock | With pmclock |
+|---|---|---|
+| 5-min Up/Down markets often misprice vs. CEX during the first 1-2 minutes after open | Manual eyeballing impossible at this speed; HFT bots own top-of-book | LLM-Skill targets the long tail (thin $50-200 books) where small operators can capture edge HFT ignores |
+| LLM math drifts (different model = different decisions) | Same prompt, different sizes, no audit trail | Compiled TypeScript binary, byte-identical decisions, stable `planHash` SHA-256 |
+| Manual decision-making is too slow for 5-min windows | Trader sees market, computes prob, sizes — already past close | Binary returns full `PmclockPlan` in < 50ms; agent's ~30s loop captures most of the open-window edge |
+| Statistical errors compound | "Felt right" sizing → over-bet on weak edges, lose long-run | Kelly-fractional sizing (1/4 Kelly at balanced), saturates at 5% edge → stable Sharpe |
+| Can't tell why a bot skipped a market | Black-box "no opp" message | 7 structured rejection reasons (`expired`, `too_far_out`, `low_liquidity`, `edge_below_threshold`, `yes_no_ask_invalid`, `insufficient_budget`, `unknown_direction`) + per-market detail |
+| Single bad CEX price could nuke account | Bot YOLOs full position | Hard caps in source: $200/scan, $20/market, 1.5% min edge — refused at plan stage |
+
+## Hard differentiators vs other Polymarket strategies
+
+1. **Deterministic binary, not LLM math** — every probability,
+   every Kelly fraction, every rejection decision is in compiled
+   TypeScript. Same inputs → byte-identical outputs. Other AI
+   strategy Skills leave the math to the LLM and drift each call.
+
+2. **Targets long-tail 5-min books, not top-of-book HFT** — pmclock
+   is intentionally slower (30-60s polling) than Rust-on-VPS
+   bots. Its niche: the first 1-2 minutes after a 5-min market
+   opens, where book depth is thin and HFT bots don't bother with
+   $50-200 books. Small AI-Skill operators can sustain 1-2% edges
+   that don't scale to multi-million-dollar HFT operations.
+
+3. **Structured rejection reasons** — every skipped market has a
+   reason code. Users can audit "why didn't pmclock buy this one?"
+   instantly. Most bots are black-box "no opportunity" — pmclock
+   shows the math.
+
+4. **Auditable Kelly + ramp** — sizing schedule is fully spelled
+   out in `src/arb.ts:sizeFromEdge`. No magic constants, no ML
+   model — pure formula, fully reproducible, fully open-source.
+
+## Safety (enforced in binary, not just documented)
+
+| Cap / check | Value |
+|---|---|
+| Max total notional per scan | **$200** |
+| Max per individual market | **$20** |
+| Min combined book liquidity (YES + NO) | **$50** |
+| Min edge to fire a decision | **1.5%** |
+| Absolute min if user lowers threshold | **0.5%** |
+| Skip markets too close to resolution | **< 30s** to close |
+| Skip markets too far out | **> 600s** (10 min) to close |
+| Conservative Kelly fraction | **0.15** |
+| Balanced Kelly fraction | **0.25** |
+| Aggressive Kelly fraction | **0.33** |
+| Edge saturation point (full per-market sizing) | **5%** |
+
+**Behavioral:** dry-run by default; explicit user confirmation
+before any order placement; `--post-only` on every limit (no
+accidental taker fills); `--expires` 30s before resolution (no
+forgotten orders).
+
+**No private keys** handled by pmclock — all signing via Agentic
+Wallet TEE through `polymarket-plugin`. The binary itself makes
+**zero** network calls. The Skill declares two read-only public
+endpoints in `plugin.yaml`: `api.binance.com` (CEX spot + klines)
+and `gamma-api.polymarket.com` (market data). Every write
+operation flows through `polymarket-plugin`.
+
+## When to use
+
+**Good fit:**
+- USDC.e on Polygon, $20+ to start
+- Comfortable with automated decision-making on a CEX-vs-PM model
+- In a non-restricted region (NOT US / France / Singapore)
+- Wants reproducible, auditable arbitrage decisions
+- OK with statistical edge over many scans rather than guaranteed wins
+
+**Bad fit:**
+- Restricted region — Polymarket TOS blocks (pre-flight refuses)
+- Wants to bet on event direction (sports / elections) — pmclock is
+  exclusively crypto Up/Down
+- Wants to compete in HFT — use Rust + VPS, not an LLM Skill
+- Expects guaranteed returns — this is statistical arbitrage,
+  individual scans can lose; edge is in long-run repetition
+
+## Requires
+
+- `onchainos` CLI + unlocked Agentic Wallet
+- **`polymarket-plugin` ≥ 0.4.10**:
+  `npx skills add okx/plugin-store --skill polymarket-plugin`
+- ≥ $20 USDC.e on Polygon (and a small POL balance for one-time
+  proxy setup if using POLY_PROXY mode)
+- Public internet access to `api.binance.com` and
+  `gamma-api.polymarket.com`
+
+## Source
+
+TypeScript → compiled to JS, distributed via `bun install -g` by the
+Plugin Store CI from
+[dddd86971-cloud/pmclock](https://github.com/dddd86971-cloud/pmclock)
+at a pinned commit (see `plugin.yaml` `build.source_commit`).
+
+Self-test suite: `npm test` — 18 invariants covering standard normal
+CDF correctness (vs known values), GBM probability bounds (ATM /
+ITM / OTM behaviors), Kelly-fractional sizing monotonicity, scan
+determinism + planHash stability, all 7 rejection-reason paths,
+direction handling (`above` vs `below`), greedy budget enforcement,
+cap clamping, structural input validation.
+
+## Strategy-id Attribution
+
+Every write operation carries `--strategy-id pmclock`. `polymarket-plugin`
+calls `onchainos wallet report-plugin-info` after each successful order
+so OKX's Plugin Store Season 1 leaderboard can attribute trades to this
+Skill.
+
+## License
+
+MIT — see `LICENSE`.
+
+See `SKILL.md` for the full command reference, error handling, and
+Security Notices. See `SUMMARY.md` for the 30-second user pitch.

--- a/skills/pmclock/SKILL.md
+++ b/skills/pmclock/SKILL.md
@@ -1,0 +1,436 @@
+---
+name: pmclock
+description: "5-minute crypto Up/Down arbitrage scanner for Polymarket. Compares CEX-implied probability vs PM ask, deploys risk-bounded buys via polymarket-plugin when edge >= 1.5%."
+version: "1.0.0"
+author: "dddd86971-cloud"
+tags:
+  - polymarket
+  - prediction-market
+  - arbitrage
+  - 5min
+  - latency-arb
+  - crypto
+  - automated-trading
+  - passive-income
+  - agentic-wallet
+  - strategy
+---
+
+# pmclock
+
+## Overview
+
+`pmclock` turns Polymarket's 5-minute crypto Up/Down markets into a
+deterministic arbitrage scanner. It pulls live BTC/ETH/SOL spot prices
+from a CEX (Binance public API), computes the GBM-implied probability
+that the underlying closes above each market's strike at resolution time,
+compares to the current PM YES/NO ask, and surfaces decisions only when
+the **net edge ≥ 1.5%** (after expected fee + slippage).
+
+What makes pmclock different from a hand-coded arb bot:
+
+- The math (probability + Kelly-fractional sizing) is in a **compiled
+  TypeScript binary** — same input → byte-identical output, across runs
+  and models. Stable `planHash` SHA-256 fingerprint per scan.
+- **LLM-Skill friendly cadence (~30s polling)** — pmclock is *not*
+  competing with Rust-on-VPS HFT bots that dominate top-volume markets.
+  It targets the **first 1-2 minutes after a 5-min market opens**, where
+  thin liquidity ($50-200 books) lets a small AI-Skill operator capture
+  edge that high-frequency bots ignore as too small to scale.
+- **All on-chain writes go through `polymarket-plugin`** — pmclock never
+  signs, never holds keys, never bypasses the Agentic Wallet TEE.
+
+**Risk level: `advanced`.** Although liability per market is bounded
+to the deployed amount (no leverage on prediction markets), the scanner
+places multiple live orders per minute. Read **Security Notices** before
+using with real funds.
+
+## When to Use
+
+Use this Skill when the user:
+
+- has **USDC.e on Polygon** (Polymarket's collateral; not generic USDC)
+  and wants AI-driven 5-min crypto arbitrage
+- is comfortable with **automated decision-making** based on a public
+  CEX price feed + Polymarket order book
+- wants **deterministic, reproducible, audit-able** decisions
+  (LLM agents can drift; pmclock binary cannot)
+- is in a **non-restricted region** (US, France, Singapore, and a few
+  others are blocked by Polymarket TOS — `polymarket-plugin check-access`
+  enforces this in pre-flight)
+
+Do **not** use this Skill when:
+
+- the user is in a Polymarket-restricted jurisdiction
+- the user expects guaranteed returns (this is statistical arbitrage —
+  individual scans can lose; the edge is in long-run repetition)
+- the user wants to bet on event direction (sports / elections /
+  political markets) — pmclock is exclusively for crypto Up/Down 5-min
+- the user wants to compete in top-of-book HFT (use a Rust + VPS bot
+  instead — pmclock is intentionally slower and targets the long tail)
+
+## Pre-flight Checks
+
+Before using this Skill, the agent must verify:
+
+1. The `onchainos` CLI is installed and the Agentic Wallet is unlocked.
+2. **`polymarket-plugin` is installed.** If not, instruct the user:
+   `npx skills add okx/plugin-store --skill polymarket-plugin`
+3. The `pmclock` binary is on PATH (installed automatically when this
+   Skill is installed via `npx skills add okx/plugin-store --skill
+   pmclock`). Verify with `pmclock --version` (expect `1.0.0`+).
+4. **Region check.** Run `polymarket-plugin check-access`. If the user
+   is in a restricted region, refuse to proceed and explain why.
+5. **Polygon wallet funded with USDC.e.** Run `polymarket-plugin
+   balance`. POLY_PROXY mode strongly recommended (gasless trades).
+   Need ≥ $20 USDC.e and a small POL balance for any one-time setup.
+6. **No existing pmclock-tagged open orders.** Run `polymarket-plugin
+   get-positions`; if any are tagged `pmclock` and approaching expiry,
+   warn the user before spawning new ones.
+7. **Dry-run mode is the default.** Every new session presents the
+   `PmclockPlan` for user review BEFORE any `polymarket-plugin buy`
+   call. Live execution requires explicit user confirmation
+   ("go live", "place it", or equivalent).
+
+## Attribution Rule
+
+Every `buy`, `sell`, or `cancel` write operation routed to
+`polymarket-plugin` MUST include `--strategy-id pmclock` for OKX
+Plugin Store leaderboard attribution:
+
+- Pass `pmclock` (10 chars) to the basic plugin's `--strategy-id` flag.
+- Read-only operations (`list-5m`, `list-markets`, `get-market`,
+  `get-positions`, `balance`) do not need the flag.
+
+This tagging is what lets the Plugin Store Season 1 Challenge
+leaderboard correctly attribute trades to this Skill. Untagged trades
+are aggregated to the generic `polymarket-plugin` account and not
+counted toward pmclock's leaderboard position.
+
+## polymarket-plugin command map
+
+This Skill is built against `polymarket-plugin` **v0.4.10** (pinned in
+`dependent_plugin` in `plugin.yaml`). Concrete commands the agent calls:
+
+| Semantic purpose | polymarket-plugin command |
+|---|---|
+| Region eligibility check | `polymarket-plugin check-access` |
+| Wallet status / balances | `polymarket-plugin quickstart` / `balance` |
+| Fund proxy wallet (one-time) | `polymarket-plugin setup-proxy` then `deposit --amount <usdc>` |
+| List next 5-min Up/Down crypto markets | `polymarket-plugin list-5m --coin <BTC\|ETH\|SOL> --count <N>` |
+| Get a specific market's order book | `polymarket-plugin get-market --market-id <id>` |
+| Place a maker-style limit buy | `polymarket-plugin buy --market-id <id> --outcome <yes\|no> --amount <usdc> --price <0-1> --order-type GTC --post-only --expires <unix_seconds> --strategy-id pmclock --confirm` |
+| Cancel an open order | `polymarket-plugin cancel --order-id <id> --confirm` |
+| List user's open orders | `polymarket-plugin get-positions` |
+| Redeem winning outcome tokens (after resolution) | `polymarket-plugin redeem --market-id <id> --confirm` |
+
+**CEX price + recent realized vol** comes from a public-read source the
+agent calls directly (declared in `plugin.yaml` `api_calls`):
+
+```bash
+# Spot price (live):
+curl -s "https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT" \
+  | jq -r '.price'
+
+# Recent realized vol from 1-minute klines (last 60 minutes):
+curl -s "https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1m&limit=60" \
+  | jq -r '[.[][4] | tonumber] as $closes
+           | reduce range(1; $closes|length) as $i (0;
+               . + (($closes[$i]/$closes[$i-1] | log) as $r | $r*$r))
+           | sqrt * sqrt(60 * 24)'   # → daily vol fraction
+```
+
+ETH/SOL: replace `BTCUSDT` with `ETHUSDT`/`SOLUSDT`.
+
+## What's new in v1.0.0
+
+Initial release. Features:
+
+- **Deterministic 5-min arbitrage scanner** — Polymarket Up/Down
+  markets vs CEX-implied GBM probability. Same input → same plan, byte
+  for byte.
+- **Standard normal CDF in pure TypeScript** (Abramowitz & Stegun
+  7.1.26 approximation, max error 1.5e-7) — no external numerics
+  library, no LLM math.
+- **Kelly-fractional sizing** with three risk profiles (conservative
+  0.15× Kelly / balanced 0.25× / aggressive 0.33×) and saturation
+  ramp at 5% edge.
+- **7 structured rejection reasons** — every skipped market gets a
+  reason (`expired`, `too_far_out`, `low_liquidity`,
+  `edge_below_threshold`, `yes_no_ask_invalid`, `insufficient_budget`,
+  `unknown_direction`) so the user can audit "why didn't pmclock buy
+  this one?".
+- **Hard caps in source**: $200 total notional / $20 per market /
+  $50 minimum book liquidity / 1.5% min edge / 0.5% absolute floor.
+- **18 self-tests** covering CDF correctness, ATM/ITM/OTM probability
+  bounds, sizing monotonicity, determinism, planHash stability,
+  per-reason rejection, direction handling, greedy budget enforcement.
+
+## Commands
+
+### scan-5min
+
+Run one arbitrage scan over the next batch of 5-minute Up/Down markets
+for a chosen coin. **Does not place orders.**
+
+**When to use:** User asks "scan BTC 5min for arb", "find me arb on
+ETH", "is there edge right now". Or as the recurring loop body when
+running pmclock on a timer.
+
+**Agent execution steps:**
+
+1. Run `polymarket-plugin check-access`. If region restricted → abort.
+
+2. Fetch live CEX spot:
+   ```bash
+   PRICE=$(curl -s "https://api.binance.com/api/v3/ticker/price?symbol=${COIN}USDT" | jq -r '.price')
+   ```
+
+3. Fetch recent realized daily vol from 1m klines:
+   ```bash
+   VOL=$(curl -s "https://api.binance.com/api/v3/klines?symbol=${COIN}USDT&interval=1m&limit=60" \
+     | jq -r '[.[][4] | tonumber] as $c
+              | reduce range(1; $c|length) as $i (0;
+                  . + (($c[$i]/$c[$i-1] | log) as $r | $r*$r))
+              | sqrt * sqrt(60 * 24)')
+   ```
+
+4. Fetch current 5-min markets:
+   ```bash
+   polymarket-plugin list-5m --coin "$COIN" --count 5
+   ```
+   For each returned market, also call `get-market --market-id <id>` to
+   pull top-of-book yesAsk / noAsk / liquidity.
+
+5. Pipe everything into `pmclock plan`:
+   ```bash
+   echo '{
+     "coin": "BTC",
+     "cexPrice": '$PRICE',
+     "cexVolDaily": '$VOL',
+     "pmMarkets": [
+       { "marketId":"<id>", "threshold":<strike>, "direction":"above|below",
+         "closesAt":<unix_ms>, "yesAsk":<0-1>, "noAsk":<0-1>,
+         "yesLiquidityUsd":<num>, "noLiquidityUsd":<num> }
+     ],
+     "totalNotionalUsd": 50,
+     "maxPerMarketUsd": 15,
+     "edgeThresholdPct": 0.015,
+     "riskProfile": "balanced",
+     "nowMs": '$(($(date +%s)*1000))'
+   }' | pmclock plan
+   ```
+
+6. Present the resulting `PmclockPlan` to the user as **DRY-RUN PLAN —
+   no orders placed**. Include:
+   - Number of decisions vs. markets scanned
+   - Per-decision: side, amount, limit price, edge %, and rationale
+   - Aggregated rejected-by-reason summary
+   - planHash (first 6 chars) — same scan is reproducible
+   - Any warnings
+
+7. End with: "No orders have been placed. Reply **'place it'** to
+   execute, or **'tighter'** to raise edge threshold to 2.5%."
+
+**Tip:** For a human-readable summary, `pmclock explain --input
+plan.json` formats the same data as plain English.
+
+### scan-and-execute
+
+Run a scan AND immediately execute decisions if `live-mode` is on.
+**This is the only path that places real orders.**
+
+**When to use:** Only after `scan-5min` has been shown to the user in
+the same session and the user has explicitly confirmed.
+
+**Mandatory pre-execution checks:**
+
+1. `polymarket-plugin check-access` passes.
+2. The plan was produced by `pmclock plan` in this session — never
+   hand-constructed.
+3. POLY_PROXY mode is set (or user has approved EOA gas costs per
+   trade) — verify with `polymarket-plugin balance`.
+4. If `plan.warnings` mentions `clamped`, surface it verbatim and ask
+   for explicit acknowledgment.
+
+**Execution loop:**
+
+For each decision in `plan.decisions`:
+
+```bash
+polymarket-plugin buy \
+  --market-id <decision.marketId> \
+  --outcome <decision.side> \
+  --amount <decision.amountUsd> \
+  --price <decision.limitPrice> \
+  --order-type GTC \
+  --post-only \
+  --expires <decision.expiresAtMs / 1000> \
+  --strategy-id pmclock \
+  --confirm
+```
+
+- `--post-only` — placement gets maker rebate; if the order would
+  cross, polymarket-plugin returns an error rather than fill as taker.
+- `--expires` — the limit naturally expires 30s before market
+  resolution; no manual cancel needed.
+- `--strategy-id pmclock` — leaderboard attribution.
+
+If a single buy is rejected (insufficient balance, price band, rate
+limit), stop immediately, quote the exact error, and ask the user how
+to proceed. Never silently retry, never silently skip.
+
+**After resolution (≥ 5 min later):** Run `polymarket-plugin redeem
+--market-id <id> --confirm` for any winning outcomes the user holds.
+
+### scan-loop
+
+Recurring scan-and-execute on a 30-60s cadence for a fixed total
+duration or budget.
+
+**When to use:** User says "run pmclock for 1 hour with $50 budget" or
+"keep arbing while I grab dinner".
+
+**Agent execution steps:**
+
+1. Confirm explicit time and budget bounds with the user.
+2. Loop: `scan-5min` → if any decision and live-mode → `scan-and-execute`
+   → sleep 30-60s → repeat.
+3. After each iteration, show running total: deployed, fills, redeemed.
+4. Stop conditions (any of):
+   - Time bound reached
+   - Cumulative deployed ≥ session budget
+   - Cumulative realized PnL < −5% of session budget (loss-stop)
+   - User says "stop"
+5. End with a session summary + redemption queue (winning markets that
+   need a `redeem` call after resolution).
+
+### caps
+
+Emit the hard caps as JSON for the agent to surface in the UI.
+
+```bash
+pmclock caps
+```
+
+## Examples
+
+### Example 1 — single BTC scan, dry-run
+
+**User:** "Scan BTC 5min arb for me, $50 budget, balanced"
+
+**Agent:** runs the `scan-5min` flow above. Returns:
+
+```
+Plan a3f82b  (BTC, balanced)
+
+• CEX price       : $77,500
+• CEX vol (daily) : 1.74%
+• Markets scanned : 5
+• Edge threshold  : 1.50%
+• Budget          : $50, deployed $7.50
+
+Decisions (1):
+  NO   $  7.50 @ 0.610  edge 38.90%  (CEX 99.9% vs PM 61.0%)
+        btc-above-78000-15-30
+
+Rejected (4):
+  3 × edge_below_threshold
+  1 × low_liquidity
+```
+
+> No orders placed. Reply 'place it' to execute, 'tighter' to raise to 2.5%.
+
+### Example 2 — region-restricted user
+
+**User (US):** "Run pmclock"
+
+**Agent:** runs `polymarket-plugin check-access` first. Sees blocked.
+Refuses with a clear message: "Polymarket's terms of service block
+trading from US IP addresses. pmclock cannot proceed. If you're
+travelling to a non-restricted region, run `check-access` again."
+
+### Example 3 — too-thin liquidity day
+
+**User:** "Run pmclock for an hour"
+
+**Agent:** runs `scan-loop`. After 10 iterations, every market is
+rejected for `low_liquidity`. The agent surfaces this and suggests
+either:
+- waiting for a more active session (US trading hours have deeper books)
+- lowering `MIN_LIQUIDITY_USD` (would require a code change + version
+  bump — not user-overridable).
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|---|---|---|
+| `polymarket-plugin: command not found` | Basic plugin not installed | `npx skills add okx/plugin-store --skill polymarket-plugin` |
+| `pmclock: command not found` | Binary not on PATH | Re-install via `npx skills add okx/plugin-store --skill pmclock`; verify `pmclock --version` |
+| `pmclock error: plan input is not valid JSON` | Malformed input | Show the binary's error verbatim; ask agent to recheck the JSON construction |
+| `polymarket-plugin check-access` fails (restricted) | User in blocked region | Refuse to proceed; tell the user the restriction is platform-side, not pmclock-side |
+| Plan has 0 decisions, all `edge_below_threshold` | Markets are fairly priced right now | Normal during low-volatility periods; suggest waiting or trying ETH/SOL instead of BTC |
+| Plan has many `low_liquidity` rejects | Off-hours / thin books | Suggest waiting for active hours (US 9am-4pm ET typically deepest) |
+| Plan has `clamped` warning on totalNotional | User asked for > $200 | pmclock caps total at $200/scan — surface warning, confirm user wants to proceed |
+| `polymarket-plugin buy` returns "insufficient balance" | Proxy wallet under-funded | `polymarket-plugin deposit --amount <N>`; never silently reduce decision sizes |
+| `polymarket-plugin buy` returns "price band" / "rate limit" | Order rejected upstream | Quote exact error; stop; ask user how to proceed |
+| Decision price differs from current ask by > 0.05 | Book moved during preview | Re-run `scan-5min` — pmclock plans are fresh-snapshot only |
+
+## Security Notices
+
+**Risk level: advanced.** This Skill places live limit orders on
+Polymarket. Each market is bounded-loss by design (a $5 buy can lose
+at most $5), but multiple concurrent orders can compound. The
+arbitrage edge depends on CEX price feeds being accurate — feed
+manipulation or stale data can flip the sign of a "winning" bet.
+
+**Hard limits enforced in `pmclock` source (`src/types.ts:CAPS`):**
+
+- Maximum **$200** total notional per scan.
+- Maximum **$20** per individual market.
+- Minimum **$50** combined liquidity (YES + NO depth) to consider
+  a market.
+- Minimum **1.5%** net edge to fire a decision (default; floor at
+  0.5% if user lowers).
+- Minimum **30s** time-to-close (skip markets too close to resolution).
+- Maximum **600s** time-to-close (skip markets > 10 min out).
+
+These limits are baked into the binary source. They cannot be
+overridden from within this Skill. To trade larger size, run multiple
+sequential scans — each scan re-evaluates the live book.
+
+**Behavioural safety:**
+
+- **Dry-run by default.** Every scan presents the `PmclockPlan` for
+  user review before any `polymarket-plugin buy` call.
+- **Explicit confirmation** required to execute (`'place it'` or
+  equivalent).
+- **Deterministic decisions.** Math is in a compiled binary, not the
+  LLM. Same scan inputs → same decisions, byte-for-byte.
+
+**What this Skill does not do:**
+
+- It does not hold or touch private keys. All signing happens inside
+  the Agentic Wallet TEE via `polymarket-plugin`.
+- It does not collect, store, or transmit user wallet addresses,
+  balances, or trade history to any external server outside the
+  declared `api_calls` (Binance public ticker for spot prices,
+  Polymarket gamma API for markets — both read-only public data).
+- It does not run ML or use any predictive model beyond a vanilla
+  GBM probability calculation. There is no "AI black box" — the math
+  is fully spelled out in `src/arb.ts`.
+
+**Disclaimer:** Statistical arbitrage on prediction markets has
+non-zero risk: the CEX price feed may be stale or manipulated; the PM
+order book may move adversely between scan and execution; resolution
+may be subject to oracle disputes. Nothing in this Skill is financial
+advice. The user is responsible for their own sizing, risk management,
+and compliance with local regulations.
+
+## Skill Routing
+
+- **For non-arbitrage Polymarket buys** (event basket, single-market
+  directional bet) → use `polymarket-plugin` directly with manual
+  market selection.
+- **For Hyperliquid perp grids** → use the `hyperliquid-aigrid` Skill.
+- **For wallet / portfolio overview** → use OKX's portfolio Skills.

--- a/skills/pmclock/SUMMARY.md
+++ b/skills/pmclock/SUMMARY.md
@@ -1,0 +1,72 @@
+# pmclock
+
+## Overview
+
+pmclock is a deterministic 5-minute crypto Up/Down arbitrage scanner
+for Polymarket. It pulls live BTC/ETH/SOL spot prices from Binance,
+computes the GBM-implied probability that the underlying closes above
+each market's strike at resolution, compares to the current PM YES/NO
+ask, and surfaces decisions only when the **net edge ≥ 1.5%** (after
+expected fees). All on-chain writes flow through `polymarket-plugin`
+with `--strategy-id pmclock` for leaderboard attribution.
+
+Core operations:
+
+- Scan the next batch of 5-minute crypto Up/Down markets via `polymarket-plugin list-5m`
+- Fetch live CEX spot price + recent realized vol from Binance public ticker
+- Compute GBM-implied probability and Kelly-fractional sizing per market in a deterministic compiled binary
+- Place maker-style limit buys (`--post-only --expires`) via polymarket-plugin only when edge clears the 1.5% threshold
+- Auto-redeem winning outcome tokens after 5-minute resolution
+- 7 structured rejection reasons (`expired`, `too_far_out`, `low_liquidity`, `edge_below_threshold`, `yes_no_ask_invalid`, `insufficient_budget`, `unknown_direction`) so every skipped market is auditable
+
+Tags: `polymarket` `prediction-market` `arbitrage` `5min` `latency-arb` `crypto` `automated-trading` `passive-income` `agentic-wallet` `strategy`
+
+## Prerequisites
+
+- Polymarket's Terms of Service restrict residents of the United States, France, Singapore, and several other jurisdictions from trading — enforced in pre-flight via `polymarket-plugin check-access`
+- Supported chain: Polygon (Polymarket CLOB)
+- Supported collateral: USDC.e (bridged USDC on Polygon, `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`), not native USDC
+- Supported coins: BTC, ETH, SOL (any coin Polymarket lists 5-minute Up/Down markets for)
+- onchainos CLI installed and Agentic Wallet unlocked
+- `polymarket-plugin` installed: `npx skills add okx/plugin-store --skill polymarket-plugin`
+- A funded wallet with USDC.e on Polygon (POLY_PROXY mode strongly recommended for gasless trades; deposit via `polymarket-plugin deposit`)
+- Public internet access to `api.binance.com` and `gamma-api.polymarket.com` (declared in `plugin.yaml` `api_calls`)
+
+## Quick Start
+
+1. **Tell the agent which coin and how much to risk**
+   For example: "Scan BTC 5min arb for me, $50 budget, balanced". pmclock
+   starts every new scan in dry-run by default — nothing is placed yet.
+
+2. **Review the dry-run scan output**
+   The agent fetches live BTC spot from Binance, computes the recent
+   realized vol from 1-minute klines, pulls the next batch of 5-minute
+   Up/Down markets from polymarket-plugin, and runs the bundled `pmclock
+   plan` binary. You'll see: number of decisions vs markets scanned,
+   each decision's side / amount / limit price / edge %, the rationale
+   ("CEX 99.9% above 78,000 vs PM YES ask 0.40 → edge 38.9%"), and
+   aggregated rejection reasons for skipped markets. Each scan has a
+   stable `planHash` so the same scan inputs always produce the same
+   decisions.
+
+3. **Go live only after explicit confirmation**
+   Reply "place it" (or "go live") to execute. For each decision the
+   agent runs `polymarket-plugin buy --market-id <id> --outcome
+   <yes|no> --amount <usd> --price <0-1> --post-only --expires <ts>
+   --strategy-id pmclock --confirm`. `--post-only` keeps the order
+   maker-side (rebate, no taker fee), and `--expires` auto-cancels 30
+   seconds before market resolution so no manual cleanup is needed.
+   Hard caps in the binary ($200 per scan, $20 per market, $50 minimum
+   liquidity, 1.5% minimum edge) cannot be overridden from the Skill —
+   to trade more, run another scan; to trade riskier, fork and rebuild.
+
+4. **Loop, monitor, and redeem**
+   For longer sessions, ask "run pmclock for 1 hour, $50 budget". The
+   agent enters `scan-loop` mode, scanning every 30-60 seconds until
+   the time bound, the budget cap, or a -5% session loss-stop triggers.
+   After each 5-minute market resolves, the agent calls
+   `polymarket-plugin redeem --market-id <id>` to claim winning outcome
+   tokens. At any time, "stop" cancels the loop and reports session
+   PnL. Because pmclock's binary is fully deterministic, the agent can
+   replay any past scan offline (with the same `planHash`) for
+   debugging.

--- a/skills/pmclock/plugin.yaml
+++ b/skills/pmclock/plugin.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+name: pmclock
+version: "1.0.0"
+description: "5-minute crypto Up/Down arbitrage scanner for Polymarket. Compares CEX-implied probability vs PM ask, deploys risk-bounded buys via polymarket-plugin when edge >= 1.5%."
+author:
+  name: "dddd86971-cloud"
+  github: "dddd86971-cloud"
+license: MIT
+category: strategy
+type: community-developer
+github_link: "https://github.com/dddd86971-cloud/pmclock"
+tags:
+  - polymarket
+  - prediction-market
+  - arbitrage
+  - 5min
+  - latency-arb
+  - crypto
+  - automated-trading
+  - passive-income
+  - agentic-wallet
+  - strategy
+
+dependent_plugin:
+  - name: polymarket-plugin
+    version: "^0.4.10"
+
+risk_level: advanced
+supported_venues:
+  - polymarket
+
+components:
+  skill:
+    dir: "."
+
+build:
+  lang: typescript
+  source_repo: "dddd86971-cloud/pmclock"
+  source_commit: "01226c38aa94f910a033b2a130b4b5fc7f30a55b"
+  source_dir: "."
+  binary_name: "pmclock"
+  main: "dist/index.js"
+
+api_calls:
+  # Read-only public endpoints. The agent fetches CEX spot price + recent
+  # realized vol from Binance public ticker (no auth needed) and current
+  # 5-minute Up/Down market state from Polymarket's read-only data API.
+  # ALL write operations (buy / sell / cancel / redeem) flow through
+  # polymarket-plugin (Agentic Wallet, no key handling here).
+  - "https://api.binance.com"
+  - "https://gamma-api.polymarket.com"


### PR DESCRIPTION
# [new-plugin] pmclock v1.0.0

**Season 1 Developer Challenge submission — strategy plugin for Polymarket 5-minute crypto Up/Down arbitrage.**

## Summary

`pmclock` turns Polymarket's 5-minute crypto Up/Down markets into a deterministic arbitrage scanner:

```
User: "Scan BTC 5min arb, $50 budget, balanced"
   ↓
pmclock Skill (natural-language parsing)
   ├─► api.binance.com /ticker/price        → live BTC spot
   ├─► api.binance.com /klines (1m, 60)     → realized daily vol from past hour
   ├─► polymarket-plugin list-5m            → next 5-min Up/Down markets
   ├─► polymarket-plugin get-market         → per-market YES/NO ask + book depth
   └─► pmclock binary                       → deterministic GBM probability +
                                              Kelly-fractional sizing per market
   ↓
Dry-run plan listing decisions (only when net edge ≥ 1.5%) +
all rejected markets with structured reason codes
   ↓
User: "place it"
   ↓
For each decision:
polymarket-plugin buy --market-id <id> --outcome <yes|no> --amount <usd> \
   --price <0-1> --post-only --order-type GTC --expires <closesAt-30s> \
   --strategy-id pmclock --confirm
   ↓
Maker-side rebate fill → wait for 5-min resolution → polymarket-plugin redeem
```

All on-chain writes flow through `polymarket-plugin`. pmclock binary makes zero network calls.

## What makes it different

1. **Deterministic binary, not LLM math** — every probability, every Kelly fraction, every rejection decision is in compiled TypeScript. Same inputs → byte-identical outputs. Stable `planHash` SHA-256 fingerprint. No LLM drift.

2. **Targets long-tail 5-min books, not top-of-book HFT** — pmclock is intentionally slower (30-60s polling) than Rust-on-VPS bots. Its niche is the first 1-2 minutes after a 5-min market opens, where book depth is thin ($50-200) and HFT bots don't bother. Small AI-Skill operators can sustain 1-2% edges that don't scale to multi-million-dollar HFT.

3. **7 structured rejection reasons** — every skipped market has a reason code: `expired`, `too_far_out`, `low_liquidity`, `edge_below_threshold`, `yes_no_ask_invalid`, `insufficient_budget`, `unknown_direction`. Users can audit "why didn't pmclock buy this one?" instantly.

4. **Auditable Kelly + ramp** — sizing schedule fully spelled out in `src/arb.ts:sizeFromEdge`. No magic constants, no ML model — pure formula, fully reproducible.

## Algorithm

For each market in `pmMarkets`:
1. Time gate (skip < 30s or > 600s to close)
2. Direction gate (`above` or `below` only)
3. Liquidity floor (combined YES+NO depth ≥ $50)
4. Ask sanity (yesAsk and noAsk ∈ [0.01, 0.99])
5. Compute CEX-implied probability under GBM:
   `pCexAbove = 1 − Φ((ln(strike/cexPrice)) / σ)` where `σ = cexVolDaily × √(hours/24)`
6. Edge = `pYesShouldBe − yesAsk` (and analogous for NO)
7. Pick the better side; reject if both below `edgeThresholdPct` (default 1.5%)
8. Kelly-fractional sizing: linear ramp 0 at threshold → `maxPerMarketUsd` at 5% edge, scaled by 0.15/0.25/0.33 by risk profile
9. Greedy budget pass (highest-edge first, trim or reject marginal)
10. Stable `planHash` over (coin, decisions[].{marketId, side, amountUsd, limitPrice}, totalNotional, edgeThreshold, riskProfile)

## Safety posture (advanced risk level)

Hard caps in source (`src/types.ts:CAPS`):
- **Max $200** total notional per scan
- **Max $20** per individual market
- **Min $50** combined book liquidity
- **Min 1.5%** net edge to fire (default; absolute floor 0.5%)
- **30s min / 600s max** time-to-close window
- Kelly fractions: conservative 0.15× / balanced 0.25× / aggressive 0.33×

Behavioral:
- Dry-run by default; explicit user confirmation before any order
- `--post-only` on every limit (no accidental taker fills)
- `--expires` 30s before resolution (no forgotten orders)
- All write ops carry `--strategy-id pmclock`
- No private key handling — all signing via Agentic Wallet TEE through `polymarket-plugin`

## Source

- Repo: `dddd86971-cloud/pmclock`
- Pinned commit: `01226c38aa94f910a033b2a130b4b5fc7f30a55b`
- Language: TypeScript (compiled to JS, distributed via `bun install -g`)
- Self-tests: 18 invariants — CDF correctness vs known values, GBM probability bounds (ATM/ITM/OTM), Kelly-fractional sizing monotonicity, scan determinism, planHash stability + sensitivity, all 7 rejection paths, direction handling, greedy budget enforcement, cap clamping, structural input validation
- License: MIT

## Pre-submission checklist

- [x] `plugin.yaml`, `.claude-plugin/plugin.json`, `SKILL.md`, `SUMMARY.md`, `LICENSE` all present
- [x] `name` = `pmclock` (lowercase, 7 chars, within 2-40)
- [x] `version` = `1.0.0` consistent across all files
- [x] `author.github` = `dddd86971-cloud` matches PR author
- [x] `license` = MIT (valid SPDX)
- [x] `category` = `strategy` (per the strategy-plugin spec)
- [x] `dependent_plugin` = [`polymarket-plugin@^0.4.10`]
- [x] `risk_level` = `advanced`, `supported_venues` = [`polymarket`]
- [x] `description` = 168 chars (within 200)
- [x] `api_calls` declares `api.binance.com` + `gamma-api.polymarket.com` (read-only public)
- [x] All write ops carry `--strategy-id pmclock`
- [x] SKILL.md sections: Overview / Pre-flight / Commands / Error Handling / Security Notices
- [x] No hardcoded credentials / private keys / mnemonics
- [x] No pre-compiled binaries committed (CI compiles TS)
- [x] PR only modifies files in `skills/pmclock/`
- [x] Source repo binary builds locally (TypeScript → JS, `#!/usr/bin/env node` shebang on `dist/index.js`)
- [x] 18/18 self-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)