### PR TITLE
[new-plugin] pm-perp-momentum v0.1.0

### DIFF
--- a/skills/pm-perp-momentum/.claude-plugin/plugin.json
+++ b/skills/pm-perp-momentum/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "pm-perp-momentum",
+  "description": "Polymarket-to-Hyperliquid momentum strategy for Onchain OS.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Taylan Bal",
+    "email": "midasbal50@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": [
+    "strategy",
+    "polymarket",
+    "hyperliquid",
+    "momentum",
+    "trading"
+  ],
+  "homepage": "https://github.com/midasbal/pm-perp-momentum",
+  "repository": "https://github.com/midasbal/pm-perp-momentum"
+}

--- a/skills/pm-perp-momentum/LICENSE
+++ b/skills/pm-perp-momentum/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 midasbal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/pm-perp-momentum/OPERATOR_RUNBOOK.md
+++ b/skills/pm-perp-momentum/OPERATOR_RUNBOOK.md
@@ -1,0 +1,371 @@
+# pm-perp-momentum Operator Runbook
+
+This runbook is the operational manual for running `pm-perp-momentum` end-to-end with safe defaults, reproducible evidence, and judge-ready outputs.
+
+---
+
+## 1) Scope and Goals
+
+This guide covers the full execution pipeline:
+
+1. Build and health checks
+2. Market discovery (`suggest-markets`)
+3. Market token resolution (`resolve-market`)
+4. Dry-run simulation (`dry-run`)
+5. Guarded live execution (`live`)
+6. Proof export (`export-proof`)
+7. Deterministic replay (`replay`)
+8. Proof integrity verification (`verify-proof`)
+
+---
+
+## 2) Prerequisites
+
+- Node.js `>= 20.10.0`
+- NPM installed
+- `polymarket-plugin` and `hyperliquid-plugin` installed and available on PATH for live execution
+
+Recommended working directory:
+
+```bash
+cd "/Users/midasbal/Desktop/okx-plugin/pm-perp-momentum"
+```
+
+---
+
+## 3) Build and Validation
+
+Run this once before any operation:
+
+```bash
+npm install
+npm run lint
+npm run typecheck
+npm test
+npm run build
+npm run submission:check
+```
+
+Expected outcome:
+- All checks pass
+- CLI entrypoint available at `dist/src/index.js`
+
+Before creating the final submission archive, run:
+
+```bash
+npm run submission:check:strict
+```
+
+For deterministic clean packaging, run:
+
+```bash
+npm run submission:bundle
+```
+
+This generates a strict-checked release tree at `release/pm-perp-momentum`.
+
+---
+
+## 4) Stage A — Discover High-Quality Active Markets
+
+Use this to get candidate markets with token IDs ranked by activity:
+
+```bash
+node dist/src/index.js suggest-markets --limit 10 --min-liquidity 5000 --json
+```
+
+Optional category filter:
+
+```bash
+node dist/src/index.js suggest-markets --limit 10 --min-liquidity 5000 --category politics --json
+```
+
+Operator action:
+- Pick one market from output
+- Copy `tokenIds[0]` for `--pm-market`
+
+---
+
+## 5) Stage B — Resolve Slug or URL into Token IDs
+
+If you start from a Polymarket URL or slug:
+
+```bash
+node dist/src/index.js resolve-market --input "https://polymarket.com/event/<event-slug>" --json
+```
+
+Or direct slug:
+
+```bash
+node dist/src/index.js resolve-market --input "<event-slug>" --json
+```
+
+Operator action:
+- Select one token ID from the returned `tokenIds` array
+- Use it as `--pm-market` in dry-run/live commands
+
+---
+
+## 6) Stage C — Dry-Run Simulation (No Real Orders)
+
+Dry-run records deterministic replay ticks and simulated decisions without placing real chain-executing orders.
+
+### Baseline dry-run
+
+```bash
+node dist/src/index.js dry-run \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --entry-slices 3 \
+  --take-profit-targets 1.25,2.5,4 \
+  --state-db ./fixtures/pm-dryrun.sqlite \
+  --run-label "dryrun-volume-baseline"
+```
+
+### High transaction profile dry-run
+
+```bash
+node dist/src/index.js dry-run \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 65 \
+  --exit-threshold 58 \
+  --dwell-seconds 8 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 1200 \
+  --leverage 4 \
+  --stop-loss-pct 7 \
+  --leaderboard-mode tx-max \
+  --entry-slices 8 \
+  --take-profit-targets 0.4,0.8,1.2,1.6 \
+  --state-db ./fixtures/pm-dryrun-tx.sqlite \
+  --run-label "dryrun-tx-profile"
+```
+
+Stop with `Ctrl+C`.
+
+---
+
+## 7) Stage D — Guarded Live Execution
+
+Live mode is hard-gated and requires both:
+
+- `--confirm-live`
+- exact `--risk-ack` phrase:
+  - `I acknowledge leveraged trading risk and accept full responsibility.`
+
+### Guarded live command (copy-paste template)
+
+```bash
+node dist/src/index.js live \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --entry-slices 3 \
+  --take-profit-targets 1.25,2.5,4 \
+  --daily-loss-limit-usd 1500 \
+  --consecutive-loss-limit 5 \
+  --state-db ./fixtures/pm-live.sqlite \
+  --run-label "live-volume-profile" \
+  --confirm-live \
+  --risk-ack "I acknowledge leveraged trading risk and accept full responsibility."
+```
+
+### Safety behavior in live mode
+
+- Entry is blocked if daily kill-switch is hit
+- Entry is blocked if consecutive-loss circuit breaker is hit
+- Stop-loss is continuously monitored
+- Multi-target take-profit executes reduce-only partial exits
+- Runtime persists tamper-evident event chain and tick history
+
+---
+
+## 8) Stage E — Export Economic Proof Pack
+
+Export latest run as JSON:
+
+```bash
+node dist/src/index.js export-proof \
+  --state-db ./fixtures/pm-live.sqlite \
+  --format json \
+  --output ./fixtures/proof-live.json
+```
+
+Export specific run as CSV bundle:
+
+```bash
+node dist/src/index.js export-proof \
+  --state-db ./fixtures/pm-live.sqlite \
+  --run-id "<RUN_ID>" \
+  --format csv \
+  --output ./fixtures/proof-live-csv
+```
+
+CSV bundle includes:
+- `run.json`
+- `positions.csv`
+- `events.csv`
+- `ticks.csv`
+
+Notes:
+- `--format json` expects `--output` to be a file path.
+- `--format csv` expects `--output` to be a directory path.
+
+---
+
+## 9) Stage F — Deterministic Replay
+
+Replay latest run:
+
+```bash
+node dist/src/index.js replay \
+  --state-db ./fixtures/pm-live.sqlite \
+  --json
+```
+
+Replay a specific run at faster speed:
+
+```bash
+node dist/src/index.js replay \
+  --state-db ./fixtures/pm-live.sqlite \
+  --run-id "<RUN_ID>" \
+  --replay-speed 5 \
+  --json
+```
+
+Replay validates reproducibility of signal and action sequence from stored ticks.
+
+---
+
+## 10) Stage G — Verify Proof Integrity
+
+```bash
+node dist/src/index.js verify-proof \
+  --state-db ./fixtures/pm-live.sqlite \
+  --json
+```
+
+Expected outcome:
+- `fingerprintValid: true`
+- `hashChainValid: true`
+- `issues: []`
+
+---
+
+## 11) Leaderboard Preset Guidance
+
+Use `--leaderboard-mode` to load tuned defaults:
+
+- `volume-max`: larger risk budget and larger target spacing
+- `tx-max`: more slices and tighter target cadence
+- `address-max`: safer profile for broader user adoption
+
+Manual flags override preset defaults:
+- `--entry-slices`
+- `--take-profit-targets`
+- `--daily-loss-limit-usd`
+- `--consecutive-loss-limit`
+
+---
+
+## 12) Rapid Command Cheatsheet
+
+### Build
+
+```bash
+npm run build
+```
+
+### Discover
+
+```bash
+node dist/src/index.js suggest-markets --limit 10 --min-liquidity 5000 --json
+```
+
+### Resolve
+
+```bash
+node dist/src/index.js resolve-market --input "<slug-or-url>" --json
+```
+
+### Dry-run
+
+```bash
+node dist/src/index.js dry-run --pm-market "<TOKEN_ID>" --signal-side YES --entry-threshold 70 --exit-threshold 60 --dwell-seconds 20 --perp ETH --side LONG --notional-usd 2000 --leverage 5 --stop-loss-pct 8 --leaderboard-mode volume-max --state-db ./fixtures/pm-dryrun.sqlite
+```
+
+### Live
+
+```bash
+node dist/src/index.js live --pm-market "<TOKEN_ID>" --signal-side YES --entry-threshold 70 --exit-threshold 60 --dwell-seconds 20 --perp ETH --side LONG --notional-usd 2000 --leverage 5 --stop-loss-pct 8 --leaderboard-mode volume-max --state-db ./fixtures/pm-live.sqlite --confirm-live --risk-ack "I acknowledge leveraged trading risk and accept full responsibility."
+```
+
+### Export Proof
+
+```bash
+node dist/src/index.js export-proof --state-db ./fixtures/pm-live.sqlite --format json --output ./fixtures/proof-live.json
+```
+
+### Replay
+
+```bash
+node dist/src/index.js replay --state-db ./fixtures/pm-live.sqlite --json
+```
+
+### Verify Proof
+
+```bash
+node dist/src/index.js verify-proof --state-db ./fixtures/pm-live.sqlite --json
+```
+
+---
+
+## 13) Operational Notes
+
+- Keep one runtime process per state DB file unless intentionally testing concurrency.
+- Always run dry-run first when changing thresholds, slices, or target ladders.
+- Use explicit `--run-label` values to make proof exports easier to audit.
+- For judge demos, prepare:
+  1. one `dry-run` DB,
+  2. one `live` DB,
+  3. exported JSON proof,
+  4. replay JSON output.
+
+---
+
+## 14) Troubleshooting
+
+- **Live mode rejected immediately**
+  - Ensure both `--confirm-live` and exact `--risk-ack` phrase are present.
+
+- **No replay ticks available**
+  - Do not pass `--no-record-ticks` during runtime runs.
+
+- **No active markets returned**
+  - Lower `--min-liquidity` and increase `--limit`.
+
+- **Entry not opening in live mode**
+  - Check if kill-switch or consecutive-loss breaker is active in event logs.
+
+- **Proof export run not found**
+  - Verify `--run-id` exists, or omit it to export the latest run.
+

--- a/skills/pm-perp-momentum/README.md
+++ b/skills/pm-perp-momentum/README.md
@@ -1,0 +1,206 @@
+# pm-perp-momentum
+
+Polymarket-to-Hyperliquid momentum strategy for Onchain OS, built for high-confidence KPI attribution, verifiable economic proof, and advanced risk-controlled execution.
+
+Repository: [https://github.com/midasbal/pm-perp-momentum](https://github.com/midasbal/pm-perp-momentum)
+
+## Why this Skill exists
+
+`pm-perp-momentum` is designed for strategy-category competition environments where leaderboard performance and compliance quality both matter. The engine translates Polymarket probability momentum into Hyperliquid perpetual execution with:
+
+- strict plugin-mediated execution paths,
+- deterministic replay and tamper-evident proof data,
+- advanced risk controls suitable for autonomous strategy operation.
+
+## Environment Warning (Read first)
+
+**CRITICAL: KPI attribution and leaderboard points are ONLY earned when this Skill is executed within the official Onchain OS / Agentic Wallet environment.**
+
+If the strategy runs outside the official environment, orders may execute but challenge KPI attribution may not be credited.
+
+## Compliance Architecture
+
+### Built on top of Basic Skills
+
+This Skill is a Strategy-layer orchestrator that depends on:
+
+- `polymarket-plugin`
+- `hyperliquid-plugin`
+
+Declared in `plugin.yaml` via `dependent_plugin`, with explicit versions.
+
+### Execution chain compliance
+
+- `dry-run` and `live` strategy paths call Basic Skill plugins through the centralized subprocess wrapper.
+- Trade write operations are tagged with `--strategy-id pm-perp-momentum` automatically.
+- No direct chain signing logic is implemented in this repository.
+
+### Utility command scope
+
+For operator performance and discovery UX:
+
+- `resolve-market` and `suggest-markets` use direct API reads.
+
+For challenge-critical strategy execution:
+
+- all trading and signal execution paths remain plugin-mediated.
+
+## Core Features
+
+- Momentum signal detection with hysteresis + dwell-time filters.
+- Entry slicing engine for volume and transaction profile tuning.
+- Multi-target take-profit ladder with partial reduce-only exits.
+- Hyperliquid mark-price stop-loss monitoring loop.
+- Daily loss kill-switch and consecutive-loss circuit breaker.
+- Run fingerprinting and hash-chained event log.
+- Exportable proof artifacts (`json` and `csv`).
+- Deterministic replay with mark-aware stop-loss behavior.
+- Proof integrity verification (`verify-proof`).
+
+## Economic Proof Model
+
+The strategy generates auditable evidence in SQLite during execution:
+
+- `runs`: run metadata + deterministic config fingerprint,
+- `positions`: entries, exits, partial closes, realized PnL context,
+- `events`: hash-chained event log,
+- `replay_ticks`: signal and mark tick streams for deterministic reconstruction.
+
+Proof workflow:
+
+1. Run strategy (`dry-run` or `live`).
+2. Export artifacts with `export-proof`.
+3. Validate integrity with `verify-proof`.
+4. Reconstruct decision sequence with `replay`.
+
+## Advanced Risk Management
+
+- **Live safety gate**: `--confirm-live` + exact risk acknowledgment phrase required.
+- **Mark-price stop-loss**: independent of Polymarket signal availability.
+- **Daily loss limit**: blocks new entries after configured threshold.
+- **Consecutive-loss breaker**: blocks new entries after loss streak threshold.
+- **Opt-in state recovery**: `--resume-open-position` must be explicitly enabled.
+
+## Command Surface
+
+### Build and validate
+
+```bash
+npm ci
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+### Discover markets
+
+```bash
+node dist/src/index.js suggest-markets --limit 10 --min-liquidity 5000 --json
+```
+
+### Resolve token IDs
+
+```bash
+node dist/src/index.js resolve-market --input "<slug-or-url>" --json
+```
+
+### Dry-run simulation
+
+```bash
+node dist/src/index.js dry-run \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --state-db ./fixtures/pm-dryrun.sqlite
+```
+
+### Guarded live execution
+
+```bash
+node dist/src/index.js live \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --daily-loss-limit-usd 1500 \
+  --consecutive-loss-limit 5 \
+  --state-db ./fixtures/pm-live.sqlite \
+  --resume-open-position \
+  --confirm-live \
+  --risk-ack "I acknowledge leveraged trading risk and accept full responsibility."
+```
+
+### Export proof artifacts
+
+```bash
+node dist/src/index.js export-proof \
+  --state-db ./fixtures/pm-live.sqlite \
+  --format json \
+  --output ./fixtures/proof-live.json
+```
+
+### Replay decisions
+
+```bash
+node dist/src/index.js replay --state-db ./fixtures/pm-live.sqlite --json
+```
+
+### Verify proof integrity
+
+```bash
+node dist/src/index.js verify-proof --state-db ./fixtures/pm-live.sqlite --json
+```
+
+## Submission-Grade Release Workflow
+
+Use the release pipeline to produce a clean deliverable tree:
+
+```bash
+npm run submission:bundle
+```
+
+This command:
+
+- builds a clean source bundle at `release/pm-perp-momentum`,
+- runs strict submission checks in that bundle,
+- ensures the release folder is the canonical final deliverable source.
+
+## Troubleshooting
+
+- `Live mode requires --confirm-live`  
+  Add `--confirm-live`.
+
+- `Live mode requires --risk-ack`  
+  Use the exact required phrase.
+
+- `Unsupported argument: --...`  
+  Use `--help` and pass only supported flags.
+
+- `Failed to fetch Polymarket market data via polymarket-plugin`  
+  Verify plugin installation and supported read command surface.
+
+- `Failed to fetch Hyperliquid mark price`  
+  Verify plugin availability and retry.
+
+- `Proof verification failed`  
+  Re-export and verify untampered database artifacts.
+
+## License
+
+MIT

--- a/skills/pm-perp-momentum/SKILL.md
+++ b/skills/pm-perp-momentum/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pm-perp-momentum
+description: "Polymarket-to-Hyperliquid momentum strategy for Onchain OS."
+version: "0.1.0"
+author: "Taylan Bal"
+tags:
+  - polymarket
+  - hyperliquid
+  - strategy
+  - trading
+---
+
+# pm-perp-momentum
+
+## Overview
+
+`pm-perp-momentum` is a strategy plugin that converts Polymarket event probability momentum into Hyperliquid perpetual futures execution. It uses dependent plugins for protocol integration, enforces strategy attribution on trading operations, and produces deterministic proof artifacts for auditability.
+
+The primary execution commands are `dry-run` and `live`. The utility commands are `resolve-market`, `suggest-markets`, `export-proof`, and `replay`.
+The integrity command is `verify-proof`.
+Maintainer GitHub handle: `midasbal`.
+
+Architecture note: utility commands (`resolve-market`, `suggest-markets`) use direct API access for discovery speed and operator UX, while all strategy execution and trading paths (`dry-run`, `live`) are strictly mediated through the official Basic Skill plugins (`polymarket-plugin`, `hyperliquid-plugin`) for challenge compliance and attribution.
+
+## Pre-flight Checks
+
+Before running this skill, verify the following:
+
+1. `polymarket-plugin` and `hyperliquid-plugin` are installed and available on PATH.
+2. The runtime has Node.js `>= 20.10.0` and project dependencies installed.
+3. The user has selected a valid Polymarket token ID and Hyperliquid perp market.
+4. The user understands this is an advanced trading strategy and has reviewed the risk disclaimer.
+5. **Environment Warning**: **CRITICAL: KPI attribution and leaderboard points are ONLY earned when this Skill is executed within the official Onchain OS / Agentic Wallet environment.**
+6. For live mode, the user explicitly accepts the live safety gate:
+   - `--confirm-live`
+   - `--risk-ack "I acknowledge leveraged trading risk and accept full responsibility."`
+
+## Commands
+
+### Run Dry Simulation
+
+```bash
+node dist/src/index.js dry-run \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --state-db ./fixtures/pm-dryrun.sqlite
+```
+
+**When to use**: Validate thresholds, slicing, and exits without placing live orders.  
+**Output**: Signal logs, simulated order actions, and replay/proof data in SQLite.
+
+### Run Guarded Live Strategy
+
+```bash
+node dist/src/index.js live \
+  --pm-market "<TOKEN_ID>" \
+  --signal-side YES \
+  --entry-threshold 70 \
+  --exit-threshold 60 \
+  --dwell-seconds 20 \
+  --perp ETH \
+  --side LONG \
+  --notional-usd 2000 \
+  --leverage 5 \
+  --stop-loss-pct 8 \
+  --leaderboard-mode volume-max \
+  --daily-loss-limit-usd 1500 \
+  --consecutive-loss-limit 5 \
+  --state-db ./fixtures/pm-live.sqlite \
+  --resume-open-position \
+  --confirm-live \
+  --risk-ack "I acknowledge leveraged trading risk and accept full responsibility."
+```
+
+**When to use**: Execute the strategy against live plugin-integrated market data and order flow.  
+**Output**: Live trade decisions, mark-risk checks, and realized risk-state updates.
+
+### Resolve Market Token IDs
+
+```bash
+node dist/src/index.js resolve-market --input "<slug-or-url>" --json
+```
+
+**When to use**: Convert a Polymarket URL or slug into token IDs for strategy execution.  
+**Output**: Market metadata and token ID list.
+
+### Suggest Active Markets
+
+```bash
+node dist/src/index.js suggest-markets --limit 10 --min-liquidity 5000 --json
+```
+
+**When to use**: Discover liquid candidate markets for strategy deployment.  
+**Output**: Ranked active markets with liquidity, volume, and token IDs.
+
+### Export Proof Artifacts
+
+```bash
+node dist/src/index.js export-proof \
+  --state-db ./fixtures/pm-live.sqlite \
+  --format json \
+  --output ./fixtures/proof-live.json
+```
+
+**When to use**: Generate submission-ready evidence from a completed run.  
+**Output**: Run metadata, positions, events, and replay ticks in JSON or CSV format.
+
+### Replay Stored Run Deterministically
+
+```bash
+node dist/src/index.js replay --state-db ./fixtures/pm-live.sqlite --json
+```
+
+**When to use**: Reconstruct decision flow from recorded ticks for audit and verification.  
+**Output**: Replay summary and deterministic action timeline.
+
+### Verify Proof Integrity
+
+```bash
+node dist/src/index.js verify-proof --state-db ./fixtures/pm-live.sqlite --json
+```
+
+**When to use**: Verify run fingerprint and hash-chain integrity before submission.  
+**Output**: Pass/fail report with any detected integrity issues.
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|---|---|---|
+| `Live mode requires --confirm-live` | Live command missing mandatory safety gate | Add `--confirm-live` and rerun |
+| `Live mode requires --risk-ack` | Missing or incorrect risk acknowledgment string | Provide the exact required acknowledgment string |
+| `Failed to fetch Polymarket data through polymarket-plugin` | Plugin command mismatch, plugin unavailable, or transport failure | Verify plugin installation and supported read commands |
+| `Failed to fetch Hyperliquid mark price` | Mark price query command not supported or temporary plugin/provider failure | Verify `hyperliquid-plugin` commands and retry |
+| `Entry was blocked due to risk guardrails` | Daily loss limit or consecutive-loss breaker threshold exceeded | Reduce risk, wait for reset, or start a new controlled session |
+| `No replay ticks were stored for this run` | Tick recording disabled or empty session | Run dry/live without `--no-record-ticks` and retry replay |
+| `Unsupported argument: --...` | Typo or unsupported CLI flag | Use `--help` and rerun with supported arguments only |
+| `Proof verification failed` | Event chain mismatch or fingerprint mismatch | Re-export from untampered DB and investigate local modifications |
+
+## Security Notices
+
+- This is an **advanced** autonomous trading strategy.
+- Dry-run mode should be executed before any live deployment.
+- Stop-loss is driven by Hyperliquid mark-price risk checks, independent of Polymarket signal availability.
+- Daily loss and consecutive-loss protections are persisted and enforced across restarts.
+- Open-position recovery is opt-in through `--resume-open-position` to avoid cross-session state surprises.
+- All trading subprocess calls to dependent plugins include `--strategy-id pm-perp-momentum` via centralized command wrapping.
+
+**Risk Disclaimer**: Leveraged perpetual trading can cause rapid and substantial losses. Market volatility, spread expansion, slippage, and execution latency can degrade performance. This plugin is provided as-is with no guarantee of profitability. Users are solely responsible for all live trading decisions and capital risk.

--- a/skills/pm-perp-momentum/SUMMARY.md
+++ b/skills/pm-perp-momentum/SUMMARY.md
@@ -1,0 +1,30 @@
+# pm-perp-momentum
+
+## Overview
+
+`pm-perp-momentum` is a strategy plugin that converts Polymarket probability momentum into Hyperliquid perpetual futures execution, with guarded live controls, deterministic replay support, and exportable proof artifacts.
+
+Core operations:
+
+- Resolve and select tradable Polymarket token IDs for signal tracking.
+- Execute momentum-triggered Hyperliquid perp entries with configurable slicing.
+- Protect positions with Hyperliquid mark-price stop-loss and risk breakers.
+- Export run evidence and deterministic replay output for auditability.
+
+Tags: `strategy` `polymarket` `hyperliquid` `momentum` `trading`
+
+## Prerequisites
+
+- Node.js `>= 20.10.0` and npm installed.
+- `polymarket-plugin` and `hyperliquid-plugin` installed and available on PATH.
+- Strategy runtime built with `npm run build`.
+- A valid Polymarket token ID and target Hyperliquid perp market selected.
+- For live execution, explicit safety confirmation and risk acknowledgment are required.
+
+## Quick Start
+
+1. **Build and validate the runtime**: Run `npm ci`, then run `npm run build` to compile the TypeScript command surface.
+2. **Discover and resolve a market token**: Use `suggest-markets` to discover candidates, then run `resolve-market` to get token IDs and choose one for `--pm-market`.
+3. **Run dry simulation first**: Execute `dry-run` with your thresholds and risk controls to validate behavior without live order placement.
+4. **Run guarded live mode**: Execute `live` only after dry-run validation, with `--confirm-live` and the exact risk acknowledgment string.
+5. **Generate and verify proof artifacts**: Use `export-proof` to produce JSON or CSV evidence, run `replay` for deterministic decision reconstruction, and run `verify-proof` to validate fingerprint/hash-chain integrity.

--- a/skills/pm-perp-momentum/eslint.config.mjs
+++ b/skills/pm-perp-momentum/eslint.config.mjs
@@ -1,0 +1,39 @@
+import js from "@eslint/js";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**", "release/**"]
+  },
+  js.configs.recommended,
+  {
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: {
+        process: "readonly"
+      }
+    }
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: "./tsconfig.json"
+      }
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin
+    },
+    rules: {
+      "no-undef": "off",
+      ...tsPlugin.configs["recommended-type-checked"].rules,
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports" }
+      ]
+    }
+  }
+];

--- a/skills/pm-perp-momentum/package-lock.json
+++ b/skills/pm-perp-momentum/package-lock.json
@@ -1,0 +1,3547 @@
+{
+  "name": "pm-perp-momentum",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pm-perp-momentum",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^11.8.1"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^22.15.17",
+        "@typescript-eslint/eslint-plugin": "^8.31.1",
+        "@typescript-eslint/parser": "^8.31.1",
+        "eslint": "^9.25.1",
+        "typescript": "^5.8.3",
+        "vitest": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=20.10.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/skills/pm-perp-momentum/package.json
+++ b/skills/pm-perp-momentum/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "pm-perp-momentum",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Polymarket to Hyperliquid signal propagation strategy core",
+  "type": "module",
+  "engines": {
+    "node": ">=20.10.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/src/index.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "submission:check": "node scripts/submission-check.mjs",
+    "submission:check:strict": "node scripts/submission-check.mjs --strict",
+    "submission:bundle": "node scripts/prepare-release.mjs"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.8.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.15.17",
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
+    "eslint": "^9.25.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2"
+  }
+}

--- a/skills/pm-perp-momentum/plugin.yaml
+++ b/skills/pm-perp-momentum/plugin.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+name: pm-perp-momentum
+version: "0.1.0"
+description: "Polymarket-to-Hyperliquid momentum strategy for Onchain OS."
+author:
+  name: "Taylan Bal"
+  github: "midasbal"
+  email: "midasbal50@gmail.com"
+license: MIT
+category: strategy
+tags:
+  - polymarket
+  - hyperliquid
+  - momentum
+  - trading-strategy
+  - automation
+
+dependent_plugin:
+  - name: polymarket-plugin
+    version: "^1.0.0"
+  - name: hyperliquid-plugin
+    version: "^1.0.0"
+
+risk_level: advanced
+
+components:
+  skill:
+    dir: "."
+
+api_calls:
+  - gamma-api.polymarket.com

--- a/skills/pm-perp-momentum/scripts/prepare-release.mjs
+++ b/skills/pm-perp-momentum/scripts/prepare-release.mjs
@@ -1,0 +1,44 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const projectRoot = process.cwd();
+const releaseRoot = join(projectRoot, "release", "pm-perp-momentum");
+
+const includePaths = [
+  ".claude-plugin",
+  "LICENSE",
+  "OPERATOR_RUNBOOK.md",
+  "README.md",
+  "SKILL.md",
+  "SUMMARY.md",
+  "eslint.config.mjs",
+  "package-lock.json",
+  "package.json",
+  "plugin.yaml",
+  "scripts",
+  "src",
+  "tests",
+  "tsconfig.json"
+];
+
+if (existsSync(releaseRoot)) {
+  rmSync(releaseRoot, { recursive: true, force: true });
+}
+mkdirSync(releaseRoot, { recursive: true });
+
+for (const relPath of includePaths) {
+  const sourcePath = join(projectRoot, relPath);
+  const targetPath = join(releaseRoot, relPath);
+  cpSync(sourcePath, targetPath, { recursive: true });
+}
+
+const strictCheck = spawnSync("node", ["scripts/submission-check.mjs", "--strict"], {
+  cwd: releaseRoot,
+  stdio: "inherit"
+});
+if (strictCheck.status !== 0) {
+  process.exit(strictCheck.status ?? 1);
+}
+
+process.stdout.write(`release bundle prepared: ${releaseRoot}\n`);

--- a/skills/pm-perp-momentum/scripts/submission-check.mjs
+++ b/skills/pm-perp-momentum/scripts/submission-check.mjs
@@ -1,0 +1,93 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const strictMode = process.argv.includes("--strict");
+const requiredFiles = [
+  "plugin.yaml",
+  "SKILL.md",
+  "SUMMARY.md",
+  "README.md",
+  "LICENSE",
+  ".claude-plugin/plugin.json"
+];
+
+const disallowedTopLevelDirs = ["node_modules", "dist"];
+const disallowedExactPaths = new Set(["fixtures/proof-live-csv"]);
+
+function walkFiles(baseDir, relativeDir = "") {
+  const currentDir = join(baseDir, relativeDir);
+  const entries = readdirSync(currentDir, { withFileTypes: true });
+  const output = [];
+  for (const entry of entries) {
+    const relPath = relativeDir ? join(relativeDir, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".git") {
+        continue;
+      }
+      output.push(...walkFiles(baseDir, relPath));
+      continue;
+    }
+    output.push(relPath);
+  }
+  return output;
+}
+
+function fail(message) {
+  process.stderr.write(`submission-check failed: ${message}\n`);
+  process.exit(1);
+}
+
+for (const file of requiredFiles) {
+  if (!existsSync(join(root, file))) {
+    fail(`missing required file: ${file}`);
+  }
+}
+
+for (const dir of disallowedTopLevelDirs) {
+  const target = join(root, dir);
+  if (existsSync(target) && statSync(target).isDirectory()) {
+    if (strictMode) {
+      fail(`remove '${dir}/' before submission packaging`);
+    }
+    process.stdout.write(
+      `submission-check warning: '${dir}/' exists (allowed in local dev, remove before final packaging).\n`
+    );
+  }
+}
+
+const files = walkFiles(root).map((item) => item.replace(/\\/g, "/"));
+const noisyArtifacts = files.filter(
+  (name) =>
+    name.endsWith(".sqlite") ||
+    name.endsWith(".sqlite-shm") ||
+    name.endsWith(".sqlite-wal")
+);
+if (noisyArtifacts.length > 0) {
+  if (strictMode) {
+    fail(`remove local sqlite artifacts: ${noisyArtifacts.join(", ")}`);
+  }
+  process.stdout.write(
+    `submission-check warning: local sqlite artifacts found: ${noisyArtifacts.join(", ")}\n`
+  );
+}
+
+const noisyFixtureArtifacts = files.filter(
+  (name) =>
+    name.startsWith("fixtures/") &&
+    (name.endsWith(".json") || disallowedExactPaths.has(name))
+);
+if (noisyFixtureArtifacts.length > 0) {
+  if (strictMode) {
+    fail(
+      `remove fixture artifacts before submission: ${noisyFixtureArtifacts.join(", ")}`
+    );
+  }
+  process.stdout.write(
+    `submission-check warning: fixture artifacts found: ${noisyFixtureArtifacts.join(", ")}\n`
+  );
+}
+
+process.stdout.write(
+  `submission-check passed${strictMode ? " (strict)" : " (dev mode)"}.\n`
+);

--- a/skills/pm-perp-momentum/src/execution/adapters.ts
+++ b/skills/pm-perp-momentum/src/execution/adapters.ts
@@ -1,0 +1,248 @@
+import type { PluginResult } from "./subprocess.js";
+import { runPlugin } from "./subprocess.js";
+
+interface RecordLike {
+  [key: string]: unknown;
+}
+
+function asRecord(input: unknown): RecordLike | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+  return input as RecordLike;
+}
+
+function asNumber(input: unknown): number | null {
+  if (typeof input === "number" && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === "string" && input.trim().length > 0) {
+    const parsed = Number(input);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function deepSearchNumber(
+  input: unknown,
+  keys: string[],
+  depth = 0
+): number | null {
+  if (depth > 6) {
+    return null;
+  }
+  const record = asRecord(input);
+  if (!record) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = record[key];
+    const direct = asNumber(value);
+    if (direct !== null) {
+      return direct;
+    }
+  }
+
+  for (const value of Object.values(record)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const nested = deepSearchNumber(item, keys, depth + 1);
+        if (nested !== null) {
+          return nested;
+        }
+      }
+      continue;
+    }
+    const nested = deepSearchNumber(value, keys, depth + 1);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+export interface HyperliquidExecution {
+  filledSize: number;
+  avgPrice: number | null;
+  feeUsd: number;
+  realizedPnlUsd: number | null;
+  raw: PluginResult;
+}
+
+export interface MarkPriceQuote {
+  markPrice: number;
+  raw: PluginResult;
+}
+
+function parseOrderExecution(result: PluginResult): HyperliquidExecution | null {
+  const payload = result.parsedJson;
+  if (payload === undefined) {
+    return null;
+  }
+
+  const filledSize =
+    deepSearchNumber(payload, [
+      "filledSize",
+      "filled_size",
+      "sizeFilled",
+      "executedSize",
+      "qty",
+      "quantity"
+    ]) ?? 0;
+  const avgPrice = deepSearchNumber(payload, [
+    "avgPrice",
+    "averagePrice",
+    "fillPrice",
+    "price",
+    "executionPrice"
+  ]);
+  const feeUsd =
+    deepSearchNumber(payload, ["feeUsd", "feesUsd", "fee", "fees"]) ?? 0;
+  const realizedPnlUsd = deepSearchNumber(payload, [
+    "realizedPnlUsd",
+    "realizedPnl",
+    "pnlUsd",
+    "pnl"
+  ]);
+
+  return {
+    filledSize,
+    avgPrice,
+    feeUsd,
+    realizedPnlUsd,
+    raw: result
+  };
+}
+
+export async function executeHyperliquidOrder(args: string[]): Promise<HyperliquidExecution> {
+  const result = await runPlugin("hyperliquid-plugin", args);
+  if (!result.ok) {
+    throw new Error(
+      `Hyperliquid order failed: ${result.stderr || "Unknown plugin error."}`
+    );
+  }
+  const parsed = parseOrderExecution(result);
+  if (parsed) {
+    return parsed;
+  }
+
+  return {
+    filledSize: 0,
+    avgPrice: null,
+    feeUsd: 0,
+    realizedPnlUsd: null,
+    raw: result
+  };
+}
+
+function parseMarkPrice(result: PluginResult): number | null {
+  const payload = result.parsedJson;
+  if (payload === undefined) {
+    return null;
+  }
+  return deepSearchNumber(payload, [
+    "markPrice",
+    "mark_price",
+    "midPrice",
+    "mid_price",
+    "price",
+    "oraclePrice"
+  ]);
+}
+
+export async function fetchHyperliquidMarkPrice(
+  market: string
+): Promise<MarkPriceQuote> {
+  const attempts: string[][] = [
+    ["price", "--market", market, "--json"],
+    ["mark-price", "--market", market, "--json"],
+    ["ticker", "--market", market, "--json"],
+    ["quote", "--market", market, "--json"]
+  ];
+
+  const failures: string[] = [];
+  for (const args of attempts) {
+    const result = await runPlugin("hyperliquid-plugin", args);
+    if (!result.ok) {
+      failures.push(`${result.command} :: ${result.stderr || "unknown error"}`);
+      continue;
+    }
+    const markPrice = parseMarkPrice(result);
+    if (markPrice !== null) {
+      return { markPrice, raw: result };
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch Hyperliquid mark price. Attempts: ${failures.join(" | ")}`
+  );
+}
+
+function parsePolymarketMid(result: PluginResult): {
+  mid: number;
+  bestBid: number | null;
+  bestAsk: number | null;
+} | null {
+  const payload = result.parsedJson;
+  if (payload === undefined) {
+    return null;
+  }
+
+  const mid = deepSearchNumber(payload, ["mid", "midPrice", "mid_price", "price"]);
+  const bestBid = deepSearchNumber(payload, ["bestBid", "best_bid", "bid"]);
+  const bestAsk = deepSearchNumber(payload, ["bestAsk", "best_ask", "ask"]);
+
+  if (mid === null) {
+    if (bestBid !== null && bestAsk !== null) {
+      return {
+        mid: (bestBid + bestAsk) / 2,
+        bestBid,
+        bestAsk
+      };
+    }
+    return null;
+  }
+
+  return {
+    mid,
+    bestBid,
+    bestAsk
+  };
+}
+
+export async function fetchPolymarketMid(marketId: string): Promise<{
+  mid: number;
+  bestBid: number | null;
+  bestAsk: number | null;
+  raw: PluginResult;
+}> {
+  const attempts: string[][] = [
+    ["market", "--token-id", marketId, "--json"],
+    ["market", "--market-id", marketId, "--json"],
+    ["price", "--token-id", marketId, "--json"],
+    ["book", "--token-id", marketId, "--json"]
+  ];
+
+  const failures: string[] = [];
+  for (const args of attempts) {
+    const result = await runPlugin("polymarket-plugin", args);
+    if (!result.ok) {
+      failures.push(`${result.command} :: ${result.stderr || "unknown error"}`);
+      continue;
+    }
+    const parsed = parsePolymarketMid(result);
+    if (parsed && parsed.mid >= 0 && parsed.mid <= 1) {
+      return { ...parsed, raw: result };
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch Polymarket market data via polymarket-plugin. Attempts: ${failures.join(
+      " | "
+    )}`
+  );
+}

--- a/skills/pm-perp-momentum/src/execution/strategy-id.ts
+++ b/skills/pm-perp-momentum/src/execution/strategy-id.ts
@@ -1,0 +1,24 @@
+export const STRATEGY_ID = "pm-perp-momentum" as const;
+
+export type SupportedPlugin = "hyperliquid-plugin" | "polymarket-plugin";
+
+const WRITE_OPERATIONS = new Set(["buy", "sell", "swap", "order"]);
+
+export function isWriteOperation(args: string[]): boolean {
+  const operation = args[0]?.trim().toLowerCase();
+  return operation ? WRITE_OPERATIONS.has(operation) : false;
+}
+
+export function withStrategyId(args: string[], force = false): string[] {
+  if (args.includes("--strategy-id")) {
+    throw new Error(
+      "Do not pass --strategy-id directly. The execution wrapper injects it automatically."
+    );
+  }
+
+  if (!force && !isWriteOperation(args)) {
+    return [...args];
+  }
+
+  return [...args, "--strategy-id", STRATEGY_ID];
+}

--- a/skills/pm-perp-momentum/src/execution/subprocess.ts
+++ b/skills/pm-perp-momentum/src/execution/subprocess.ts
@@ -1,0 +1,100 @@
+import { spawn } from "node:child_process";
+
+import type { SupportedPlugin } from "./strategy-id.js";
+import { withStrategyId } from "./strategy-id.js";
+
+export interface RunPluginOptions {
+  dryRun?: boolean;
+  timeoutMs?: number;
+  forceStrategyId?: boolean;
+}
+
+export interface PluginResult {
+  ok: boolean;
+  command: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  parsedJson?: unknown;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function safeParseJson(payload: string): unknown {
+  const trimmed = payload.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function runPlugin(
+  plugin: SupportedPlugin,
+  args: string[],
+  options: RunPluginOptions = {}
+): Promise<PluginResult> {
+  const finalArgs = withStrategyId(args, options.forceStrategyId ?? false);
+  const command = `${plugin} ${finalArgs.join(" ")}`;
+
+  if (options.dryRun) {
+    return {
+      ok: true,
+      command,
+      exitCode: 0,
+      stdout: `[DRY-RUN] ${command}`,
+      stderr: ""
+    };
+  }
+
+  return await new Promise<PluginResult>((resolve) => {
+    const child = spawn(plugin, finalArgs, {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("close", (exitCode) => {
+      clearTimeout(timeout);
+      const parsedJson = safeParseJson(stdout);
+      resolve({
+        ok: !timedOut && exitCode === 0,
+        command,
+        exitCode,
+        stdout,
+        stderr: timedOut ? `${stderr}\nProcess timed out.`.trim() : stderr,
+        parsedJson
+      });
+    });
+
+    child.on("error", (error: Error) => {
+      clearTimeout(timeout);
+      resolve({
+        ok: false,
+        command,
+        exitCode: null,
+        stdout,
+        stderr: `${stderr}\n${error.message}`.trim()
+      });
+    });
+  });
+}

--- a/skills/pm-perp-momentum/src/index.ts
+++ b/skills/pm-perp-momentum/src/index.ts
@@ -1,0 +1,92 @@
+import { parseDryRunArgs, runDryRunRuntime } from "./runtime/dry-run.js";
+import { runExportProofCommand } from "./runtime/export-proof.js";
+import { parseLiveArgs, runLiveRuntime } from "./runtime/live.js";
+import { runReplayCommand } from "./runtime/replay.js";
+import { runResolveMarketCommand } from "./runtime/resolve-market.js";
+import { runSuggestMarketsCommand } from "./runtime/suggest-markets.js";
+import { runVerifyProofCommand } from "./runtime/verify-proof.js";
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "pm-perp-momentum",
+      "",
+      "Usage:",
+      "  node dist/src/index.js dry-run --pm-market <id> --signal-side <YES|NO> \\",
+      "    --entry-threshold <pct> --exit-threshold <pct> --dwell-seconds <seconds> \\",
+      "    --perp <market> --side <LONG|SHORT> --notional-usd <usd> \\",
+      "    --leverage <n> --stop-loss-pct <pct> [--leaderboard-mode <volume-max|tx-max|address-max>] \\",
+      "    [--entry-slices <n>] [--take-profit-targets <pct,pct,...>] [--state-db <path>]",
+      "",
+      "  node dist/src/index.js live --pm-market <id> --signal-side <YES|NO> \\",
+      "    --entry-threshold <pct> --exit-threshold <pct> --dwell-seconds <seconds> \\",
+      "    --perp <market> --side <LONG|SHORT> --notional-usd <usd> \\",
+      "    --leverage <n> --stop-loss-pct <pct> [--leaderboard-mode <volume-max|tx-max|address-max>] \\",
+      "    [--entry-slices <n>] [--take-profit-targets <pct,pct,...>] [--daily-loss-limit-usd <n>] \\",
+      "    [--consecutive-loss-limit <n>] [--state-db <path>] [--resume-open-position] \\",
+      "    --confirm-live --risk-ack \"I acknowledge leveraged trading risk and accept full responsibility.\"",
+      "",
+      "  node dist/src/index.js resolve-market --input <slug-or-url> [--json]",
+      "  node dist/src/index.js suggest-markets [--limit <n>] [--min-liquidity <n>] [--category <tag>] [--json]",
+      "  node dist/src/index.js replay --state-db <path> [--run-id <id>] [--replay-speed <n>] [--json]",
+      "  node dist/src/index.js export-proof --state-db <path> [--run-id <id>] [--format <json|csv>] [--output <path>]",
+      "  node dist/src/index.js verify-proof --state-db <path> [--run-id <id>] [--json]",
+      ""
+    ].join("\n")
+  );
+}
+
+async function main(): Promise<void> {
+  const [, , command, ...rest] = process.argv;
+
+  if (!command || command === "--help" || command === "-h") {
+    printHelp();
+    return;
+  }
+
+  if (command === "dry-run") {
+    const config = parseDryRunArgs(rest);
+    await runDryRunRuntime(config);
+    return;
+  }
+
+  if (command === "live") {
+    const config = parseLiveArgs(rest);
+    await runLiveRuntime(config);
+    return;
+  }
+
+  if (command === "resolve-market") {
+    await runResolveMarketCommand(rest);
+    return;
+  }
+
+  if (command === "suggest-markets") {
+    await runSuggestMarketsCommand(rest);
+    return;
+  }
+
+  if (command === "replay") {
+    await runReplayCommand(rest);
+    return;
+  }
+
+  if (command === "export-proof") {
+    await runExportProofCommand(rest);
+    return;
+  }
+
+  if (command === "verify-proof") {
+    await runVerifyProofCommand(rest);
+    return;
+  }
+
+  throw new Error(`Unsupported command: ${command}`);
+}
+
+main().catch((error: unknown) => {
+  const message =
+    error instanceof Error ? error.message : "Unknown runtime error";
+  process.stderr.write(`pm-perp-momentum failed: ${message}\n`);
+  process.exit(1);
+});

--- a/skills/pm-perp-momentum/src/risk/stop-loss.ts
+++ b/skills/pm-perp-momentum/src/risk/stop-loss.ts
@@ -1,0 +1,53 @@
+import type { StoredPosition } from "../state/store.js";
+
+export interface StopLossSpec {
+  markPriceTrigger: number;
+  side: "LONG" | "SHORT";
+  stopLossPct: number;
+}
+
+export function computeStopLossTrigger(
+  entryMarkPrice: number,
+  side: "LONG" | "SHORT",
+  stopLossPct: number
+): number {
+  const ratio = stopLossPct / 100;
+  if (side === "LONG") {
+    return entryMarkPrice * (1 - ratio);
+  }
+  return entryMarkPrice * (1 + ratio);
+}
+
+export class StopLossManager {
+  private readonly spec: StopLossSpec;
+
+  public constructor(spec: StopLossSpec) {
+    this.spec = spec;
+  }
+
+  public static fromStoredPosition(position: StoredPosition): StopLossManager {
+    return new StopLossManager({
+      markPriceTrigger: position.stopLossMarkPrice,
+      side: position.perpSide,
+      stopLossPct: position.stopLossPct
+    });
+  }
+
+  public shouldTrigger(markPrice: number): boolean {
+    if (this.spec.side === "LONG") {
+      return markPrice <= this.spec.markPriceTrigger;
+    }
+    return markPrice >= this.spec.markPriceTrigger;
+  }
+
+  public describe(): string {
+    const trigger = this.spec.markPriceTrigger.toFixed(6);
+    return `side=${this.spec.side} stop-loss=${this.spec.stopLossPct.toFixed(
+      2
+    )}% trigger-mark-price=${trigger}`;
+  }
+
+  public getTrigger(): number {
+    return this.spec.markPriceTrigger;
+  }
+}

--- a/skills/pm-perp-momentum/src/runtime/common.ts
+++ b/skills/pm-perp-momentum/src/runtime/common.ts
@@ -1,0 +1,342 @@
+export interface RuntimeConfig {
+  pmMarket: string;
+  signalSide: "YES" | "NO";
+  entryThresholdPct: number;
+  exitThresholdPct: number;
+  dwellSeconds: number;
+  perpMarket: string;
+  perpSide: "LONG" | "SHORT";
+  notionalUsd: number;
+  leverage: number;
+  stopLossPct: number;
+  leaderboardMode: "volume-max" | "tx-max" | "address-max";
+  entrySlices: number;
+  takeProfitTargetsPct: number[];
+  dailyLossLimitUsd: number;
+  consecutiveLossLimit: number;
+  recordTicks: boolean;
+  resumeOpenPosition: boolean;
+}
+
+export interface RuntimeExtras {
+  stateDbPath?: string;
+  confirmLive: boolean;
+  riskAcknowledgement?: string;
+  replayRunId?: string;
+  replaySpeed: number;
+  runLabel?: string;
+}
+
+export type RuntimeConfigWithExtras = RuntimeConfig & RuntimeExtras;
+
+function parseNumericArg(raw: string, name: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Invalid numeric value for ${name}: ${raw}`);
+  }
+  return value;
+}
+
+function parseIntegerArg(raw: string, name: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value)) {
+    throw new Error(`Invalid integer value for ${name}: ${raw}`);
+  }
+  return value;
+}
+
+function parseTakeProfitTargets(raw: string): number[] {
+  const parts = raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (parts.length === 0) {
+    throw new Error(
+      "take-profit-targets must contain at least one numeric percentage."
+    );
+  }
+
+  const values = parts.map((part) => parseNumericArg(part, "--take-profit-targets"));
+  values.sort((a, b) => a - b);
+  return values;
+}
+
+function readRequired(args: Map<string, string>, key: string): string {
+  const value = args.get(key);
+  if (!value) {
+    throw new Error(`Missing required argument: ${key}`);
+  }
+  return value;
+}
+
+function parseArgMaps(argv: string[]): { args: Map<string, string>; flags: Set<string> } {
+  const args = new Map<string, string>();
+  const flags = new Set<string>();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      flags.add(token);
+      continue;
+    }
+
+    args.set(token, value);
+    index += 1;
+  }
+
+  return { args, flags };
+}
+
+function assertNoUnknownArgs(
+  argv: string[],
+  valueArgs: ReadonlySet<string>,
+  flagArgs: ReadonlySet<string>
+): void {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (valueArgs.has(token)) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`Missing value for argument: ${token}`);
+      }
+      index += 1;
+      continue;
+    }
+    if (flagArgs.has(token)) {
+      continue;
+    }
+    throw new Error(`Unsupported argument: ${token}`);
+  }
+}
+
+function applyLeaderboardPreset(
+  mode: "volume-max" | "tx-max" | "address-max"
+): {
+  entrySlices: number;
+  takeProfitTargetsPct: number[];
+  dailyLossLimitUsd: number;
+  consecutiveLossLimit: number;
+  dwellSecondsFloor: number;
+} {
+  if (mode === "volume-max") {
+    return {
+      entrySlices: 3,
+      takeProfitTargetsPct: [1.25, 2.5, 4],
+      dailyLossLimitUsd: 1500,
+      consecutiveLossLimit: 5,
+      dwellSecondsFloor: 10
+    };
+  }
+  if (mode === "tx-max") {
+    return {
+      entrySlices: 8,
+      takeProfitTargetsPct: [0.4, 0.8, 1.2, 1.6],
+      dailyLossLimitUsd: 900,
+      consecutiveLossLimit: 4,
+      dwellSecondsFloor: 5
+    };
+  }
+  return {
+    entrySlices: 2,
+    takeProfitTargetsPct: [0.8, 1.6, 2.4],
+    dailyLossLimitUsd: 500,
+    consecutiveLossLimit: 3,
+    dwellSecondsFloor: 20
+  };
+}
+
+export function parseRuntimeArgs(argv: string[]): RuntimeConfigWithExtras {
+  assertNoUnknownArgs(
+    argv,
+    new Set([
+      "--pm-market",
+      "--signal-side",
+      "--entry-threshold",
+      "--exit-threshold",
+      "--dwell-seconds",
+      "--perp",
+      "--side",
+      "--notional-usd",
+      "--leverage",
+      "--stop-loss-pct",
+      "--leaderboard-mode",
+      "--entry-slices",
+      "--take-profit-targets",
+      "--daily-loss-limit-usd",
+      "--consecutive-loss-limit",
+      "--state-db",
+      "--risk-ack",
+      "--run-id",
+      "--replay-speed",
+      "--run-label"
+    ]),
+    new Set(["--no-record-ticks", "--confirm-live", "--resume-open-position"])
+  );
+  const { args, flags } = parseArgMaps(argv);
+
+  const signalSide = readRequired(args, "--signal-side");
+  if (signalSide !== "YES" && signalSide !== "NO") {
+    throw new Error("signal-side must be YES or NO.");
+  }
+
+  const perpSide = readRequired(args, "--side");
+  if (perpSide !== "LONG" && perpSide !== "SHORT") {
+    throw new Error("side must be LONG or SHORT.");
+  }
+
+  const leaderboardModeRaw = args.get("--leaderboard-mode") ?? "volume-max";
+  if (
+    leaderboardModeRaw !== "volume-max" &&
+    leaderboardModeRaw !== "tx-max" &&
+    leaderboardModeRaw !== "address-max"
+  ) {
+    throw new Error(
+      "leaderboard-mode must be one of: volume-max, tx-max, address-max."
+    );
+  }
+  const preset = applyLeaderboardPreset(leaderboardModeRaw);
+
+  const entrySlices = args.has("--entry-slices")
+    ? parseIntegerArg(readRequired(args, "--entry-slices"), "--entry-slices")
+    : preset.entrySlices;
+  const takeProfitTargetsPct = args.has("--take-profit-targets")
+    ? parseTakeProfitTargets(readRequired(args, "--take-profit-targets"))
+    : preset.takeProfitTargetsPct;
+  const dailyLossLimitUsd = args.has("--daily-loss-limit-usd")
+    ? parseNumericArg(
+        readRequired(args, "--daily-loss-limit-usd"),
+        "--daily-loss-limit-usd"
+      )
+    : preset.dailyLossLimitUsd;
+  const consecutiveLossLimit = args.has("--consecutive-loss-limit")
+    ? parseIntegerArg(
+        readRequired(args, "--consecutive-loss-limit"),
+        "--consecutive-loss-limit"
+      )
+    : preset.consecutiveLossLimit;
+  const dwellSecondsParsed = parseNumericArg(
+    readRequired(args, "--dwell-seconds"),
+    "--dwell-seconds"
+  );
+
+  return {
+    pmMarket: readRequired(args, "--pm-market"),
+    signalSide,
+    entryThresholdPct: parseNumericArg(
+      readRequired(args, "--entry-threshold"),
+      "--entry-threshold"
+    ),
+    exitThresholdPct: parseNumericArg(
+      readRequired(args, "--exit-threshold"),
+      "--exit-threshold"
+    ),
+    dwellSeconds: Math.max(dwellSecondsParsed, preset.dwellSecondsFloor),
+    perpMarket: readRequired(args, "--perp"),
+    perpSide,
+    notionalUsd: parseNumericArg(
+      readRequired(args, "--notional-usd"),
+      "--notional-usd"
+    ),
+    leverage: parseNumericArg(readRequired(args, "--leverage"), "--leverage"),
+    stopLossPct: parseNumericArg(
+      readRequired(args, "--stop-loss-pct"),
+      "--stop-loss-pct"
+    ),
+    leaderboardMode: leaderboardModeRaw,
+    entrySlices,
+    takeProfitTargetsPct,
+    dailyLossLimitUsd,
+    consecutiveLossLimit,
+    recordTicks: !flags.has("--no-record-ticks"),
+    resumeOpenPosition: flags.has("--resume-open-position"),
+    stateDbPath: args.get("--state-db"),
+    confirmLive: flags.has("--confirm-live"),
+    riskAcknowledgement: args.get("--risk-ack"),
+    replayRunId: args.get("--run-id"),
+    replaySpeed: args.has("--replay-speed")
+      ? parseNumericArg(readRequired(args, "--replay-speed"), "--replay-speed")
+      : 1,
+    runLabel: args.get("--run-label")
+  };
+}
+
+export function validateRuntimeConfig(config: RuntimeConfig): void {
+  if (config.entryThresholdPct <= config.exitThresholdPct) {
+    throw new Error(
+      "entry-threshold must be greater than exit-threshold for hysteresis."
+    );
+  }
+  if (config.entryThresholdPct < 0 || config.entryThresholdPct > 100) {
+    throw new Error("entry-threshold must be between 0 and 100.");
+  }
+  if (config.exitThresholdPct < 0 || config.exitThresholdPct > 100) {
+    throw new Error("exit-threshold must be between 0 and 100.");
+  }
+  if (config.dwellSeconds < 0) {
+    throw new Error("dwell-seconds must be non-negative.");
+  }
+  if (config.leverage <= 0) {
+    throw new Error("leverage must be greater than 0.");
+  }
+  if (config.notionalUsd <= 0) {
+    throw new Error("notional-usd must be greater than 0.");
+  }
+  if (config.stopLossPct <= 0 || config.stopLossPct >= 50) {
+    throw new Error("stop-loss-pct must be between 0 and 50.");
+  }
+  if (!Number.isInteger(config.entrySlices) || config.entrySlices <= 0) {
+    throw new Error("entry-slices must be a positive integer.");
+  }
+  if (config.takeProfitTargetsPct.length === 0) {
+    throw new Error("take-profit-targets must not be empty.");
+  }
+  for (const target of config.takeProfitTargetsPct) {
+    if (target <= 0 || target > 100) {
+      throw new Error("take-profit-target values must be between 0 and 100.");
+    }
+  }
+  if (config.dailyLossLimitUsd <= 0) {
+    throw new Error("daily-loss-limit-usd must be greater than 0.");
+  }
+  if (!Number.isInteger(config.consecutiveLossLimit) || config.consecutiveLossLimit <= 0) {
+    throw new Error("consecutive-loss-limit must be a positive integer.");
+  }
+}
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function log(message: string): void {
+  process.stdout.write(`[${nowIso()}] ${message}\n`);
+}
+
+export function pctToProb(value: number): number {
+  return value / 100;
+}
+
+export function clampProbability(input: number): number {
+  return Math.max(0, Math.min(1, input));
+}
+
+export function adjustedSignalMid(mid: number, signalSide: "YES" | "NO"): number {
+  return signalSide === "YES" ? mid : 1 - mid;
+}
+
+export function formatPercent(input: number): string {
+  return (input * 100).toFixed(2);
+}
+
+export function deriveSizeProxy(notionalUsd: number, leverage: number): number {
+  const margin = notionalUsd / leverage;
+  return Number(margin.toFixed(6));
+}

--- a/skills/pm-perp-momentum/src/runtime/dry-run.ts
+++ b/skills/pm-perp-momentum/src/runtime/dry-run.ts
@@ -1,0 +1,221 @@
+import { runPlugin } from "../execution/subprocess.js";
+import { ThresholdDetector } from "../signal/threshold.js";
+import { StrategyStateStore } from "../state/store.js";
+import { PolymarketWatcher } from "../watcher/polymarket-ws.js";
+import {
+  adjustedSignalMid,
+  clampProbability,
+  deriveSizeProxy,
+  formatPercent,
+  log,
+  parseRuntimeArgs,
+  pctToProb,
+  type RuntimeConfigWithExtras,
+  validateRuntimeConfig
+} from "./common.js";
+
+export type DryRunRuntimeConfig = RuntimeConfigWithExtras;
+
+interface PositionState {
+  openedAt: number;
+  entrySignalMid: number;
+  direction: "LONG" | "SHORT";
+}
+
+export function parseDryRunArgs(argv: string[]): DryRunRuntimeConfig {
+  return parseRuntimeArgs(argv);
+}
+
+export async function runDryRunRuntime(
+  config: DryRunRuntimeConfig
+): Promise<void> {
+  validateRuntimeConfig(config);
+  const stateDbPath = config.stateDbPath ?? "./fixtures/dry-run.sqlite";
+  const store = new StrategyStateStore(stateDbPath, {
+    mode: "dry-run",
+    config,
+    runLabel: config.runLabel
+  });
+
+  const detector = new ThresholdDetector({
+    entryThreshold: pctToProb(config.entryThresholdPct),
+    exitThreshold: pctToProb(config.exitThresholdPct),
+    dwellMs: config.dwellSeconds * 1_000
+  });
+
+  const watcher = new PolymarketWatcher({
+    marketId: config.pmMarket
+  });
+
+  let lastPrintedTickAt = 0;
+  let position: PositionState | null = null;
+  const sizeProxy = deriveSizeProxy(config.notionalUsd, config.leverage);
+
+  const cleanupFns: Array<() => void> = [];
+
+  const handleTick = async (tick: {
+    ts: number;
+    mid: number;
+  }): Promise<void> => {
+    const adjustedMid = clampProbability(
+      adjustedSignalMid(tick.mid, config.signalSide)
+    );
+    if (config.recordTicks) {
+      store.recordTick(config.pmMarket, adjustedMid, tick.mid, tick.ts, null, "signal");
+    }
+
+    if (Date.now() - lastPrintedTickAt > 3_000) {
+      log(
+        `tick market=${config.pmMarket} mid=${formatPercent(
+          adjustedMid
+        )}% signal-side=${config.signalSide}`
+      );
+      lastPrintedTickAt = Date.now();
+    }
+
+    const event = detector.feed({
+      ts: tick.ts,
+      mid: adjustedMid
+    });
+
+    if (!event) {
+      return;
+    }
+
+    if (event.kind === "ENTER" && !position) {
+      log(
+        `signal-enter triggered at ${formatPercent(
+          event.mid
+        )}% -> simulated ${config.perpSide} ${config.perpMarket}-PERP`
+      );
+
+      const orderResult = await runPlugin(
+        "hyperliquid-plugin",
+        [
+          "order",
+          "--market",
+          config.perpMarket,
+          "--side",
+          config.perpSide.toLowerCase(),
+          "--size",
+          String(sizeProxy),
+          "--leverage",
+          String(config.leverage),
+          "--confirm"
+        ],
+        { dryRun: true }
+      );
+
+      log(`sim-order: ${orderResult.stdout}`);
+      store.appendEvent("sim_entry", "Dry-run simulated entry.", {
+        command: orderResult.command
+      });
+      log(
+        `sim-risk: stop-loss=${config.stopLossPct.toFixed(
+          2
+        )}% notional=${config.notionalUsd.toFixed(2)}`
+      );
+
+      position = {
+        openedAt: tick.ts,
+        entrySignalMid: event.mid,
+        direction: config.perpSide
+      };
+      return;
+    }
+
+    if (event.kind === "EXIT" && position) {
+      log(
+        `signal-exit triggered at ${formatPercent(
+          event.mid
+        )}% -> simulated close ${config.perpMarket}-PERP`
+      );
+
+      const closeSide = position.direction === "LONG" ? "sell" : "buy";
+      const closeResult = await runPlugin(
+        "hyperliquid-plugin",
+        [
+          "order",
+          "--market",
+          config.perpMarket,
+          "--side",
+          closeSide,
+          "--size",
+          String(sizeProxy),
+          "--reduce-only",
+          "true",
+          "--confirm"
+        ],
+        { dryRun: true }
+      );
+
+      const heldSeconds = Math.floor((tick.ts - position.openedAt) / 1_000);
+      const deltaPct = (event.mid - position.entrySignalMid) * 100;
+      log(`sim-close: ${closeResult.stdout}`);
+      store.appendEvent("sim_exit", "Dry-run simulated exit.", {
+        command: closeResult.command
+      });
+      log(
+        `sim-summary: held=${heldSeconds}s signal-delta=${deltaPct.toFixed(
+          2
+        )}pp`
+      );
+
+      position = null;
+    }
+  };
+
+  cleanupFns.push(
+    watcher.onError((error) => {
+      log(`watcher-error: ${error.message}`);
+    })
+  );
+
+  cleanupFns.push(
+    watcher.onStatus((status) => {
+      if (status.kind === "connected") {
+        log(`watcher-connected url=${status.url}`);
+        return;
+      }
+      if (status.kind === "disconnected") {
+        log("watcher-disconnected");
+        return;
+      }
+      log(
+        `watcher-reconnecting attempt=${status.attempt} wait-ms=${status.waitMs}`
+      );
+    })
+  );
+
+  cleanupFns.push(
+    watcher.onTick((tick) => {
+      void handleTick(tick).catch((error: unknown) => {
+        const message =
+          error instanceof Error ? error.message : "Unknown tick handling error";
+        log(`tick-error: ${message}`);
+      });
+    })
+  );
+
+  log(
+    `dry-run started run-id=${store.getRunId()} market=${config.pmMarket} signal-side=${config.signalSide} entry=${config.entryThresholdPct}% exit=${config.exitThresholdPct}% db=${stateDbPath}`
+  );
+  store.appendEvent("runtime_start", "Dry-run runtime started.");
+  watcher.start();
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      log("shutdown signal received, stopping watcher");
+      watcher.stop();
+      for (const cleanup of cleanupFns) {
+        cleanup();
+      }
+      store.appendEvent("runtime_stop", "Dry-run runtime stopped.");
+      store.close();
+      resolve();
+    };
+
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}

--- a/skills/pm-perp-momentum/src/runtime/export-proof.ts
+++ b/skills/pm-perp-momentum/src/runtime/export-proof.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import Database from "better-sqlite3";
+
+interface ExportArgs {
+  dbPath: string;
+  runId?: string;
+  format: "json" | "csv";
+  outputPath: string;
+}
+
+function parseArgs(argv: string[]): ExportArgs {
+  const args = new Map<string, string>();
+  const valueArgs = new Set(["--state-db", "--run-id", "--format", "--output"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (!valueArgs.has(token)) {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for argument: ${token}`);
+    }
+    args.set(token, value);
+    index += 1;
+  }
+
+  const dbPath = args.get("--state-db");
+  if (!dbPath) {
+    throw new Error("Missing required argument: --state-db <path>");
+  }
+
+  const formatRaw = args.get("--format") ?? "json";
+  if (formatRaw !== "json" && formatRaw !== "csv") {
+    throw new Error("format must be either json or csv.");
+  }
+
+  const outputPath = args.get("--output") ?? `./proof-export.${formatRaw}`;
+  return {
+    dbPath,
+    runId: args.get("--run-id"),
+    format: formatRaw,
+    outputPath
+  };
+}
+
+function escapeCsvField(input: unknown): string {
+  const raw =
+    input === null || input === undefined
+      ? ""
+      : typeof input === "string"
+        ? input
+        : typeof input === "number" || typeof input === "boolean"
+          ? String(input)
+          : JSON.stringify(input);
+  if (raw.includes(",") || raw.includes('"') || raw.includes("\n")) {
+    return `"${raw.replace(/"/g, '""')}"`;
+  }
+  return raw;
+}
+
+function toCsv(rows: Array<Record<string, unknown>>): string {
+  if (rows.length === 0) {
+    return "";
+  }
+  const headers = Object.keys(rows[0] ?? {});
+  const lines = [headers.join(",")];
+  for (const row of rows) {
+    const line = headers.map((header) => escapeCsvField(row[header])).join(",");
+    lines.push(line);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function resolveRunId(db: Database.Database, runId?: string): string {
+  if (runId) {
+    return runId;
+  }
+  const row = db
+    .prepare("SELECT run_id FROM runs ORDER BY created_at_ms DESC LIMIT 1")
+    .get() as { run_id: string } | undefined;
+  if (!row?.run_id) {
+    throw new Error("No run records found in the provided state database.");
+  }
+  return row.run_id;
+}
+
+function ensureParent(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+}
+
+export function runExportProofCommand(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const db = new Database(args.dbPath, { readonly: true });
+  try {
+    const runId = resolveRunId(db, args.runId);
+    const run = db
+      .prepare(
+        "SELECT run_id as runId, mode, fingerprint, config_json as configJson, label, created_at_ms as createdAtMs FROM runs WHERE run_id = @runId LIMIT 1"
+      )
+      .get({ runId }) as Record<string, unknown> | undefined;
+    if (!run) {
+      throw new Error(`Run not found: ${runId}`);
+    }
+
+    const positions = db
+      .prepare(
+        "SELECT * FROM positions WHERE run_id = @runId ORDER BY opened_at_ms ASC"
+      )
+      .all({ runId }) as Array<Record<string, unknown>>;
+    const events = db
+      .prepare(
+        "SELECT id, run_id as runId, event_type as eventType, message, payload_json as payloadJson, previous_hash as previousHash, current_hash as currentHash, created_at_ms as createdAtMs FROM events WHERE run_id = @runId ORDER BY id ASC"
+      )
+      .all({ runId }) as Array<Record<string, unknown>>;
+    const ticks = db
+      .prepare(
+        "SELECT id, run_id as runId, market_id as marketId, tick_kind as tickKind, signal_mid as signalMid, raw_mid as rawMid, ts, mark_price as markPrice FROM replay_ticks WHERE run_id = @runId ORDER BY ts ASC, id ASC"
+      )
+      .all({ runId }) as Array<Record<string, unknown>>;
+
+    if (args.format === "json") {
+      ensureParent(args.outputPath);
+      writeFileSync(
+        args.outputPath,
+        JSON.stringify({ run, positions, events, ticks }, null, 2),
+        "utf8"
+      );
+      process.stdout.write(
+        `Proof export complete: ${args.outputPath} (format=json, run-id=${runId}).\n`
+      );
+      return Promise.resolve();
+    }
+
+    mkdirSync(args.outputPath, { recursive: true });
+    writeFileSync(join(args.outputPath, "run.json"), JSON.stringify(run, null, 2), "utf8");
+    writeFileSync(join(args.outputPath, "positions.csv"), toCsv(positions), "utf8");
+    writeFileSync(join(args.outputPath, "events.csv"), toCsv(events), "utf8");
+    writeFileSync(join(args.outputPath, "ticks.csv"), toCsv(ticks), "utf8");
+    process.stdout.write(
+      `Proof export complete: ${args.outputPath} (format=csv, run-id=${runId}).\n`
+    );
+  } finally {
+    db.close();
+  }
+  return Promise.resolve();
+}

--- a/skills/pm-perp-momentum/src/runtime/live-impl.ts
+++ b/skills/pm-perp-momentum/src/runtime/live-impl.ts
@@ -1,0 +1,713 @@
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  executeHyperliquidOrder,
+  fetchHyperliquidMarkPrice
+} from "../execution/adapters.js";
+import {
+  StopLossManager,
+  computeStopLossTrigger
+} from "../risk/stop-loss.js";
+import { ThresholdDetector } from "../signal/threshold.js";
+import {
+  StrategyStateStore,
+  type PositionOpenInput,
+  type StoredPosition
+} from "../state/store.js";
+import { PolymarketWatcher } from "../watcher/polymarket-ws.js";
+import {
+  adjustedSignalMid,
+  clampProbability,
+  deriveSizeProxy,
+  formatPercent,
+  log,
+  parseRuntimeArgs,
+  pctToProb,
+  type RuntimeConfigWithExtras,
+  validateRuntimeConfig
+} from "./common.js";
+
+export type LiveRuntimeConfig = RuntimeConfigWithExtras;
+
+const DEFAULT_DB_PATH = join(homedir(), ".pm-perp-momentum", "state.sqlite");
+const RISK_ACK_REQUIRED_PHRASE =
+  "I acknowledge leveraged trading risk and accept full responsibility.";
+const MARK_RISK_INTERVAL_MS = 1_000;
+
+interface ActivePosition {
+  id: string;
+  openedAt: number;
+  entrySignalMid: number;
+  entryMarkPrice: number;
+  direction: "LONG" | "SHORT";
+  sizeTotal: number;
+  remainingSize: number;
+  nextTakeProfitIndex: number;
+  takeProfitTargetsPct: number[];
+  notionalUsd: number;
+  leverage: number;
+  avgEntryPrice: number | null;
+  totalFeesUsd: number;
+  filledEntrySize: number;
+  filledExitSize: number;
+  lastKnownMarkPrice: number | null;
+  stopLossManager: StopLossManager;
+}
+
+function toActivePosition(position: StoredPosition): ActivePosition {
+  const takeProfitTargetsPct = JSON.parse(position.takeProfitTargetsJson) as number[];
+  return {
+    id: position.id,
+    openedAt: position.openedAtMs,
+    entrySignalMid: position.entrySignalMid,
+    entryMarkPrice: position.entryMarkPrice,
+    direction: position.perpSide,
+    sizeTotal: position.sizeProxy,
+    remainingSize: position.remainingSize,
+    nextTakeProfitIndex: position.nextTakeProfitIndex,
+    takeProfitTargetsPct,
+    notionalUsd: position.notionalUsd,
+    leverage: position.leverage,
+    avgEntryPrice: position.avgEntryPrice,
+    totalFeesUsd: position.totalFeesUsd,
+    filledEntrySize: position.filledEntrySize,
+    filledExitSize: position.filledExitSize,
+    lastKnownMarkPrice: null,
+    stopLossManager: StopLossManager.fromStoredPosition(position)
+  };
+}
+
+function canTriggerTakeProfit(position: ActivePosition, signalMid: number): boolean {
+  const target = position.takeProfitTargetsPct[position.nextTakeProfitIndex];
+  if (target === undefined) {
+    return false;
+  }
+  const ratio = target / 100;
+  if (position.direction === "LONG") {
+    return signalMid >= position.entrySignalMid * (1 + ratio);
+  }
+  return signalMid <= position.entrySignalMid * (1 - ratio);
+}
+
+function takeProfitCloseSize(position: ActivePosition): number {
+  const targetsCount = position.takeProfitTargetsPct.length;
+  const isFinalTarget = position.nextTakeProfitIndex >= targetsCount - 1;
+  if (isFinalTarget) {
+    return position.remainingSize;
+  }
+  const baseSlice = position.sizeTotal / targetsCount;
+  return Number(Math.min(position.remainingSize, baseSlice).toFixed(8));
+}
+
+function computeFallbackPnlUsd(position: ActivePosition, markPrice: number): number {
+  const entry = position.avgEntryPrice ?? position.entryMarkPrice;
+  const deltaPerUnit =
+    position.direction === "LONG" ? markPrice - entry : entry - markPrice;
+  return deltaPerUnit * position.filledEntrySize - position.totalFeesUsd;
+}
+
+async function executeSlicedEntry(
+  config: LiveRuntimeConfig,
+  sliceCount: number,
+  sizeTotal: number
+): Promise<{
+  filledSize: number;
+  successfulSlices: number;
+  failedSlices: number;
+  totalFeesUsd: number;
+  weightedEntryPrice: number | null;
+}> {
+  const sliceSize = Number((sizeTotal / sliceCount).toFixed(8));
+  let filledSize = 0;
+  let successfulSlices = 0;
+  let failedSlices = 0;
+  let totalFeesUsd = 0;
+  let weightedPriceNumerator = 0;
+  let weightedSizeDenominator = 0;
+
+  for (let index = 0; index < sliceCount; index += 1) {
+    try {
+      const order = await executeHyperliquidOrder([
+        "order",
+        "--market",
+        config.perpMarket,
+        "--side",
+        config.perpSide.toLowerCase(),
+        "--size",
+        String(sliceSize),
+        "--leverage",
+        String(config.leverage),
+        "--confirm"
+      ]);
+
+      const actualFilled = order.filledSize > 0 ? order.filledSize : sliceSize;
+      successfulSlices += 1;
+      filledSize += actualFilled;
+      totalFeesUsd += order.feeUsd;
+      if (order.avgPrice !== null) {
+        weightedPriceNumerator += order.avgPrice * actualFilled;
+        weightedSizeDenominator += actualFilled;
+      }
+    } catch {
+      failedSlices += 1;
+    }
+  }
+
+  const weightedEntryPrice =
+    weightedSizeDenominator > 0
+      ? weightedPriceNumerator / weightedSizeDenominator
+      : null;
+
+  return {
+    filledSize: Number(filledSize.toFixed(8)),
+    successfulSlices,
+    failedSlices,
+    totalFeesUsd: Number(totalFeesUsd.toFixed(8)),
+    weightedEntryPrice:
+      weightedEntryPrice === null ? null : Number(weightedEntryPrice.toFixed(8))
+  };
+}
+
+async function closeLivePosition(
+  reason: "SIGNAL_EXIT" | "STOP_LOSS",
+  config: LiveRuntimeConfig,
+  store: StrategyStateStore,
+  position: ActivePosition,
+  signalMid: number,
+  markPrice: number
+): Promise<"CLOSED" | "PARTIAL" | "FAILED"> {
+  const closeSide = position.direction === "LONG" ? "sell" : "buy";
+
+  let order;
+  try {
+    order = await executeHyperliquidOrder([
+      "order",
+      "--market",
+      config.perpMarket,
+      "--side",
+      closeSide,
+      "--size",
+      String(position.remainingSize),
+      "--reduce-only",
+      "true",
+      "--confirm"
+    ]);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown close order failure.";
+    store.appendEvent("live_close_failed", message, { reason });
+    log(`live-close-failed reason=${reason} error=${message}`);
+    return "FAILED";
+  }
+
+  const requestedSize = position.remainingSize;
+  const actualClosedRaw = order.filledSize > 0 ? order.filledSize : 0;
+  if (actualClosedRaw <= 0) {
+    store.appendEvent("live_close_failed", "Close order did not fill.", {
+      reason,
+      requestedSize,
+      command: order.raw.command
+    });
+    return "FAILED";
+  }
+  const actualClosed = Number(Math.min(requestedSize, actualClosedRaw).toFixed(8));
+  const nextRemaining = Number(Math.max(0, requestedSize - actualClosed).toFixed(8));
+
+  const heldSeconds = Math.floor((Date.now() - position.openedAt) / 1_000);
+  const deltaPct = (signalMid - position.entrySignalMid) * 100;
+  const avgExitPrice = order.avgPrice ?? markPrice;
+  const totalFeesUsd = Number((position.totalFeesUsd + order.feeUsd).toFixed(8));
+  const filledExitSize = Number((position.filledExitSize + actualClosed).toFixed(8));
+  position.totalFeesUsd = totalFeesUsd;
+  position.filledExitSize = filledExitSize;
+  position.remainingSize = nextRemaining;
+
+  if (nextRemaining > 0) {
+    store.withTransaction(() => {
+      store.applyPartialClose(
+        position.id,
+        nextRemaining,
+        totalFeesUsd,
+        filledExitSize,
+        avgExitPrice
+      );
+      store.appendEvent("position_partial_close", "Position partially closed.", {
+        reason,
+        requestedSize,
+        closedSize: actualClosed,
+        remainingSize: nextRemaining,
+        avgExitPrice: Number(avgExitPrice.toFixed(6)),
+        command: order.raw.command
+      });
+    });
+    log(
+      `live-close partial reason=${reason} closed=${actualClosed} remaining=${nextRemaining}`
+    );
+    return "PARTIAL";
+  }
+
+  const realizedPnlUsd =
+    order.realizedPnlUsd ?? computeFallbackPnlUsd(position, markPrice);
+  store.withTransaction(() => {
+    store.closePosition(
+      position.id,
+      reason,
+      Date.now(),
+      realizedPnlUsd,
+      avgExitPrice,
+      totalFeesUsd,
+      filledExitSize
+    );
+    const riskState = store.applyTradeOutcome(realizedPnlUsd);
+    store.appendEvent("position_closed", "Position closed successfully.", {
+      reason,
+      heldSeconds,
+      avgExitPrice: Number(avgExitPrice.toFixed(6)),
+      realizedPnlUsd: Number(realizedPnlUsd.toFixed(4)),
+      pnlSource: order.realizedPnlUsd === null ? "fallback" : "plugin",
+      dailyLossUsd: Number(riskState.dailyLossUsd.toFixed(4)),
+      consecutiveLosses: riskState.consecutiveLosses,
+      signalDeltaPct: Number(deltaPct.toFixed(4)),
+      command: order.raw.command
+    });
+  });
+  log(
+    `live-close success reason=${reason} held=${heldSeconds}s signal-delta=${deltaPct.toFixed(
+      2
+    )}pp`
+  );
+  return "CLOSED";
+}
+
+export function parseLiveArgs(argv: string[]): LiveRuntimeConfig {
+  return parseRuntimeArgs(argv);
+}
+
+export async function runLiveRuntime(config: LiveRuntimeConfig): Promise<void> {
+  validateRuntimeConfig(config);
+  if (!config.confirmLive) {
+    throw new Error(
+      "Live mode requires --confirm-live. Dry-run mode is safer for first-time execution."
+    );
+  }
+  if (config.riskAcknowledgement !== RISK_ACK_REQUIRED_PHRASE) {
+    throw new Error(
+      `Live mode requires --risk-ack "${RISK_ACK_REQUIRED_PHRASE}".`
+    );
+  }
+
+  log(
+    "CRITICAL: KPI attribution and leaderboard points are ONLY earned when this Skill is executed within the official Onchain OS / Agentic Wallet environment."
+  );
+
+  const stateDbPath = config.stateDbPath ?? DEFAULT_DB_PATH;
+  const store = new StrategyStateStore(stateDbPath, {
+    mode: "live",
+    config,
+    runLabel: config.runLabel
+  });
+  const detector = new ThresholdDetector({
+    entryThreshold: pctToProb(config.entryThresholdPct),
+    exitThreshold: pctToProb(config.exitThresholdPct),
+    dwellMs: config.dwellSeconds * 1_000
+  });
+  const watcher = new PolymarketWatcher({
+    marketId: config.pmMarket
+  });
+
+  const cleanupFns: Array<() => void> = [];
+  const sizeProxy = deriveSizeProxy(config.notionalUsd, config.leverage);
+  const takeProfitTargetsPct = [...config.takeProfitTargetsPct];
+  let lastPrintedTickAt = 0;
+  let processingQueue: Promise<void> = Promise.resolve();
+  let stopOpeningTrades = false;
+  let activePosition: ActivePosition | null = null;
+  let markRiskTimer: NodeJS.Timeout | null = null;
+  let lastSignalMid = 0.5;
+  let lastRawMid = 0.5;
+
+  const recovered = config.resumeOpenPosition
+    ? store.getOpenPosition(config.pmMarket, config.perpMarket)
+    : null;
+  if (recovered) {
+    activePosition = toActivePosition(recovered);
+    detector.forceInPosition();
+    log(
+      `state-recovered open-position id=${recovered.id} stop-loss-mark-price=${recovered.stopLossMarkPrice.toFixed(
+        6
+      )}`
+    );
+    store.appendEvent("state_recovered", "Recovered open position from SQLite.", {
+      positionId: recovered.id
+    });
+  } else if (!config.resumeOpenPosition) {
+    store.appendEvent(
+      "state_recovery_skipped",
+      "Open-position recovery disabled for this run."
+    );
+  }
+
+  const riskBaseline = store.getRiskState();
+  if (
+    riskBaseline.dailyLossUsd >= config.dailyLossLimitUsd ||
+    riskBaseline.consecutiveLosses >= config.consecutiveLossLimit
+  ) {
+    stopOpeningTrades = true;
+    log(
+      `risk-gate-engaged on startup daily-loss=${riskBaseline.dailyLossUsd.toFixed(
+        2
+      )}/${config.dailyLossLimitUsd.toFixed(2)} consecutive-losses=${
+        riskBaseline.consecutiveLosses
+      }/${config.consecutiveLossLimit}`
+    );
+  }
+
+  cleanupFns.push(
+    watcher.onError((error) => {
+      log(`watcher-error: ${error.message}`);
+      store.appendEvent("watcher_error", error.message);
+    })
+  );
+  cleanupFns.push(
+    watcher.onStatus((status) => {
+      if (status.kind === "connected") {
+        log(`watcher-connected url=${status.url}`);
+        return;
+      }
+      if (status.kind === "disconnected") {
+        log("watcher-disconnected");
+        return;
+      }
+      log(
+        `watcher-reconnecting attempt=${status.attempt} wait-ms=${status.waitMs}`
+      );
+    })
+  );
+
+  const handleTick = async (tick: { ts: number; mid: number }): Promise<void> => {
+    const adjustedMid = clampProbability(
+      adjustedSignalMid(tick.mid, config.signalSide)
+    );
+    lastSignalMid = adjustedMid;
+    lastRawMid = tick.mid;
+    if (config.recordTicks) {
+      store.recordTick(config.pmMarket, adjustedMid, tick.mid, tick.ts, null, "signal");
+    }
+    if (Date.now() - lastPrintedTickAt > 3_000) {
+      log(
+        `tick market=${config.pmMarket} mid=${formatPercent(
+          adjustedMid
+        )}% signal-side=${config.signalSide}`
+      );
+      lastPrintedTickAt = Date.now();
+    }
+
+    if (activePosition && canTriggerTakeProfit(activePosition, adjustedMid)) {
+      const closeSize = takeProfitCloseSize(activePosition);
+      const closeSide = activePosition.direction === "LONG" ? "sell" : "buy";
+      let tpOrder;
+      try {
+        tpOrder = await executeHyperliquidOrder([
+          "order",
+          "--market",
+          config.perpMarket,
+          "--side",
+          closeSide,
+          "--size",
+          String(closeSize),
+          "--reduce-only",
+          "true",
+          "--confirm"
+        ]);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown take-profit failure.";
+        store.appendEvent("take_profit_failed", message);
+        return;
+      }
+
+      const targetHit =
+        activePosition.takeProfitTargetsPct[activePosition.nextTakeProfitIndex] ?? 0;
+      const actualClosed = tpOrder.filledSize > 0 ? tpOrder.filledSize : closeSize;
+      activePosition.remainingSize = Number(
+        Math.max(0, activePosition.remainingSize - actualClosed).toFixed(8)
+      );
+      activePosition.filledExitSize += actualClosed;
+      activePosition.totalFeesUsd += tpOrder.feeUsd;
+      activePosition.nextTakeProfitIndex += 1;
+
+      store.updatePositionAfterTakeProfit(
+        activePosition.id,
+        activePosition.nextTakeProfitIndex,
+        activePosition.remainingSize
+      );
+      store.appendEvent("take_profit_hit", "Take profit target executed.", {
+        targetPct: targetHit,
+        closedSize: actualClosed,
+        remainingSize: activePosition.remainingSize,
+        command: tpOrder.raw.command
+      });
+
+      if (activePosition.remainingSize <= 0) {
+        const closingPosition = activePosition;
+        const markPrice =
+          closingPosition.lastKnownMarkPrice ?? closingPosition.entryMarkPrice;
+        const realizedPnlUsd =
+          tpOrder.realizedPnlUsd ?? computeFallbackPnlUsd(closingPosition, markPrice);
+        store.withTransaction(() => {
+          store.closePosition(
+            closingPosition.id,
+            "SIGNAL_EXIT",
+            Date.now(),
+            realizedPnlUsd,
+            tpOrder.avgPrice,
+            closingPosition.totalFeesUsd,
+            closingPosition.filledExitSize
+          );
+          const riskState = store.applyTradeOutcome(realizedPnlUsd);
+          store.appendEvent(
+            "position_closed",
+            "Position closed after final take-profit.",
+            {
+              realizedPnlUsd: Number(realizedPnlUsd.toFixed(4)),
+              dailyLossUsd: Number(riskState.dailyLossUsd.toFixed(4)),
+              consecutiveLosses: riskState.consecutiveLosses
+            }
+          );
+        });
+        activePosition = null;
+      }
+      return;
+    }
+
+    const event = detector.feed({
+      ts: tick.ts,
+      mid: adjustedMid
+    });
+    if (!event) {
+      return;
+    }
+
+    if (event.kind === "ENTER" && !activePosition) {
+      if (stopOpeningTrades) {
+        store.appendEvent(
+          "entry_blocked",
+          "Entry was blocked due to risk guardrails.",
+          {
+            dailyLossLimitUsd: config.dailyLossLimitUsd,
+            consecutiveLossLimit: config.consecutiveLossLimit
+          }
+        );
+        return;
+      }
+      const entryMark = await fetchHyperliquidMarkPrice(config.perpMarket);
+      const sliced = await executeSlicedEntry(config, config.entrySlices, sizeProxy);
+      if (sliced.filledSize <= 0 || sliced.successfulSlices === 0) {
+        store.appendEvent("live_entry_failed", "All entry slices failed.", {
+          requestedSlices: config.entrySlices
+        });
+        return;
+      }
+
+      const stopLossMarkPrice = computeStopLossTrigger(
+        entryMark.markPrice,
+        config.perpSide,
+        config.stopLossPct
+      );
+      const positionId = randomUUID();
+      const openInput: PositionOpenInput = {
+        id: positionId,
+        runId: store.getRunId(),
+        pmMarket: config.pmMarket,
+        signalSide: config.signalSide,
+        perpMarket: config.perpMarket,
+        perpSide: config.perpSide,
+        notionalUsd: config.notionalUsd,
+        leverage: config.leverage,
+        sizeProxy: sliced.filledSize,
+        avgEntryPrice: sliced.weightedEntryPrice,
+        totalFeesUsd: sliced.totalFeesUsd,
+        filledEntrySize: sliced.filledSize,
+        entrySignalMid: event.mid,
+        entryMarkPrice: entryMark.markPrice,
+        stopLossPct: config.stopLossPct,
+        stopLossMarkPrice,
+        remainingSize: sliced.filledSize,
+        nextTakeProfitIndex: 0,
+        takeProfitTargetsJson: JSON.stringify(takeProfitTargetsPct),
+        openedAtMs: Date.now()
+      };
+      store.openPosition(openInput);
+
+      activePosition = {
+        id: positionId,
+        openedAt: openInput.openedAtMs,
+        entrySignalMid: event.mid,
+        entryMarkPrice: entryMark.markPrice,
+        direction: config.perpSide,
+        sizeTotal: sliced.filledSize,
+        remainingSize: sliced.filledSize,
+        nextTakeProfitIndex: 0,
+        takeProfitTargetsPct,
+        notionalUsd: config.notionalUsd,
+        leverage: config.leverage,
+        avgEntryPrice: sliced.weightedEntryPrice,
+        totalFeesUsd: sliced.totalFeesUsd,
+        filledEntrySize: sliced.filledSize,
+        filledExitSize: 0,
+        lastKnownMarkPrice: entryMark.markPrice,
+        stopLossManager: new StopLossManager({
+          markPriceTrigger: stopLossMarkPrice,
+          side: config.perpSide,
+          stopLossPct: config.stopLossPct
+        })
+      };
+      store.appendEvent("position_opened", "Position opened successfully.", {
+        positionId,
+        entryMarkPrice: entryMark.markPrice,
+        stopLossMarkPrice,
+        requestedSlices: config.entrySlices,
+        successfulSlices: sliced.successfulSlices,
+        failedSlices: sliced.failedSlices,
+        filledSize: sliced.filledSize
+      });
+      log(
+        `live-entry success id=${positionId} filled-size=${sliced.filledSize} slices=${sliced.successfulSlices}/${config.entrySlices} stop-loss-mark=${stopLossMarkPrice.toFixed(
+          6
+        )}`
+      );
+      return;
+    }
+
+    if (event.kind === "EXIT" && activePosition) {
+      const markPrice =
+        activePosition.lastKnownMarkPrice ?? activePosition.entryMarkPrice;
+      const closeResult = await closeLivePosition(
+        "SIGNAL_EXIT",
+        config,
+        store,
+        activePosition,
+        adjustedMid,
+        markPrice
+      );
+      if (closeResult === "CLOSED") {
+        activePosition = null;
+        const riskState = store.getRiskState();
+        if (riskState.dailyLossUsd < config.dailyLossLimitUsd) {
+          stopOpeningTrades = false;
+        }
+      }
+    }
+  };
+
+  cleanupFns.push(
+    watcher.onTick((tick) => {
+      processingQueue = processingQueue
+        .then(async () => {
+          await handleTick(tick);
+        })
+        .catch((error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : "Unknown tick handling error";
+          store.appendEvent("tick_error", message);
+          log(`tick-error: ${message}`);
+        });
+    })
+  );
+
+  markRiskTimer = setInterval(() => {
+    if (!activePosition) {
+      return;
+    }
+    processingQueue = processingQueue
+      .then(async () => {
+        if (!activePosition) {
+          return;
+        }
+        const quote = await fetchHyperliquidMarkPrice(config.perpMarket);
+        activePosition.lastKnownMarkPrice = quote.markPrice;
+        if (config.recordTicks) {
+          store.recordTick(
+            config.pmMarket,
+            lastSignalMid,
+            lastRawMid,
+            Date.now(),
+            quote.markPrice,
+            "mark"
+          );
+        }
+        if (!activePosition.stopLossManager.shouldTrigger(quote.markPrice)) {
+          return;
+        }
+        log(
+          `stop-loss-triggered mark-price=${quote.markPrice.toFixed(6)} (${activePosition.stopLossManager.describe()})`
+        );
+        const closeResult = await closeLivePosition(
+          "STOP_LOSS",
+          config,
+          store,
+          activePosition,
+          activePosition.entrySignalMid,
+          quote.markPrice
+        );
+        if (closeResult === "CLOSED") {
+          activePosition = null;
+          const riskState = store.getRiskState();
+          if (
+            riskState.dailyLossUsd >= config.dailyLossLimitUsd ||
+            riskState.consecutiveLosses >= config.consecutiveLossLimit
+          ) {
+            stopOpeningTrades = true;
+            log(
+              `risk-gate-engaged after stop-loss daily-loss=${riskState.dailyLossUsd.toFixed(
+                2
+              )}/${config.dailyLossLimitUsd.toFixed(
+                2
+              )} consecutive-losses=${riskState.consecutiveLosses}/${
+                config.consecutiveLossLimit
+              }`
+            );
+          }
+        }
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error ? error.message : "Unknown mark-risk error.";
+        store.appendEvent("mark_risk_error", message);
+        log(`mark-risk-error: ${message}`);
+      });
+  }, MARK_RISK_INTERVAL_MS);
+
+  log(
+    `live runtime started run-id=${store.getRunId()} mode=${config.leaderboardMode} market=${config.pmMarket} signal-side=${config.signalSide} entry=${config.entryThresholdPct}% exit=${config.exitThresholdPct}% db=${stateDbPath}`
+  );
+  store.appendEvent("runtime_start", "Live runtime started.", {
+    pmMarket: config.pmMarket,
+    perpMarket: config.perpMarket
+  });
+  watcher.start();
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      log("shutdown signal received, stopping watcher");
+      watcher.stop();
+      if (markRiskTimer) {
+        clearInterval(markRiskTimer);
+        markRiskTimer = null;
+      }
+      for (const cleanup of cleanupFns) {
+        cleanup();
+      }
+      void processingQueue.finally(() => {
+        store.appendEvent("runtime_stop", "Live runtime stopped.");
+        store.close();
+        resolve();
+      });
+    };
+
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}

--- a/skills/pm-perp-momentum/src/runtime/live.ts
+++ b/skills/pm-perp-momentum/src/runtime/live.ts
@@ -1,0 +1,1 @@
+export * from "./live-impl.js";

--- a/skills/pm-perp-momentum/src/runtime/replay.ts
+++ b/skills/pm-perp-momentum/src/runtime/replay.ts
@@ -1,0 +1,315 @@
+import Database from "better-sqlite3";
+
+import { computeStopLossTrigger } from "../risk/stop-loss.js";
+import { ThresholdDetector } from "../signal/threshold.js";
+import { pctToProb } from "./common.js";
+
+interface ReplayArgs {
+  dbPath: string;
+  runId?: string;
+  speed: number;
+  json: boolean;
+}
+
+interface ReplayTick {
+  ts: number;
+  tickKind: "signal" | "mark";
+  signalMid: number;
+  markPrice: number | null;
+}
+
+interface ReplayPosition {
+  entryMarkPrice: number;
+}
+
+interface ReplayRuntimeConfig {
+  entryThresholdPct: number;
+  exitThresholdPct: number;
+  dwellSeconds: number;
+  stopLossPct: number;
+  perpSide: "LONG" | "SHORT";
+  takeProfitTargetsPct: number[];
+}
+
+interface ReplayAction {
+  ts: number;
+  type: "ENTER" | "TAKE_PROFIT" | "STOP_LOSS" | "EXIT";
+  signalMid: number;
+  detail: string;
+}
+
+function parseArgs(argv: string[]): ReplayArgs {
+  const args = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueArgs = new Set(["--state-db", "--run-id", "--replay-speed"]);
+  const flagArgs = new Set(["--json"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (!valueArgs.has(token) && !flagArgs.has(token)) {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (flagArgs.has(token)) {
+      flags.add(token);
+      continue;
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for argument: ${token}`);
+    }
+    args.set(token, value);
+    index += 1;
+  }
+
+  const dbPath = args.get("--state-db");
+  if (!dbPath) {
+    throw new Error("Missing required argument: --state-db <path>");
+  }
+  const speed = Number(args.get("--replay-speed") ?? "1");
+  if (!Number.isFinite(speed) || speed <= 0) {
+    throw new Error("replay-speed must be a positive number.");
+  }
+  return {
+    dbPath,
+    runId: args.get("--run-id"),
+    speed,
+    json: flags.has("--json")
+  };
+}
+
+function resolveRunId(db: Database.Database, runId?: string): string {
+  if (runId) {
+    return runId;
+  }
+  const row = db
+    .prepare("SELECT run_id FROM runs ORDER BY created_at_ms DESC LIMIT 1")
+    .get() as { run_id: string } | undefined;
+  if (!row?.run_id) {
+    throw new Error("No run records are available for replay.");
+  }
+  return row.run_id;
+}
+
+function parseConfig(rawConfig: string): ReplayRuntimeConfig {
+  const cfg = JSON.parse(rawConfig) as Record<string, unknown>;
+  const sideRaw = cfg.perpSide;
+  const perpSide =
+    sideRaw === "SHORT" || sideRaw === "LONG" ? sideRaw : ("LONG" as const);
+  const targetsRaw = cfg.takeProfitTargetsPct;
+  const targets = Array.isArray(targetsRaw)
+    ? targetsRaw.map((item) => Number(item)).filter((item) => Number.isFinite(item))
+    : [1, 2, 3];
+  return {
+    entryThresholdPct: Number(cfg.entryThresholdPct),
+    exitThresholdPct: Number(cfg.exitThresholdPct),
+    dwellSeconds: Number(cfg.dwellSeconds),
+    stopLossPct: Number(cfg.stopLossPct),
+    perpSide,
+    takeProfitTargetsPct: targets.length > 0 ? targets : [1, 2, 3]
+  };
+}
+
+function shouldTakeProfit(
+  side: "LONG" | "SHORT",
+  entryMid: number,
+  signalMid: number,
+  targetPct: number
+): boolean {
+  const ratio = targetPct / 100;
+  if (side === "LONG") {
+    return signalMid >= entryMid * (1 + ratio);
+  }
+  return signalMid <= entryMid * (1 - ratio);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function runReplayCommand(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const db = new Database(args.dbPath, { readonly: true });
+  try {
+    const runId = resolveRunId(db, args.runId);
+    const run = db
+      .prepare("SELECT config_json as configJson FROM runs WHERE run_id = @runId LIMIT 1")
+      .get({ runId }) as { configJson: string } | undefined;
+    if (!run?.configJson) {
+      throw new Error(`Run not found: ${runId}`);
+    }
+
+    const cfg = parseConfig(run.configJson);
+    const ticks = db
+      .prepare(
+        "SELECT ts, tick_kind as tickKind, signal_mid as signalMid, mark_price as markPrice FROM replay_ticks WHERE run_id = @runId ORDER BY ts ASC, id ASC"
+      )
+      .all({ runId }) as ReplayTick[];
+    const positions = db
+      .prepare(
+        "SELECT entry_mark_price as entryMarkPrice FROM positions WHERE run_id = @runId ORDER BY opened_at_ms ASC"
+      )
+      .all({ runId }) as ReplayPosition[];
+    if (ticks.length === 0) {
+      throw new Error(
+        "No replay ticks were stored for this run. Re-run live mode without --no-record-ticks."
+      );
+    }
+
+    const detector = new ThresholdDetector({
+      entryThreshold: pctToProb(cfg.entryThresholdPct),
+      exitThreshold: pctToProb(cfg.exitThresholdPct),
+      dwellMs: cfg.dwellSeconds * 1_000
+    });
+
+    const actions: ReplayAction[] = [];
+    let inPosition = false;
+    let entryMid = 0;
+    let entryMarkBasis = 0;
+    let nextTakeProfitIndex = 0;
+    let stopLossTrigger = 0;
+    let latestMarkPrice: number | null = null;
+    let previousTs = ticks[0]?.ts ?? 0;
+    const positionQueue = positions.map((item) => item.entryMarkPrice);
+
+    for (const tick of ticks) {
+      const tickKind = tick.tickKind === "mark" ? "mark" : "signal";
+      if (tick.markPrice !== null && tick.markPrice !== undefined) {
+        latestMarkPrice = tick.markPrice;
+      }
+
+      if (tickKind === "mark") {
+        if (
+          inPosition &&
+          latestMarkPrice !== null &&
+          ((cfg.perpSide === "LONG" && latestMarkPrice <= stopLossTrigger) ||
+            (cfg.perpSide === "SHORT" && latestMarkPrice >= stopLossTrigger))
+        ) {
+          actions.push({
+            ts: tick.ts,
+            type: "STOP_LOSS",
+            signalMid: tick.signalMid,
+            detail: "stop-loss threshold reached source=mark"
+          });
+          inPosition = false;
+        }
+        previousTs = tick.ts;
+        continue;
+      }
+
+      const event = detector.feed({ ts: tick.ts, mid: tick.signalMid });
+      if (event?.kind === "ENTER" && !inPosition) {
+        inPosition = true;
+        entryMid = event.mid;
+        entryMarkBasis =
+          positionQueue.shift() ?? latestMarkPrice ?? tick.markPrice ?? tick.signalMid;
+        nextTakeProfitIndex = 0;
+        stopLossTrigger = computeStopLossTrigger(
+          entryMarkBasis,
+          cfg.perpSide,
+          cfg.stopLossPct
+        );
+        actions.push({
+          ts: tick.ts,
+          type: "ENTER",
+          signalMid: tick.signalMid,
+          detail: `entry-mid=${entryMid.toFixed(6)} entry-mark=${entryMarkBasis.toFixed(
+            6
+          )} stop-loss-mark=${stopLossTrigger.toFixed(6)}`
+        });
+      }
+
+      if (inPosition) {
+        const usesMarkStopLoss = stopLossTrigger > 1;
+        if (usesMarkStopLoss && latestMarkPrice === null) {
+          previousTs = tick.ts;
+          continue;
+        }
+        const stopLossSource = usesMarkStopLoss
+          ? (latestMarkPrice as number)
+          : tick.signalMid;
+        if (
+          (cfg.perpSide === "LONG" && stopLossSource <= stopLossTrigger) ||
+          (cfg.perpSide === "SHORT" && stopLossSource >= stopLossTrigger)
+        ) {
+          actions.push({
+            ts: tick.ts,
+            type: "STOP_LOSS",
+            signalMid: tick.signalMid,
+            detail: `stop-loss threshold reached source=${
+              usesMarkStopLoss ? "mark" : "signal"
+            }`
+          });
+          inPosition = false;
+        } else {
+          const target = cfg.takeProfitTargetsPct[nextTakeProfitIndex];
+          if (
+            target !== undefined &&
+            shouldTakeProfit(cfg.perpSide, entryMid, tick.signalMid, target)
+          ) {
+            nextTakeProfitIndex += 1;
+            actions.push({
+              ts: tick.ts,
+              type: "TAKE_PROFIT",
+              signalMid: tick.signalMid,
+              detail: `target=${target.toFixed(2)}%`
+            });
+            if (nextTakeProfitIndex >= cfg.takeProfitTargetsPct.length) {
+              inPosition = false;
+            }
+          }
+        }
+      }
+
+      if (event?.kind === "EXIT" && inPosition) {
+        actions.push({
+          ts: tick.ts,
+          type: "EXIT",
+          signalMid: tick.signalMid,
+          detail: "signal exit threshold reached"
+        });
+        inPosition = false;
+      }
+
+      if (!args.json) {
+        const waitMs = Math.max(0, Math.floor((tick.ts - previousTs) / args.speed));
+        if (waitMs > 0 && waitMs <= 1000) {
+          // Keep replay practical while preserving deterministic order.
+          await sleep(waitMs);
+        }
+      }
+      previousTs = tick.ts;
+    }
+
+    const summary = {
+      runId,
+      totalTicks: ticks.length,
+      totalActions: actions.length,
+      entries: actions.filter((item) => item.type === "ENTER").length,
+      exits: actions.filter((item) => item.type === "EXIT").length,
+      stopLosses: actions.filter((item) => item.type === "STOP_LOSS").length,
+      takeProfits: actions.filter((item) => item.type === "TAKE_PROFIT").length
+    };
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify({ summary, actions }, null, 2)}\n`);
+      return;
+    }
+
+    process.stdout.write(
+      `Replay summary run-id=${summary.runId} ticks=${summary.totalTicks} actions=${summary.totalActions}\n`
+    );
+    for (const action of actions) {
+      process.stdout.write(
+        `- ts=${action.ts} type=${action.type} signal=${action.signalMid.toFixed(
+          6
+        )} ${action.detail}\n`
+      );
+    }
+  } finally {
+    db.close();
+  }
+}

--- a/skills/pm-perp-momentum/src/runtime/resolve-market.ts
+++ b/skills/pm-perp-momentum/src/runtime/resolve-market.ts
@@ -1,0 +1,341 @@
+interface ResolveMarketArgs {
+  input: string;
+  json: boolean;
+}
+
+interface FetchLikeResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}
+
+type FetchLike = (url: string, init?: RequestInit) => Promise<FetchLikeResponse>;
+
+interface ResolvedMarket {
+  id: string;
+  slug: string;
+  question: string;
+  active: boolean;
+  tokenIds: string[];
+}
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS = 3;
+
+function toStringValue(input: unknown): string | undefined {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input === "number" || typeof input === "boolean") {
+    return String(input);
+  }
+  return undefined;
+}
+
+function asRecord(input: unknown): Record<string, unknown> | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+  return input as Record<string, unknown>;
+}
+
+function parseJsonPayload<T>(text: string): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error("The API returned invalid JSON.");
+  }
+}
+
+function maybeParseJsonStringArray(input: unknown): string[] {
+  if (typeof input !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function extractSlugFromInput(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Input cannot be empty.");
+  }
+
+  if (!trimmed.includes("://")) {
+    return trimmed;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error("Input URL is not valid.");
+  }
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  const eventIndex = parts.indexOf("event");
+  const eventSlug = eventIndex >= 0 ? parts[eventIndex + 1] : undefined;
+  if (eventSlug) {
+    return decodeURIComponent(eventSlug);
+  }
+
+  const last = parts.at(-1);
+  if (!last) {
+    throw new Error("Could not extract market slug from URL.");
+  }
+  return decodeURIComponent(last);
+}
+
+export function extractTokenIds(rawMarket: unknown): string[] {
+  const market = asRecord(rawMarket);
+  if (!market) {
+    return [];
+  }
+
+  const output = new Set<string>();
+
+  const directArrayCandidates: unknown[] = [
+    market.clobTokenIds,
+    market.clob_token_ids,
+    market.tokenIds,
+    market.token_ids,
+    market.assets_ids
+  ];
+
+  for (const candidate of directArrayCandidates) {
+    if (Array.isArray(candidate)) {
+      for (const id of candidate) {
+        const parsed = toStringValue(id);
+        if (parsed) {
+          output.add(parsed);
+        }
+      }
+    }
+    for (const id of maybeParseJsonStringArray(candidate)) {
+      output.add(String(id));
+    }
+  }
+
+  const tokenObjectsCandidates: unknown[] = [market.tokens, market.outcomes];
+  for (const candidate of tokenObjectsCandidates) {
+    if (!Array.isArray(candidate)) {
+      continue;
+    }
+    for (const item of candidate) {
+      const record = asRecord(item);
+      if (!record) {
+        continue;
+      }
+      const id =
+        record.token_id ??
+        record.tokenId ??
+        record.asset_id ??
+        record.id ??
+        record.outcomeTokenId;
+      if (id !== undefined && id !== null) {
+        const parsed = toStringValue(id);
+        if (parsed) {
+          output.add(parsed);
+        }
+      }
+    }
+  }
+
+  return [...output];
+}
+
+function parseResolveArgs(argv: string[]): ResolveMarketArgs {
+  const args = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueArgs = new Set(["--input"]);
+  const flagArgs = new Set(["--json"]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (!valueArgs.has(token) && !flagArgs.has(token)) {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+    const maybeValue = argv[index + 1];
+    if (flagArgs.has(token)) {
+      flags.add(token);
+      continue;
+    }
+    if (!maybeValue || maybeValue.startsWith("--")) {
+      throw new Error(`Missing value for argument: ${token}`);
+    }
+    args.set(token, maybeValue);
+    index += 1;
+  }
+
+  const input = args.get("--input");
+  if (!input) {
+    throw new Error("Missing required argument: --input <slug-or-url>");
+  }
+
+  return {
+    input,
+    json: flags.has("--json")
+  };
+}
+
+function parseMarketsApiResponse(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload === null || payload === undefined) {
+    return [];
+  }
+  return [payload];
+}
+
+async function fetchJson(
+  fetchFn: FetchLike,
+  url: string
+): Promise<{ ok: boolean; status: number; payload: unknown }> {
+  let lastStatus = 0;
+  let lastPayload: unknown = "";
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetchFn(url, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "pm-perp-momentum/0.1.0"
+        },
+        signal: controller.signal
+      });
+      const raw = await response.text();
+      clearTimeout(timer);
+      if (response.ok) {
+        return {
+          ok: true,
+          status: response.status,
+          payload: parseJsonPayload<unknown>(raw)
+        };
+      }
+      lastStatus = response.status;
+      lastPayload = raw;
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Unknown network error.";
+      lastPayload = message;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 250 * 2 ** (attempt - 1));
+      });
+    }
+  }
+
+  return {
+    ok: false,
+    status: lastStatus,
+    payload: lastPayload
+  };
+}
+
+async function resolveBySlug(
+  slug: string,
+  fetchFn: FetchLike
+): Promise<ResolvedMarket> {
+  const encodedSlug = encodeURIComponent(slug);
+  const candidateUrls = [
+    `https://gamma-api.polymarket.com/markets/slug/${encodedSlug}`,
+    `https://gamma-api.polymarket.com/markets?slug=${encodedSlug}`
+  ];
+
+  let payload: unknown = null;
+  let success = false;
+  let status = 0;
+
+  for (const url of candidateUrls) {
+    const result = await fetchJson(fetchFn, url);
+    status = result.status;
+    if (!result.ok) {
+      continue;
+    }
+    payload = result.payload;
+    success = true;
+    break;
+  }
+
+  if (!success) {
+    throw new Error(
+      `Could not resolve slug "${slug}". API status code: ${status || "unknown"}.`
+    );
+  }
+
+  const markets = parseMarketsApiResponse(payload);
+  if (markets.length === 0) {
+    throw new Error(`No market found for slug "${slug}".`);
+  }
+
+  const market = asRecord(markets[0]);
+  if (!market) {
+    throw new Error("Resolved market has an unexpected response format.");
+  }
+
+  const tokenIds = extractTokenIds(market);
+  if (tokenIds.length === 0) {
+    throw new Error(
+      "Market was found but no CLOB token IDs were detected in the response."
+    );
+  }
+
+  return {
+    id: toStringValue(market.id) ?? "",
+    slug: toStringValue(market.slug) ?? slug,
+    question:
+      toStringValue(market.question) ??
+      toStringValue(market.title) ??
+      "Unknown question",
+    active: Boolean(market.active ?? true),
+    tokenIds
+  };
+}
+
+export async function resolveMarketFromInput(
+  input: string,
+  fetchFn: FetchLike = fetch
+): Promise<ResolvedMarket> {
+  const slug = extractSlugFromInput(input);
+  return await resolveBySlug(slug, fetchFn);
+}
+
+export async function runResolveMarketCommand(argv: string[]): Promise<void> {
+  const args = parseResolveArgs(argv);
+  const resolved = await resolveMarketFromInput(args.input);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(resolved, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(
+    [
+      "Resolved Polymarket market:",
+      `- Question: ${resolved.question}`,
+      `- Slug: ${resolved.slug}`,
+      `- Market ID: ${resolved.id || "n/a"}`,
+      `- Active: ${resolved.active ? "yes" : "no"}`,
+      `- Token IDs (${resolved.tokenIds.length}):`,
+      ...resolved.tokenIds.map((tokenId, index) => `  ${index + 1}. ${tokenId}`),
+      "",
+      "Use one of the token IDs above as --pm-market in dry-run/live commands."
+    ].join("\n")
+  );
+}

--- a/skills/pm-perp-momentum/src/runtime/suggest-markets.ts
+++ b/skills/pm-perp-momentum/src/runtime/suggest-markets.ts
@@ -1,0 +1,200 @@
+import { extractTokenIds } from "./resolve-market.js";
+
+interface SuggestArgs {
+  limit: number;
+  minLiquidity: number;
+  category?: string;
+  json: boolean;
+}
+
+interface MarketSuggestion {
+  slug: string;
+  question: string;
+  active: boolean;
+  volume24h: number;
+  liquidity: number;
+  tokenIds: string[];
+}
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS = 3;
+
+function parseArgs(argv: string[]): SuggestArgs {
+  const args = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueArgs = new Set(["--limit", "--min-liquidity", "--category"]);
+  const flagArgs = new Set(["--json"]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (!valueArgs.has(token) && !flagArgs.has(token)) {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (flagArgs.has(token)) {
+      flags.add(token);
+      continue;
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for argument: ${token}`);
+    }
+    args.set(token, value);
+    index += 1;
+  }
+
+  const limitRaw = Number(args.get("--limit") ?? "10");
+  const minLiquidityRaw = Number(args.get("--min-liquidity") ?? "1000");
+  if (!Number.isInteger(limitRaw) || limitRaw <= 0) {
+    throw new Error("limit must be a positive integer.");
+  }
+  if (!Number.isFinite(minLiquidityRaw) || minLiquidityRaw < 0) {
+    throw new Error("min-liquidity must be a non-negative number.");
+  }
+
+  return {
+    limit: limitRaw,
+    minLiquidity: minLiquidityRaw,
+    category: args.get("--category"),
+    json: flags.has("--json")
+  };
+}
+
+function parseNumber(input: unknown): number {
+  if (typeof input === "number" && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === "string") {
+    const parsed = Number(input);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function asRecord(input: unknown): Record<string, unknown> | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+  return input as Record<string, unknown>;
+}
+
+function normalizeMarket(input: unknown): MarketSuggestion | null {
+  const record = asRecord(input);
+  if (!record) {
+    return null;
+  }
+
+  const tokenIds = extractTokenIds(record);
+  if (tokenIds.length === 0) {
+    return null;
+  }
+
+  return {
+    slug: typeof record.slug === "string" ? record.slug : "",
+    question:
+      typeof record.question === "string"
+        ? record.question
+        : typeof record.title === "string"
+          ? record.title
+          : "Unknown question",
+    active: Boolean(record.active ?? true),
+    volume24h: parseNumber(record.volume24hr ?? record.volume_24hr),
+    liquidity: parseNumber(record.liquidity_num ?? record.liquidity),
+    tokenIds
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchMarkets(url: string): Promise<Response> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "pm-perp-momentum/0.1.0"
+        },
+        signal: controller.signal
+      });
+      clearTimeout(timer);
+      if (response.ok) {
+        return response;
+      }
+      lastError = new Error(
+        `Gamma API request failed with status ${response.status}.`
+      );
+    } catch (error: unknown) {
+      lastError =
+        error instanceof Error ? error : new Error("Unknown network error.");
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(250 * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError ?? new Error("Gamma API request failed.");
+}
+
+export async function runSuggestMarketsCommand(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const query = new URLSearchParams({
+    active: "true",
+    closed: "false",
+    limit: String(Math.max(50, args.limit * 5))
+  });
+  if (args.category) {
+    query.set("tag", args.category);
+  }
+
+  const response = await fetchMarkets(
+    `https://gamma-api.polymarket.com/markets?${query.toString()}`
+  );
+
+  const payload = (await response.json()) as unknown;
+  const list = Array.isArray(payload) ? payload : [payload];
+  const suggestions = list
+    .map((item) => normalizeMarket(item))
+    .filter((item): item is MarketSuggestion => item !== null)
+    .filter((item) => item.active && item.liquidity >= args.minLiquidity)
+    .sort((a, b) => b.volume24h - a.volume24h)
+    .slice(0, args.limit);
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(suggestions, null, 2)}\n`);
+    return;
+  }
+
+  if (suggestions.length === 0) {
+    process.stdout.write(
+      "No active markets matched the current filters. Try lowering min-liquidity.\n"
+    );
+    return;
+  }
+
+  process.stdout.write("Suggested active Polymarket markets:\n");
+  for (const [index, suggestion] of suggestions.entries()) {
+    process.stdout.write(
+      [
+        `${index + 1}. ${suggestion.question}`,
+        `   slug: ${suggestion.slug}`,
+        `   volume24h: ${suggestion.volume24h.toFixed(2)}`,
+        `   liquidity: ${suggestion.liquidity.toFixed(2)}`,
+        `   tokenId[0]: ${suggestion.tokenIds[0] ?? "n/a"}`
+      ].join("\n") + "\n"
+    );
+  }
+}

--- a/skills/pm-perp-momentum/src/runtime/verify-proof.ts
+++ b/skills/pm-perp-momentum/src/runtime/verify-proof.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+
+import Database from "better-sqlite3";
+
+interface VerifyArgs {
+  dbPath: string;
+  runId?: string;
+  json: boolean;
+}
+
+interface EventRow {
+  id: number;
+  runId: string;
+  eventType: string;
+  message: string;
+  payloadJson: string | null;
+  previousHash: string | null;
+  currentHash: string;
+  createdAtMs: number;
+}
+
+function parseArgs(argv: string[]): VerifyArgs {
+  const args = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueArgs = new Set(["--state-db", "--run-id"]);
+  const flagArgs = new Set(["--json"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${token ?? "<empty>"}`);
+    }
+    if (!valueArgs.has(token) && !flagArgs.has(token)) {
+      throw new Error(`Unsupported argument: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (flagArgs.has(token)) {
+      flags.add(token);
+      continue;
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for argument: ${token}`);
+    }
+    args.set(token, value);
+    index += 1;
+  }
+
+  const dbPath = args.get("--state-db");
+  if (!dbPath) {
+    throw new Error("Missing required argument: --state-db <path>");
+  }
+  return {
+    dbPath,
+    runId: args.get("--run-id"),
+    json: flags.has("--json")
+  };
+}
+
+function resolveRunId(db: Database.Database, runId?: string): string {
+  if (runId) {
+    return runId;
+  }
+  const row = db
+    .prepare("SELECT run_id FROM runs ORDER BY created_at_ms DESC LIMIT 1")
+    .get() as { run_id: string } | undefined;
+  if (!row?.run_id) {
+    throw new Error("No run records found in the provided state database.");
+  }
+  return row.run_id;
+}
+
+function hashEvent(previousHash: string, runId: string, row: EventRow): string {
+  return createHash("sha256")
+    .update(
+      [
+        previousHash,
+        runId,
+        row.eventType,
+        row.message,
+        row.payloadJson ?? "",
+        String(row.createdAtMs)
+      ].join("|")
+    )
+    .digest("hex");
+}
+
+export function runVerifyProofCommand(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+  const db = new Database(args.dbPath, { readonly: true });
+  try {
+    const runId = resolveRunId(db, args.runId);
+    const run = db
+      .prepare(
+        "SELECT run_id as runId, mode, fingerprint, config_json as configJson, created_at_ms as createdAtMs FROM runs WHERE run_id = @runId LIMIT 1"
+      )
+      .get({ runId }) as
+      | { runId: string; mode: string; fingerprint: string; configJson: string; createdAtMs: number }
+      | undefined;
+    if (!run) {
+      throw new Error(`Run not found: ${runId}`);
+    }
+
+    const expectedFingerprint = createHash("sha256")
+      .update(`${run.mode}:${run.configJson}`)
+      .digest("hex");
+    const events = db
+      .prepare(
+        "SELECT id, run_id as runId, event_type as eventType, message, payload_json as payloadJson, previous_hash as previousHash, current_hash as currentHash, created_at_ms as createdAtMs FROM events WHERE run_id = @runId ORDER BY id ASC"
+      )
+      .all({ runId }) as EventRow[];
+
+    const issues: string[] = [];
+    let previousHash = "GENESIS";
+    for (const row of events) {
+      if ((row.previousHash ?? "GENESIS") !== previousHash) {
+        issues.push(
+          `Event #${row.id} previous hash mismatch (expected=${previousHash}, actual=${row.previousHash ?? "null"})`
+        );
+      }
+      const recalculated = hashEvent(previousHash, runId, row);
+      if (recalculated !== row.currentHash) {
+        issues.push(
+          `Event #${row.id} current hash mismatch (expected=${recalculated}, actual=${row.currentHash})`
+        );
+      }
+      previousHash = row.currentHash;
+    }
+
+    if (run.fingerprint !== expectedFingerprint) {
+      issues.push(
+        `Run fingerprint mismatch (expected=${expectedFingerprint}, actual=${run.fingerprint})`
+      );
+    }
+
+    const result = {
+      runId,
+      eventCount: events.length,
+      fingerprintValid: run.fingerprint === expectedFingerprint,
+      hashChainValid: issues.length === 0,
+      issues
+    };
+
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return Promise.resolve();
+    }
+
+    if (issues.length === 0) {
+      process.stdout.write(
+        `Proof verification passed: run-id=${runId} events=${events.length} fingerprint=valid hash-chain=valid\n`
+      );
+      return Promise.resolve();
+    }
+
+    process.stdout.write(
+      `Proof verification failed: run-id=${runId} events=${events.length} issues=${issues.length}\n`
+    );
+    for (const issue of issues) {
+      process.stdout.write(`- ${issue}\n`);
+    }
+  } finally {
+    db.close();
+  }
+  return Promise.resolve();
+}

--- a/skills/pm-perp-momentum/src/signal/threshold.ts
+++ b/skills/pm-perp-momentum/src/signal/threshold.ts
@@ -1,0 +1,96 @@
+export interface Tick {
+  ts: number;
+  mid: number;
+}
+
+export interface ThresholdConfig {
+  entryThreshold: number;
+  exitThreshold: number;
+  dwellMs: number;
+}
+
+export type SignalEvent =
+  | { kind: "ENTER"; ts: number; mid: number }
+  | { kind: "EXIT"; ts: number; mid: number };
+
+export class ThresholdDetector {
+  private aboveSince: number | null = null;
+  private inPosition = false;
+
+  public constructor(private readonly config: ThresholdConfig) {
+    this.validateConfig(config);
+  }
+
+  public feed(tick: Tick): SignalEvent | null {
+    if (!this.inPosition) {
+      return this.maybeEnter(tick);
+    }
+    return this.maybeExit(tick);
+  }
+
+  public isInPosition(): boolean {
+    return this.inPosition;
+  }
+
+  public forceInPosition(): void {
+    this.inPosition = true;
+    this.aboveSince = null;
+  }
+
+  private validateConfig(config: ThresholdConfig): void {
+    const fields: Array<[string, number]> = [
+      ["entryThreshold", config.entryThreshold],
+      ["exitThreshold", config.exitThreshold]
+    ];
+
+    for (const [name, value] of fields) {
+      if (value < 0 || value > 1) {
+        throw new Error(`${name} must be between 0 and 1.`);
+      }
+    }
+
+    if (config.exitThreshold >= config.entryThreshold) {
+      throw new Error("exitThreshold must be lower than entryThreshold.");
+    }
+
+    if (!Number.isFinite(config.dwellMs) || config.dwellMs < 0) {
+      throw new Error("dwellMs must be a non-negative finite number.");
+    }
+  }
+
+  private maybeEnter(tick: Tick): SignalEvent | null {
+    if (tick.mid < this.config.entryThreshold) {
+      this.aboveSince = null;
+      return null;
+    }
+
+    this.aboveSince ??= tick.ts;
+
+    if (tick.ts - this.aboveSince < this.config.dwellMs) {
+      return null;
+    }
+
+    this.inPosition = true;
+    this.aboveSince = null;
+
+    return {
+      kind: "ENTER",
+      ts: tick.ts,
+      mid: tick.mid
+    };
+  }
+
+  private maybeExit(tick: Tick): SignalEvent | null {
+    if (tick.mid > this.config.exitThreshold) {
+      return null;
+    }
+
+    this.inPosition = false;
+
+    return {
+      kind: "EXIT",
+      ts: tick.ts,
+      mid: tick.mid
+    };
+  }
+}

--- a/skills/pm-perp-momentum/src/state/store.ts
+++ b/skills/pm-perp-momentum/src/state/store.ts
@@ -1,0 +1,641 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+
+import Database from "better-sqlite3";
+
+export type PositionStatus = "OPEN" | "CLOSED";
+
+export interface StoredPosition {
+  id: string;
+  runId: string;
+  pmMarket: string;
+  signalSide: "YES" | "NO";
+  perpMarket: string;
+  perpSide: "LONG" | "SHORT";
+  notionalUsd: number;
+  leverage: number;
+  sizeProxy: number;
+  avgEntryPrice: number | null;
+  avgExitPrice: number | null;
+  totalFeesUsd: number;
+  filledEntrySize: number;
+  filledExitSize: number;
+  entrySignalMid: number;
+  entryMarkPrice: number;
+  stopLossPct: number;
+  stopLossMarkPrice: number;
+  remainingSize: number;
+  nextTakeProfitIndex: number;
+  takeProfitTargetsJson: string;
+  openedAtMs: number;
+  closedAtMs: number | null;
+  closeReason: string | null;
+  realizedPnlUsd: number | null;
+  status: PositionStatus;
+}
+
+export interface PositionOpenInput {
+  id: string;
+  runId: string;
+  pmMarket: string;
+  signalSide: "YES" | "NO";
+  perpMarket: string;
+  perpSide: "LONG" | "SHORT";
+  notionalUsd: number;
+  leverage: number;
+  sizeProxy: number;
+  avgEntryPrice: number | null;
+  totalFeesUsd: number;
+  filledEntrySize: number;
+  entrySignalMid: number;
+  entryMarkPrice: number;
+  stopLossPct: number;
+  stopLossMarkPrice: number;
+  remainingSize: number;
+  nextTakeProfitIndex: number;
+  takeProfitTargetsJson: string;
+  openedAtMs: number;
+}
+
+export interface EventRow {
+  id: number;
+  runId: string;
+  eventType: string;
+  message: string;
+  payloadJson: string | null;
+  previousHash: string | null;
+  currentHash: string;
+  createdAtMs: number;
+}
+
+export interface TickRow {
+  id: number;
+  runId: string;
+  marketId: string;
+  tickKind: "signal" | "mark";
+  signalMid: number;
+  rawMid: number;
+  ts: number;
+  markPrice: number | null;
+}
+
+export interface RunRecord {
+  runId: string;
+  mode: string;
+  fingerprint: string;
+  configJson: string;
+  label: string | null;
+  createdAtMs: number;
+}
+
+function toStringValue(input: unknown): string | null {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (typeof input === "number" || typeof input === "boolean") {
+    return String(input);
+  }
+  return null;
+}
+
+export class StrategyStateStore {
+  private readonly db: Database.Database;
+  private readonly runId: string;
+  private previousEventHash: string;
+
+  public constructor(
+    dbPath: string,
+    options: { mode: string; config: unknown; runLabel?: string }
+  ) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.pragma("journal_mode = WAL");
+    this.init();
+    this.runId = randomUUID();
+    const configJson = JSON.stringify(options.config);
+    const fingerprint = createHash("sha256")
+      .update(`${options.mode}:${configJson}`)
+      .digest("hex");
+    this.db
+      .prepare(
+        `
+        INSERT INTO runs (run_id, mode, fingerprint, config_json, label, created_at_ms)
+        VALUES (@runId, @mode, @fingerprint, @configJson, @label, @createdAtMs)
+      `
+      )
+      .run({
+        runId: this.runId,
+        mode: options.mode,
+        fingerprint,
+        configJson,
+        label: options.runLabel ?? null,
+        createdAtMs: Date.now()
+      });
+    this.previousEventHash = "GENESIS";
+  }
+
+  public close(): void {
+    this.db.close();
+  }
+
+  public getRunId(): string {
+    return this.runId;
+  }
+
+  public withTransaction<T>(fn: () => T): T {
+    const txn = this.db.transaction(fn);
+    return txn();
+  }
+
+  public appendEvent(
+    eventType: string,
+    message: string,
+    payload: Record<string, unknown> | null = null
+  ): void {
+    const payloadJson = payload ? JSON.stringify(payload) : null;
+    const createdAtMs = Date.now();
+    const currentHash = createHash("sha256")
+      .update(
+        [
+          this.previousEventHash,
+          this.runId,
+          eventType,
+          message,
+          payloadJson ?? "",
+          createdAtMs.toString()
+        ].join("|")
+      )
+      .digest("hex");
+
+    const stmt = this.db.prepare(
+      `
+      INSERT INTO events (
+        run_id, event_type, message, payload_json,
+        previous_hash, current_hash, created_at_ms
+      )
+      VALUES (
+        @runId, @eventType, @message, @payloadJson,
+        @previousHash, @currentHash, @createdAtMs
+      )
+      `
+    );
+    stmt.run({
+      runId: this.runId,
+      eventType,
+      message,
+      payloadJson,
+      previousHash: this.previousEventHash,
+      currentHash,
+      createdAtMs
+    });
+    this.previousEventHash = currentHash;
+  }
+
+  public getOpenPosition(
+    pmMarket: string,
+    perpMarket: string,
+    options: { currentRunOnly?: boolean } = {}
+  ): StoredPosition | null {
+    const stmt = this.db.prepare(
+      `
+      SELECT *
+      FROM positions
+      WHERE pm_market = @pmMarket
+        AND perp_market = @perpMarket
+        AND status = 'OPEN'
+        AND (@currentRunOnly = 0 OR run_id = @runId)
+      ORDER BY opened_at_ms DESC
+      LIMIT 1
+      `
+    );
+    const rowScoped = stmt.get({
+      pmMarket,
+      perpMarket,
+      currentRunOnly: options.currentRunOnly ? 1 : 0,
+      runId: this.runId
+    }) as Record<string, unknown> | undefined;
+    return rowScoped ? this.rowToPosition(rowScoped) : null;
+  }
+
+  public openPosition(input: PositionOpenInput): void {
+    const stmt = this.db.prepare(
+      `
+      INSERT INTO positions (
+        id, run_id, pm_market, signal_side, perp_market, perp_side,
+        notional_usd, leverage, size_proxy,
+        avg_entry_price, total_fees_usd, filled_entry_size, filled_exit_size, avg_exit_price,
+        entry_signal_mid, entry_mark_price, stop_loss_pct, stop_loss_mark_price,
+        remaining_size, next_take_profit_index, take_profit_targets_json,
+        opened_at_ms, status
+      ) VALUES (
+        @id, @runId, @pmMarket, @signalSide, @perpMarket, @perpSide,
+        @notionalUsd, @leverage, @sizeProxy,
+        @avgEntryPrice, @totalFeesUsd, @filledEntrySize, 0, NULL,
+        @entrySignalMid, @entryMarkPrice, @stopLossPct, @stopLossMarkPrice,
+        @remainingSize, @nextTakeProfitIndex, @takeProfitTargetsJson,
+        @openedAtMs, 'OPEN'
+      )
+      `
+    );
+    stmt.run(input);
+  }
+
+  public updatePositionAfterTakeProfit(
+    id: string,
+    nextTakeProfitIndex: number,
+    remainingSize: number
+  ): void {
+    const stmt = this.db.prepare(
+      `
+      UPDATE positions
+      SET next_take_profit_index = @nextTakeProfitIndex,
+          remaining_size = @remainingSize
+      WHERE id = @id
+      `
+    );
+    stmt.run({ id, nextTakeProfitIndex, remainingSize });
+  }
+
+  public closePosition(
+    id: string,
+    reason: string,
+    closedAtMs: number,
+    realizedPnlUsd: number,
+    avgExitPrice: number | null,
+    totalFeesUsd: number,
+    filledExitSize: number
+  ): void {
+    const stmt = this.db.prepare(
+      `
+      UPDATE positions
+      SET status = 'CLOSED',
+          closed_at_ms = @closedAtMs,
+          close_reason = @reason,
+          realized_pnl_usd = @realizedPnlUsd,
+          avg_exit_price = @avgExitPrice,
+          total_fees_usd = @totalFeesUsd,
+          filled_exit_size = @filledExitSize
+      WHERE id = @id
+      `
+    );
+    stmt.run({
+      id,
+      reason,
+      closedAtMs,
+      realizedPnlUsd,
+      avgExitPrice,
+      totalFeesUsd,
+      filledExitSize
+    });
+  }
+
+  public applyPartialClose(
+    id: string,
+    remainingSize: number,
+    totalFeesUsd: number,
+    filledExitSize: number,
+    avgExitPrice: number | null
+  ): void {
+    const stmt = this.db.prepare(
+      `
+      UPDATE positions
+      SET remaining_size = @remainingSize,
+          total_fees_usd = @totalFeesUsd,
+          filled_exit_size = @filledExitSize,
+          avg_exit_price = @avgExitPrice
+      WHERE id = @id
+      `
+    );
+    stmt.run({
+      id,
+      remainingSize,
+      totalFeesUsd,
+      filledExitSize,
+      avgExitPrice
+    });
+  }
+
+  public recordTick(
+    marketId: string,
+    signalMid: number,
+    rawMid: number,
+    ts: number,
+    markPrice: number | null = null,
+    tickKind: "signal" | "mark" = "signal"
+  ): void {
+    this.db
+      .prepare(
+        `
+      INSERT INTO replay_ticks (run_id, market_id, tick_kind, signal_mid, raw_mid, ts, mark_price)
+      VALUES (@runId, @marketId, @tickKind, @signalMid, @rawMid, @ts, @markPrice)
+    `
+      )
+      .run({
+        runId: this.runId,
+        marketId,
+        tickKind,
+        signalMid,
+        rawMid,
+        ts,
+        markPrice
+      });
+  }
+
+  public applyTradeOutcome(outcomePnlUsd: number): {
+    dateKey: string;
+    dailyLossUsd: number;
+    consecutiveLosses: number;
+  } {
+    const dateKey = new Date().toISOString().slice(0, 10);
+    const existing = this.db
+      .prepare(
+        `
+      SELECT daily_loss_usd, consecutive_losses
+      FROM risk_state
+      WHERE date_key = @dateKey
+    `
+      )
+      .get({ dateKey }) as Record<string, unknown> | undefined;
+
+    let dailyLossUsd = existing ? Number(existing.daily_loss_usd) : 0;
+    let consecutiveLosses = existing ? Number(existing.consecutive_losses) : 0;
+    if (outcomePnlUsd < 0) {
+      dailyLossUsd += Math.abs(outcomePnlUsd);
+      consecutiveLosses += 1;
+    } else {
+      consecutiveLosses = 0;
+    }
+
+    this.db
+      .prepare(
+        `
+      INSERT INTO risk_state (date_key, daily_loss_usd, consecutive_losses, updated_at_ms)
+      VALUES (@dateKey, @dailyLossUsd, @consecutiveLosses, @updatedAtMs)
+      ON CONFLICT(date_key) DO UPDATE SET
+        daily_loss_usd = excluded.daily_loss_usd,
+        consecutive_losses = excluded.consecutive_losses,
+        updated_at_ms = excluded.updated_at_ms
+    `
+      )
+      .run({
+        dateKey,
+        dailyLossUsd,
+        consecutiveLosses,
+        updatedAtMs: Date.now()
+      });
+
+    return { dateKey, dailyLossUsd, consecutiveLosses };
+  }
+
+  public getRiskState(dateKey = new Date().toISOString().slice(0, 10)): {
+    dateKey: string;
+    dailyLossUsd: number;
+    consecutiveLosses: number;
+  } {
+    const row = this.db
+      .prepare(
+        `
+      SELECT daily_loss_usd, consecutive_losses
+      FROM risk_state
+      WHERE date_key = @dateKey
+    `
+      )
+      .get({ dateKey }) as Record<string, unknown> | undefined;
+    return {
+      dateKey,
+      dailyLossUsd: row ? Number(row.daily_loss_usd) : 0,
+      consecutiveLosses: row ? Number(row.consecutive_losses) : 0
+    };
+  }
+
+  public listRuns(limit: number): RunRecord[] {
+    return this.db
+      .prepare(
+        `
+      SELECT run_id as runId,
+             mode,
+             fingerprint,
+             config_json as configJson,
+             label,
+             created_at_ms as createdAtMs
+      FROM runs
+      ORDER BY created_at_ms DESC
+      LIMIT @limit
+    `
+      )
+      .all({ limit }) as RunRecord[];
+  }
+
+  public getRun(runId: string): RunRecord | null {
+    const row = this.db
+      .prepare(
+        `
+      SELECT run_id as runId,
+             mode,
+             fingerprint,
+             config_json as configJson,
+             label,
+             created_at_ms as createdAtMs
+      FROM runs
+      WHERE run_id = @runId
+      LIMIT 1
+    `
+      )
+      .get({ runId }) as RunRecord | undefined;
+    return row ?? null;
+  }
+
+  public listTicks(runId: string): TickRow[] {
+    return this.db
+      .prepare(
+        `
+      SELECT id, run_id as runId, market_id as marketId, signal_mid as signalMid, raw_mid as rawMid, ts
+             , mark_price as markPrice, tick_kind as tickKind
+      FROM replay_ticks
+      WHERE run_id = @runId
+      ORDER BY ts ASC, id ASC
+    `
+      )
+      .all({ runId }) as TickRow[];
+  }
+
+  public listEvents(runId: string): EventRow[] {
+    return this.db
+      .prepare(
+        `
+      SELECT id,
+             run_id as runId,
+             event_type as eventType,
+             message,
+             payload_json as payloadJson,
+             previous_hash as previousHash,
+             current_hash as currentHash,
+             created_at_ms as createdAtMs
+      FROM events
+      WHERE run_id = @runId
+      ORDER BY id ASC
+    `
+      )
+      .all({ runId }) as EventRow[];
+  }
+
+  public listPositions(runId: string): StoredPosition[] {
+    const rows = this.db
+      .prepare(
+        `
+      SELECT *
+      FROM positions
+      WHERE run_id = @runId
+      ORDER BY opened_at_ms ASC
+    `
+      )
+      .all({ runId }) as Record<string, unknown>[];
+    return rows.map((row) => this.rowToPosition(row));
+  }
+
+  private init(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS runs (
+        run_id TEXT PRIMARY KEY,
+        mode TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        label TEXT,
+        created_at_ms INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS positions (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        pm_market TEXT NOT NULL,
+        signal_side TEXT NOT NULL,
+        perp_market TEXT NOT NULL,
+        perp_side TEXT NOT NULL,
+        notional_usd REAL NOT NULL,
+        leverage REAL NOT NULL,
+        size_proxy REAL NOT NULL,
+        avg_entry_price REAL,
+        avg_exit_price REAL,
+        total_fees_usd REAL NOT NULL DEFAULT 0,
+        filled_entry_size REAL NOT NULL DEFAULT 0,
+        filled_exit_size REAL NOT NULL DEFAULT 0,
+        entry_signal_mid REAL NOT NULL,
+        entry_mark_price REAL NOT NULL DEFAULT 0,
+        stop_loss_pct REAL NOT NULL,
+        stop_loss_mark_price REAL NOT NULL DEFAULT 0,
+        remaining_size REAL NOT NULL,
+        next_take_profit_index INTEGER NOT NULL,
+        take_profit_targets_json TEXT NOT NULL,
+        opened_at_ms INTEGER NOT NULL,
+        closed_at_ms INTEGER,
+        close_reason TEXT,
+        realized_pnl_usd REAL,
+        status TEXT NOT NULL CHECK (status IN ('OPEN', 'CLOSED'))
+      );
+
+      CREATE TABLE IF NOT EXISTS events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        message TEXT NOT NULL,
+        payload_json TEXT,
+        previous_hash TEXT,
+        current_hash TEXT NOT NULL,
+        created_at_ms INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS replay_ticks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id TEXT NOT NULL,
+        market_id TEXT NOT NULL,
+        tick_kind TEXT NOT NULL DEFAULT 'signal',
+        signal_mid REAL NOT NULL,
+        raw_mid REAL NOT NULL,
+        ts INTEGER NOT NULL,
+        mark_price REAL
+      );
+
+      CREATE TABLE IF NOT EXISTS risk_state (
+        date_key TEXT PRIMARY KEY,
+        daily_loss_usd REAL NOT NULL,
+        consecutive_losses INTEGER NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_positions_lookup
+        ON positions (pm_market, perp_market, status);
+      CREATE INDEX IF NOT EXISTS idx_positions_run
+        ON positions (run_id);
+      CREATE INDEX IF NOT EXISTS idx_events_run
+        ON events (run_id, id);
+      CREATE INDEX IF NOT EXISTS idx_ticks_run
+        ON replay_ticks (run_id, ts);
+    `);
+
+    const alterStatements = [
+      "ALTER TABLE positions ADD COLUMN avg_entry_price REAL",
+      "ALTER TABLE positions ADD COLUMN avg_exit_price REAL",
+      "ALTER TABLE positions ADD COLUMN total_fees_usd REAL NOT NULL DEFAULT 0",
+      "ALTER TABLE positions ADD COLUMN filled_entry_size REAL NOT NULL DEFAULT 0",
+      "ALTER TABLE positions ADD COLUMN filled_exit_size REAL NOT NULL DEFAULT 0",
+      "ALTER TABLE positions ADD COLUMN entry_mark_price REAL NOT NULL DEFAULT 0",
+      "ALTER TABLE positions ADD COLUMN stop_loss_mark_price REAL NOT NULL DEFAULT 0",
+      "ALTER TABLE replay_ticks ADD COLUMN mark_price REAL",
+      "ALTER TABLE replay_ticks ADD COLUMN tick_kind TEXT NOT NULL DEFAULT 'signal'"
+    ];
+    for (const statement of alterStatements) {
+      try {
+        this.db.exec(statement);
+      } catch {
+        // Column already exists.
+      }
+    }
+  }
+
+  private rowToPosition(row: Record<string, unknown>): StoredPosition {
+    return {
+      id: String(row.id),
+      runId: String(row.run_id),
+      pmMarket: String(row.pm_market),
+      signalSide: String(row.signal_side) as "YES" | "NO",
+      perpMarket: String(row.perp_market),
+      perpSide: String(row.perp_side) as "LONG" | "SHORT",
+      notionalUsd: Number(row.notional_usd),
+      leverage: Number(row.leverage),
+      sizeProxy: Number(row.size_proxy),
+      avgEntryPrice:
+        row.avg_entry_price === null || row.avg_entry_price === undefined
+          ? null
+          : Number(row.avg_entry_price),
+      avgExitPrice:
+        row.avg_exit_price === null || row.avg_exit_price === undefined
+          ? null
+          : Number(row.avg_exit_price),
+      totalFeesUsd: Number(row.total_fees_usd ?? 0),
+      filledEntrySize: Number(row.filled_entry_size ?? 0),
+      filledExitSize: Number(row.filled_exit_size ?? 0),
+      entrySignalMid: Number(row.entry_signal_mid),
+      entryMarkPrice: Number(row.entry_mark_price ?? 0),
+      stopLossPct: Number(row.stop_loss_pct),
+      stopLossMarkPrice: Number(row.stop_loss_mark_price ?? 0),
+      remainingSize: Number(row.remaining_size),
+      nextTakeProfitIndex: Number(row.next_take_profit_index),
+      takeProfitTargetsJson: String(row.take_profit_targets_json),
+      openedAtMs: Number(row.opened_at_ms),
+      closedAtMs:
+        row.closed_at_ms === null || row.closed_at_ms === undefined
+          ? null
+          : Number(row.closed_at_ms),
+      closeReason:
+        row.close_reason === null || row.close_reason === undefined
+          ? null
+          : toStringValue(row.close_reason),
+      realizedPnlUsd:
+        row.realized_pnl_usd === null || row.realized_pnl_usd === undefined
+          ? null
+          : Number(row.realized_pnl_usd),
+      status: String(row.status) as PositionStatus
+    };
+  }
+}

--- a/skills/pm-perp-momentum/src/watcher/polymarket-ws.ts
+++ b/skills/pm-perp-momentum/src/watcher/polymarket-ws.ts
@@ -1,0 +1,328 @@
+import { fetchPolymarketMid } from "../execution/adapters.js";
+
+import type {
+  ErrorHandler,
+  PolymarketTick,
+  PolymarketWatcherConfig,
+  StatusHandler,
+  TickHandler
+} from "./types.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_RECONNECT_BASE_MS = 1_000;
+const DEFAULT_RECONNECT_MAX_MS = 30_000;
+
+function asRecord(input: unknown): Record<string, unknown> | null {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return null;
+  }
+  return input as Record<string, unknown>;
+}
+
+function asNumber(input: unknown): number | undefined {
+  if (typeof input === "number" && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === "string" && input.trim().length > 0) {
+    const parsed = Number(input);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function firstOrderPrice(levels: unknown): number | undefined {
+  if (!Array.isArray(levels) || levels.length === 0) {
+    return undefined;
+  }
+
+  const first = (levels as unknown[])[0];
+  if (Array.isArray(first) && first.length > 0) {
+    return asNumber(first[0]);
+  }
+
+  const record = asRecord(first);
+  if (!record) {
+    return undefined;
+  }
+
+  return asNumber(record.price);
+}
+
+export function parsePolymarketTick(
+  marketId: string,
+  payload: unknown
+): PolymarketTick | null {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+
+  const payloadMarketId =
+    (record.market as string | undefined) ??
+    (record.market_id as string | undefined) ??
+    (record.asset_id as string | undefined) ??
+    (record.token_id as string | undefined) ??
+    (record.slug as string | undefined);
+
+  if (payloadMarketId && payloadMarketId !== marketId) {
+    return null;
+  }
+
+  const bestBid =
+    asNumber(record.best_bid) ??
+    asNumber(record.bid) ??
+    firstOrderPrice(record.bids);
+
+  const bestAsk =
+    asNumber(record.best_ask) ??
+    asNumber(record.ask) ??
+    firstOrderPrice(record.asks);
+
+  const directMid =
+    asNumber(record.mid) ??
+    asNumber(record.mid_price) ??
+    asNumber(record.price) ??
+    asNumber(record.p);
+
+  const mid =
+    directMid ??
+    (bestBid !== undefined && bestAsk !== undefined
+      ? (bestBid + bestAsk) / 2
+      : undefined);
+
+  if (mid === undefined || mid < 0 || mid > 1) {
+    return null;
+  }
+
+  return {
+    ts: Date.now(),
+    marketId,
+    bestBid,
+    bestAsk,
+    mid,
+    raw: payload
+  };
+}
+
+function parsePolymarketPayload(payload: unknown): PolymarketTick | null {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+
+  const marketId =
+    (record.market as string | undefined) ??
+    (record.market_id as string | undefined) ??
+    (record.asset_id as string | undefined) ??
+    (record.token_id as string | undefined) ??
+    (record.slug as string | undefined) ??
+    "unknown-market";
+
+  return parsePolymarketTick(marketId, payload);
+}
+
+function computeBackoffMs(
+  attempt: number,
+  baseMs: number,
+  maxMs: number
+): number {
+  const expo = Math.min(maxMs, baseMs * 2 ** Math.max(0, attempt - 1));
+  const jitterFactor = 0.8 + Math.random() * 0.4;
+  return Math.floor(expo * jitterFactor);
+}
+
+export class PolymarketWatcher {
+  private readonly marketId: string;
+  private readonly pollIntervalMs: number;
+  private readonly reconnectBaseMs: number;
+  private readonly reconnectMaxMs: number;
+  private shouldRun = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private pollTimer: NodeJS.Timeout | null = null;
+  private inFlight = false;
+  private readonly tickHandlers = new Set<TickHandler>();
+  private readonly errorHandlers = new Set<ErrorHandler>();
+  private readonly statusHandlers = new Set<StatusHandler>();
+
+  public constructor(config: PolymarketWatcherConfig) {
+    this.marketId = config.marketId;
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.reconnectBaseMs = config.reconnectBaseMs ?? DEFAULT_RECONNECT_BASE_MS;
+    this.reconnectMaxMs = config.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS;
+  }
+
+  public onTick(handler: TickHandler): () => void {
+    this.tickHandlers.add(handler);
+    return () => {
+      this.tickHandlers.delete(handler);
+    };
+  }
+
+  public onError(handler: ErrorHandler): () => void {
+    this.errorHandlers.add(handler);
+    return () => {
+      this.errorHandlers.delete(handler);
+    };
+  }
+
+  public onStatus(handler: StatusHandler): () => void {
+    this.statusHandlers.add(handler);
+    return () => {
+      this.statusHandlers.delete(handler);
+    };
+  }
+
+  public start(): void {
+    if (this.shouldRun) {
+      return;
+    }
+    this.shouldRun = true;
+    this.connect();
+  }
+
+  public stop(): void {
+    this.shouldRun = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.emitStatus({ kind: "disconnected" });
+  }
+
+  private connect(): void {
+    this.reconnectAttempt = 0;
+    this.emitStatus({
+      kind: "connected",
+      url: "polymarket-plugin subprocess polling"
+    });
+    this.scheduleNextPoll(0);
+  }
+
+  private scheduleNextPoll(delayMs: number): void {
+    if (!this.shouldRun) {
+      return;
+    }
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.pollOnce().catch((error: unknown) => {
+        const parsed =
+          error instanceof Error ? error : new Error("Unknown polling error.");
+        this.emitError(parsed);
+        this.scheduleReconnect();
+      });
+    }, delayMs);
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (!this.shouldRun) {
+      return;
+    }
+    if (this.inFlight) {
+      this.scheduleNextPoll(this.pollIntervalMs);
+      return;
+    }
+    this.inFlight = true;
+    try {
+      const payload = await this.fetchMarketPayload();
+      this.reconnectAttempt = 0;
+      this.emitTickIfAny(payload);
+      this.scheduleNextPoll(this.pollIntervalMs);
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  private async fetchMarketPayload(): Promise<unknown> {
+    const quote = await fetchPolymarketMid(this.marketId);
+    return {
+      token_id: this.marketId,
+      best_bid: quote.bestBid ?? undefined,
+      best_ask: quote.bestAsk ?? undefined,
+      mid: quote.mid
+    };
+  }
+
+  private emitTickIfAny(payload: unknown): void {
+    const payloadRecord = asRecord(payload);
+    if (payloadRecord && Array.isArray(payloadRecord.price_changes)) {
+      for (const item of payloadRecord.price_changes) {
+        this.emitTickIfAny(item);
+      }
+      return;
+    }
+
+    const tick = parsePolymarketTick(this.marketId, payload);
+    if (!tick) {
+      const parsed = parsePolymarketPayload(payload);
+      if (parsed && parsed.marketId === this.marketId) {
+        for (const handler of this.tickHandlers) {
+          handler(parsed);
+        }
+      }
+      return;
+    }
+
+    if (tick.marketId !== this.marketId) {
+      // Data came through but references another token.
+      return;
+    }
+
+    if (tick.mid < 0 || tick.mid > 1) {
+      return;
+    }
+
+    for (const handler of this.tickHandlers) {
+      try {
+        handler(tick);
+      } catch (error) {
+        this.emitError(
+          error instanceof Error
+            ? error
+            : new Error("Tick handler threw a non-Error value.")
+        );
+      }
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.shouldRun) {
+      return;
+    }
+
+    this.reconnectAttempt += 1;
+    const waitMs = computeBackoffMs(
+      this.reconnectAttempt,
+      this.reconnectBaseMs,
+      this.reconnectMaxMs
+    );
+
+    this.scheduleNextPoll(waitMs);
+
+    this.emitStatus({
+      kind: "reconnecting",
+      attempt: this.reconnectAttempt,
+      waitMs
+    });
+  }
+
+  private emitError(error: Error): void {
+    for (const handler of this.errorHandlers) {
+      handler(error);
+    }
+  }
+
+  private emitStatus(
+    status: Parameters<StatusHandler>[0]
+  ): void {
+    for (const handler of this.statusHandlers) {
+      handler(status);
+    }
+  }
+}

--- a/skills/pm-perp-momentum/src/watcher/types.ts
+++ b/skills/pm-perp-momentum/src/watcher/types.ts
@@ -1,0 +1,25 @@
+export interface PolymarketTick {
+  ts: number;
+  marketId: string;
+  bestBid?: number;
+  bestAsk?: number;
+  mid: number;
+  raw: unknown;
+}
+
+export interface PolymarketWatcherConfig {
+  marketId: string;
+  pollIntervalMs?: number;
+  reconnectBaseMs?: number;
+  reconnectMaxMs?: number;
+}
+
+export type TickHandler = (tick: PolymarketTick) => void;
+export type ErrorHandler = (error: Error) => void;
+
+export type WatcherStatus =
+  | { kind: "connected"; url: string }
+  | { kind: "disconnected" }
+  | { kind: "reconnecting"; attempt: number; waitMs: number };
+
+export type StatusHandler = (status: WatcherStatus) => void;

--- a/skills/pm-perp-momentum/tests/common.test.ts
+++ b/skills/pm-perp-momentum/tests/common.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRuntimeArgs } from "../src/runtime/common.js";
+
+describe("parseRuntimeArgs", () => {
+  it("applies tx-max preset defaults", () => {
+    const config = parseRuntimeArgs([
+      "--pm-market",
+      "123",
+      "--signal-side",
+      "YES",
+      "--entry-threshold",
+      "70",
+      "--exit-threshold",
+      "60",
+      "--dwell-seconds",
+      "1",
+      "--perp",
+      "ETH",
+      "--side",
+      "LONG",
+      "--notional-usd",
+      "1000",
+      "--leverage",
+      "5",
+      "--stop-loss-pct",
+      "8",
+      "--leaderboard-mode",
+      "tx-max"
+    ]);
+
+    expect(config.entrySlices).toBe(8);
+    expect(config.takeProfitTargetsPct).toEqual([0.4, 0.8, 1.2, 1.6]);
+    expect(config.dwellSeconds).toBeGreaterThanOrEqual(5);
+  });
+
+  it("parses confirm-live and risk-ack flags", () => {
+    const config = parseRuntimeArgs([
+      "--pm-market",
+      "123",
+      "--signal-side",
+      "YES",
+      "--entry-threshold",
+      "70",
+      "--exit-threshold",
+      "60",
+      "--dwell-seconds",
+      "30",
+      "--perp",
+      "ETH",
+      "--side",
+      "LONG",
+      "--notional-usd",
+      "1000",
+      "--leverage",
+      "5",
+      "--stop-loss-pct",
+      "8",
+      "--confirm-live",
+      "--risk-ack",
+      "I acknowledge leveraged trading risk and accept full responsibility."
+    ]);
+
+    expect(config.confirmLive).toBe(true);
+    expect(config.riskAcknowledgement).toContain("accept full responsibility");
+  });
+
+  it("rejects unknown arguments", () => {
+    expect(() =>
+      parseRuntimeArgs([
+        "--pm-market",
+        "123",
+        "--signal-side",
+        "YES",
+        "--entry-threshold",
+        "70",
+        "--exit-threshold",
+        "60",
+        "--dwell-seconds",
+        "30",
+        "--perp",
+        "ETH",
+        "--side",
+        "LONG",
+        "--notional-usd",
+        "1000",
+        "--leverage",
+        "5",
+        "--stop-loss-pct",
+        "8",
+        "--unknown-flag"
+      ])
+    ).toThrow("Unsupported argument");
+  });
+});

--- a/skills/pm-perp-momentum/tests/polymarket-ws.test.ts
+++ b/skills/pm-perp-momentum/tests/polymarket-ws.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePolymarketTick } from "../src/watcher/polymarket-ws.js";
+
+describe("parsePolymarketTick", () => {
+  it("parses direct mid payload", () => {
+    const tick = parsePolymarketTick("fed-cuts", {
+      market: "fed-cuts",
+      mid: 0.71
+    });
+
+    expect(tick).not.toBeNull();
+    expect(tick?.mid).toBe(0.71);
+  });
+
+  it("parses best bid and ask payload", () => {
+    const tick = parsePolymarketTick("fed-cuts", {
+      market: "fed-cuts",
+      best_bid: "0.40",
+      best_ask: "0.44"
+    });
+
+    expect(tick).not.toBeNull();
+    expect(tick?.mid).toBeCloseTo(0.42, 8);
+  });
+
+  it("ignores payload from another market", () => {
+    const tick = parsePolymarketTick("fed-cuts", {
+      market: "other-market",
+      mid: 0.55
+    });
+
+    expect(tick).toBeNull();
+  });
+
+  it("ignores invalid probability values", () => {
+    const tick = parsePolymarketTick("fed-cuts", {
+      market: "fed-cuts",
+      mid: 1.2
+    });
+
+    expect(tick).toBeNull();
+  });
+
+  it("parses token_id based payloads", () => {
+    const tick = parsePolymarketTick("12345", {
+      token_id: "12345",
+      best_bid: "0.22",
+      best_ask: "0.28"
+    });
+
+    expect(tick).not.toBeNull();
+    expect(tick?.mid).toBeCloseTo(0.25, 8);
+  });
+});

--- a/skills/pm-perp-momentum/tests/replay.test.ts
+++ b/skills/pm-perp-momentum/tests/replay.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { runReplayCommand } from "../src/runtime/replay.js";
+import { StrategyStateStore } from "../src/state/store.js";
+
+describe("replay command", () => {
+  it("uses mark-based stop-loss parity when mark ticks are present", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pm-perp-replay-test-"));
+    const dbPath = join(tempDir, "state.sqlite");
+
+    const store = new StrategyStateStore(dbPath, {
+      mode: "live",
+      config: {
+        pmMarket: "token-1",
+        signalSide: "YES",
+        entryThresholdPct: 70,
+        exitThresholdPct: 60,
+        dwellSeconds: 0,
+        perpMarket: "ETH",
+        perpSide: "LONG",
+        notionalUsd: 1000,
+        leverage: 5,
+        stopLossPct: 10,
+        leaderboardMode: "volume-max",
+        entrySlices: 3,
+        takeProfitTargetsPct: [1.25, 2.5, 4],
+        dailyLossLimitUsd: 1000,
+        consecutiveLossLimit: 3,
+        recordTicks: true,
+        resumeOpenPosition: true
+      }
+    });
+
+    store.openPosition({
+      id: randomUUID(),
+      runId: store.getRunId(),
+      pmMarket: "token-1",
+      signalSide: "YES",
+      perpMarket: "ETH",
+      perpSide: "LONG",
+      notionalUsd: 1000,
+      leverage: 5,
+      sizeProxy: 1,
+      avgEntryPrice: 3000,
+      totalFeesUsd: 0,
+      filledEntrySize: 1,
+      entrySignalMid: 0.71,
+      entryMarkPrice: 3000,
+      stopLossPct: 10,
+      stopLossMarkPrice: 2700,
+      remainingSize: 1,
+      nextTakeProfitIndex: 0,
+      takeProfitTargetsJson: JSON.stringify([1.25, 2.5, 4]),
+      openedAtMs: 1
+    });
+    store.recordTick("token-1", 0.71, 0.71, 1, null, "signal");
+    store.recordTick("token-1", 0.71, 0.71, 2, 2690, "mark");
+    store.close();
+
+    let output = "";
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const patchedWrite: typeof process.stdout.write = (chunk: string | Uint8Array) => {
+      output += chunk.toString();
+      return true;
+    };
+    process.stdout.write = patchedWrite;
+
+    try {
+      await runReplayCommand(["--state-db", dbPath, "--json"]);
+    } finally {
+      process.stdout.write = originalWrite;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    const parsed = JSON.parse(output) as {
+      actions: Array<{ type: string; detail: string }>;
+    };
+    expect(parsed.actions.some((item) => item.type === "STOP_LOSS")).toBe(true);
+    expect(parsed.actions.some((item) => item.detail.includes("source=mark"))).toBe(true);
+  });
+});

--- a/skills/pm-perp-momentum/tests/resolve-market.test.ts
+++ b/skills/pm-perp-momentum/tests/resolve-market.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractSlugFromInput,
+  extractTokenIds,
+  resolveMarketFromInput
+} from "../src/runtime/resolve-market.js";
+
+describe("resolve-market helpers", () => {
+  it("extracts slug from raw slug input", () => {
+    expect(extractSlugFromInput("fed-decision-october")).toBe(
+      "fed-decision-october"
+    );
+  });
+
+  it("extracts slug from polymarket event URL", () => {
+    expect(
+      extractSlugFromInput(
+        "https://polymarket.com/event/fed-decision-october?tid=123"
+      )
+    ).toBe("fed-decision-october");
+  });
+
+  it("extracts token ids from mixed market payload", () => {
+    const tokenIds = extractTokenIds({
+      clobTokenIds: ["111", "222"],
+      tokens: [{ token_id: "333" }]
+    });
+    expect(tokenIds).toEqual(["111", "222", "333"]);
+  });
+
+  it("resolves market payload with fetch mock", async () => {
+    const fakeFetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              id: "42",
+              slug: "fed-decision-october",
+              question: "Will the Fed cut rates?",
+              active: true,
+              clobTokenIds: ["1001", "1002"]
+            })
+          )
+      });
+
+    const result = await resolveMarketFromInput(
+      "fed-decision-october",
+      fakeFetch
+    );
+    expect(result.slug).toBe("fed-decision-october");
+    expect(result.tokenIds).toEqual(["1001", "1002"]);
+  });
+});

--- a/skills/pm-perp-momentum/tests/stop-loss.test.ts
+++ b/skills/pm-perp-momentum/tests/stop-loss.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { StopLossManager, computeStopLossTrigger } from "../src/risk/stop-loss.js";
+
+describe("stop-loss manager", () => {
+  it("computes long trigger below entry", () => {
+    const trigger = computeStopLossTrigger(3000, "LONG", 10);
+    expect(trigger).toBeCloseTo(2700, 10);
+  });
+
+  it("computes short trigger above entry", () => {
+    const trigger = computeStopLossTrigger(3000, "SHORT", 10);
+    expect(trigger).toBeCloseTo(3300, 10);
+  });
+
+  it("triggers long stop-loss when mark price drops to trigger", () => {
+    const manager = new StopLossManager({
+      markPriceTrigger: 2700,
+      side: "LONG",
+      stopLossPct: 8
+    });
+
+    expect(manager.shouldTrigger(2701)).toBe(false);
+    expect(manager.shouldTrigger(2700)).toBe(true);
+  });
+
+  it("triggers short stop-loss when mark price rises to trigger", () => {
+    const manager = new StopLossManager({
+      markPriceTrigger: 3300,
+      side: "SHORT",
+      stopLossPct: 8
+    });
+
+    expect(manager.shouldTrigger(3299)).toBe(false);
+    expect(manager.shouldTrigger(3300)).toBe(true);
+  });
+});

--- a/skills/pm-perp-momentum/tests/store.test.ts
+++ b/skills/pm-perp-momentum/tests/store.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { StrategyStateStore } from "../src/state/store.js";
+
+describe("StrategyStateStore", () => {
+  it("writes hash-chained events and risk state", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pm-perp-store-test-"));
+    const dbPath = join(tempDir, "state.sqlite");
+
+    const store = new StrategyStateStore(dbPath, {
+      mode: "test",
+      config: { sample: true }
+    });
+
+    store.appendEvent("event_one", "First event.");
+    store.appendEvent("event_two", "Second event.");
+
+    const runs = store.listRuns(1);
+    expect(runs.length).toBe(1);
+    const runId = runs[0]?.runId;
+    expect(runId).toBeDefined();
+
+    const events = store.listEvents(runId as string);
+    expect(events.length).toBe(2);
+    expect(events[0]?.currentHash).toBeTruthy();
+    expect(events[1]?.previousHash).toBe(events[0]?.currentHash);
+
+    const stateLoss = store.applyTradeOutcome(-50);
+    expect(stateLoss.dailyLossUsd).toBe(50);
+    expect(stateLoss.consecutiveLosses).toBe(1);
+
+    const stateWin = store.applyTradeOutcome(10);
+    expect(stateWin.consecutiveLosses).toBe(0);
+
+    store.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/skills/pm-perp-momentum/tests/threshold.test.ts
+++ b/skills/pm-perp-momentum/tests/threshold.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { ThresholdDetector } from "../src/signal/threshold.js";
+
+describe("ThresholdDetector", () => {
+  it("throws when exit threshold is not below entry threshold", () => {
+    expect(
+      () =>
+        new ThresholdDetector({
+          entryThreshold: 0.7,
+          exitThreshold: 0.7,
+          dwellMs: 30_000
+        })
+    ).toThrow("exitThreshold must be lower than entryThreshold.");
+  });
+
+  it("enters only after threshold dwell time is satisfied", () => {
+    const detector = new ThresholdDetector({
+      entryThreshold: 0.7,
+      exitThreshold: 0.6,
+      dwellMs: 30_000
+    });
+
+    expect(detector.feed({ ts: 1_000, mid: 0.71 })).toBeNull();
+    expect(detector.feed({ ts: 20_000, mid: 0.72 })).toBeNull();
+
+    const signal = detector.feed({ ts: 31_001, mid: 0.73 });
+    expect(signal).toEqual({ kind: "ENTER", ts: 31_001, mid: 0.73 });
+    expect(detector.isInPosition()).toBe(true);
+  });
+
+  it("resets dwell timer if signal drops under entry threshold", () => {
+    const detector = new ThresholdDetector({
+      entryThreshold: 0.8,
+      exitThreshold: 0.7,
+      dwellMs: 10_000
+    });
+
+    expect(detector.feed({ ts: 1_000, mid: 0.81 })).toBeNull();
+    expect(detector.feed({ ts: 5_000, mid: 0.79 })).toBeNull();
+
+    expect(detector.feed({ ts: 6_000, mid: 0.82 })).toBeNull();
+    expect(detector.feed({ ts: 15_000, mid: 0.83 })).toBeNull();
+
+    const signal = detector.feed({ ts: 16_200, mid: 0.84 });
+    expect(signal).toEqual({ kind: "ENTER", ts: 16_200, mid: 0.84 });
+  });
+
+  it("exits only when price crosses exit threshold", () => {
+    const detector = new ThresholdDetector({
+      entryThreshold: 0.65,
+      exitThreshold: 0.55,
+      dwellMs: 0
+    });
+
+    const enter = detector.feed({ ts: 1_000, mid: 0.65 });
+    expect(enter).toEqual({ kind: "ENTER", ts: 1_000, mid: 0.65 });
+
+    expect(detector.feed({ ts: 2_000, mid: 0.56 })).toBeNull();
+    const exit = detector.feed({ ts: 3_000, mid: 0.55 });
+    expect(exit).toEqual({ kind: "EXIT", ts: 3_000, mid: 0.55 });
+    expect(detector.isInPosition()).toBe(false);
+  });
+
+  it("supports immediate entry when dwell is zero", () => {
+    const detector = new ThresholdDetector({
+      entryThreshold: 0.5,
+      exitThreshold: 0.4,
+      dwellMs: 0
+    });
+
+    const signal = detector.feed({ ts: 100, mid: 0.51 });
+    expect(signal).toEqual({ kind: "ENTER", ts: 100, mid: 0.51 });
+  });
+});

--- a/skills/pm-perp-momentum/tests/verify-proof.test.ts
+++ b/skills/pm-perp-momentum/tests/verify-proof.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runVerifyProofCommand } from "../src/runtime/verify-proof.js";
+import { StrategyStateStore } from "../src/state/store.js";
+
+describe("verify-proof command", () => {
+  it("reports valid proof chain in json mode", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pm-perp-verify-test-"));
+    const dbPath = join(tempDir, "state.sqlite");
+    const store = new StrategyStateStore(dbPath, {
+      mode: "test",
+      config: { sample: true }
+    });
+    store.appendEvent("runtime_start", "Started");
+    store.appendEvent("runtime_stop", "Stopped");
+    store.close();
+
+    let output = "";
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const patchedWrite: typeof process.stdout.write = (chunk: string | Uint8Array) => {
+      output += chunk.toString();
+      return true;
+    };
+    process.stdout.write = patchedWrite;
+
+    try {
+      await runVerifyProofCommand(["--state-db", dbPath, "--json"]);
+    } finally {
+      process.stdout.write = originalWrite;
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    const parsed = JSON.parse(output) as {
+      fingerprintValid: boolean;
+      hashChainValid: boolean;
+      issues: string[];
+    };
+    expect(parsed.fingerprintValid).toBe(true);
+    expect(parsed.hashChainValid).toBe(true);
+    expect(parsed.issues).toEqual([]);
+  });
+});

--- a/skills/pm-perp-momentum/tsconfig.json
+++ b/skills/pm-perp-momentum/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"],
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Made-with: Cursor

## Plugin Submission

**Plugin name:** `pm-perp-momentum`  
**Version:** `0.1.0`  
**Type:** `new-plugin`

### Checklist

- [x] `plugin-store lint` passes locally with no errors
- [x] I have read the [Development Guide](../PLUGIN_DEVELOPMENT_GUIDE.md)
- [x] My plugin does NOT use reserved prefixes (`okx-`, `official-`, `plugin-store-`)
- [x] LICENSE file is included
- [x] SKILL.md has YAML frontmatter with `name` and `description`

### What does this plugin do?

`pm-perp-momentum` is a strategy plugin that converts Polymarket probability momentum into Hyperliquid perpetual execution through official Basic Skill plugin orchestration.  
It provides advanced automated risk management (mark-price stop-loss, daily loss kill-switch, and consecutive-loss circuit breaker) with deterministic replay and exportable proof artifacts.  
The strategy is designed for attribution-safe execution with strict `--strategy-id` propagation on all trading write operations.

### Which onchainos commands does it use?

This plugin does not directly invoke `onchainos` CLI subcommands in its core runtime.  
Instead, it is a strategy-category orchestrator that calls dependent plugins (`polymarket-plugin` and `hyperliquid-plugin`) via subprocess execution.

Referenced command paths include:

- `polymarket-plugin market --token-id <id> --json` (with fallback reads such as `price` / `book`)
- `hyperliquid-plugin price --market <market> --json` (with fallback reads such as `mark-price` / `ticker` / `quote`)
- `hyperliquid-plugin order ... --confirm` for entries/exits, including reduce-only closes

### Security Considerations

- This is an `advanced` risk-level trading strategy and may initiate live trades when `live` mode is used.
- Live mode is hard-gated by `--confirm-live` and an exact risk acknowledgment phrase.
- Stop-loss is enforced using Hyperliquid mark price (independent of Polymarket signal availability).
- Daily loss and consecutive-loss circuit breaker protections are persisted in local SQLite state.
- The strategy core does not directly handle wallet private keys; execution is delegated to dependent plugins.
- Utility discovery commands may read public external APIs, while strategy execution/trading paths remain plugin-mediated.
- Deterministic proof integrity is supported via hash-chained event logs and `verify-proof`.

### Testing

Validated locally with the full quality and packaging pipeline:

- `npm run lint`
- `npm run typecheck`
- `npm test` (48/48 passing)
- `npm run build`
- `npm run submission:check`
- `npm run submission:bundle` (strict clean release bundle generation and verification)

Additional coverage includes replay parity checks, proof verification tests, risk logic tests, watcher parsing tests, and state store hash-chain integrity tests.