### PR TITLE
[new-plugin] hyperalpha-adaptive v1.0.0

### DIFF
--- a/skills/hyperalpha-adaptive/.claude-plugin/plugin.json
+++ b/skills/hyperalpha-adaptive/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "hyperalpha-adaptive",
+  "description": "Multi-asset adaptive perpetual strategy skill for Hyperliquid Plugin with dry-run safety, dynamic risk controls, position management, and explicit strategy attribution.",
+  "version": "1.0.0",
+  "author": {
+    "name": "cw",
+    "email": "2100813zyw@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": [
+    "hyperliquid",
+    "perpetuals",
+    "multi-asset",
+    "strategy",
+    "risk-management",
+    "adaptive"
+  ]
+}

--- a/skills/hyperalpha-adaptive/.gitignore
+++ b/skills/hyperalpha-adaptive/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/skills/hyperalpha-adaptive/LICENSE
+++ b/skills/hyperalpha-adaptive/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 cw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/hyperalpha-adaptive/README.md
+++ b/skills/hyperalpha-adaptive/README.md
@@ -1,0 +1,32 @@
+# HyperAlpha Adaptive
+
+HyperAlpha Adaptive is a competition-quality community strategy plugin for Hyperliquid perpetual planning. It is designed to satisfy the OKX plugin-store `docs/FOR-DEVELOPERS.md` requirements for strategy submissions while keeping the trading logic dry-run-first, risk-aware, and attributable through `--strategy-id an25hlq1`.
+
+## Included files
+
+- `plugin.yaml` — plugin metadata and strategy manifest
+- `.claude-plugin/plugin.json` — Claude skill registration metadata
+- `SKILL.md` — agent-facing operating contract
+- `SUMMARY.md` — English marketplace summary
+- `config/` — strategy defaults, supported coins, and risk tiers
+- `scripts/` — CLI entrypoint and strategy engines
+- `tests/` — regression coverage
+
+## Local verification
+
+```bash
+python3 -m py_compile scripts/*.py
+python3 scripts/adaptive_hyperliquid_strategy.py validate-config --config config/default.json
+python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json
+python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json
+python3 -m unittest discover -s tests -v
+```
+
+## Submission notes
+
+- Category is `strategy`
+- Dependent execution plugin is `hyperliquid-plugin`
+- Public external API domain currently declared: `www.okx.com`
+- Live-capable write paths must preserve `--strategy-id an25hlq1`
+- Dry-run should remain the default safety posture
+- No secrets or undeclared external calls should be introduced

--- a/skills/hyperalpha-adaptive/SKILL.md
+++ b/skills/hyperalpha-adaptive/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: hyperalpha-adaptive
+description: "Multi-asset adaptive perpetual strategy skill for Hyperliquid Plugin with dry-run safety, dynamic risk controls, position management, and explicit strategy attribution."
+version: "1.0.0"
+author: "cw"
+license: MIT
+tags:
+  - hyperliquid
+  - perpetuals
+  - multi-asset
+  - strategy
+  - risk-management
+  - adaptive
+---
+
+# HyperAlpha Adaptive
+
+## Overview
+
+HyperAlpha Adaptive is a community-installable Hyperliquid strategy skill for multi-asset perpetual planning across BTC, ETH, SOL, HYPE, XRP, DOGE, BNB, LINK, and AVAX. It produces dry-run-first trade plans, risk-aware action decisions, and Hyperliquid Plugin command templates while preserving explicit strategy attribution through `--strategy-id an25hlq1`.
+
+This skill does not bypass the Hyperliquid Plugin and does not use private exchange APIs for execution. It is designed as a competition-quality strategy submission with release-grade documentation, explicit safety guardrails, and deterministic no-trade fallbacks for unsupported or invalid states.
+
+## Pre-flight Checks
+
+Before using this skill, ensure:
+
+1. The plugin metadata files remain present and consistent: `plugin.yaml`, `.claude-plugin/plugin.json`, `SKILL.md`, `SUMMARY.md`, `README.md`, and `LICENSE`.
+2. The required metadata fields match across files where applicable: `name`, `description`, `version`, `license`, and author identity.
+3. `.claude-plugin/plugin.json` is submission-ready, including `license`, `author`, and useful discovery metadata such as `keywords` (and optionally `homepage` / `repository` before final PR submission).
+4. `SUMMARY.md` stays in English and keeps the store-friendly structure `Overview`, `Prerequisites`, and `Quick Start`.
+5. The strategy plugin metadata is intact in `plugin.yaml`, including:
+   - `category: strategy`
+   - `dependent_plugin` referencing `hyperliquid-plugin`
+   - `risk_level: high`
+   - declared external API domain `www.okx.com`
+6. Python 3 is available for local validation.
+7. The operator understands that `dry_run` is the default safety mode and that any live write action requires explicit user confirmation.
+8. Protective TP/SL may need to be placed separately through the Hyperliquid Plugin flow if bracket support is unavailable.
+9. The project should remain submission-focused: avoid generated artifacts, undeclared external calls, or stale references to deprecated strategy copies.
+
+Run these checks before release or submission:
+
+```bash
+python3 -m py_compile scripts/*.py
+python3 scripts/adaptive_hyperliquid_strategy.py validate-config --config config/default.json
+python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json
+python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json
+python3 -m unittest discover -s tests -v
+```
+
+## Commands
+
+### Validate configuration
+
+```bash
+python3 scripts/adaptive_hyperliquid_strategy.py validate-config --config config/default.json
+```
+
+**When to use**: Before submission, after config edits, or before running strategy evaluation in a fresh environment.
+**Output**: Validation result for `config/default.json`, `config/coins.json`, and `config/risk-tiers.json`.
+**Example**: Use this after changing thresholds, supported coins, or risk tiers.
+
+### Evaluate a single market input
+
+```bash
+python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json
+```
+
+**When to use**: When the user wants a decision for one market at a time.
+**Output**: A single strategy decision including action, safety result, confidence, diagnostics, and a Hyperliquid command template when a live-capable action is allowed.
+**Example**: Evaluate whether ETH should be opened, reduced, scaled in, closed, or observed under the current account and position state.
+
+### Scan multiple markets
+
+```bash
+python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json
+```
+
+**When to use**: When the user wants a ranked multi-asset scan across supported markets.
+**Output**: Ordered results prioritized by action severity and signal score.
+**Example**: Compare BTC, ETH, SOL, HYPE, XRP, DOGE, BNB, LINK, and AVAX to identify the best current opportunity.
+
+### Evaluate or scan with public market fetching
+
+```bash
+python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json --fetch-market
+python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json --fetch-market
+python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json --fetch-market --audit-output /tmp/evaluate-audit.json
+python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json --fetch-market --audit-output /tmp/scan-audit.json
+```
+
+**When to use**: When public OKX swap market data should override the input `market` payload, and optionally when you need a durable audit artifact of fetched/derived state.
+**Output**: Strategy output using public fetched market data where supported. With `--audit-output`, also writes a JSON artifact containing the original request payload, fetched market data, derived market fields, and the final strategy result.
+**Example**: For OKX-supported symbols, the fetched data is used. For unsupported fetches such as `HYPE`, the skill degrades safely to `action="observe"` with no live command template. In audit mode, keep the JSON for post-run debugging or handoff.
+
+**Implementation notes / regression guards**:
+1. In `scan --fetch-market`, requested markets should be resolved from the input payload's `markets` list when present, with fallback to the enabled coin list only when `payload.markets` is absent or empty. Do not reference CLI `args` or a nonexistent `bundle` object inside helper resolution logic. Keep a regression test covering this path so market-fetch scans cannot crash on helper-scope mistakes.
+2. Public fetch is now sourced from OKX swap endpoints, not Binance. Keep metadata and docs aligned with `www.okx.com`, parse `mark-price`, `funding-rate`, and `history-candles` responses with explicit `code == "0"` checks, and sort returned candles by `open_time` before deriving indicators.
+3. In mean-reversion / fade logic, watch for structurally unreachable comparisons when breakout or breakdown thresholds are derived from the same swing extrema being checked. Example anti-pattern: `recent_high >= breakout_up` when `breakout_up = swing_high + positive_buffer`, or `recent_low <= breakdown_dn` when `breakdown_dn = swing_low - positive_buffer`. With a positive buffer or ATR multiple, those predicates cannot become true unless the references come from different time windows or different sources. Prove reachability with simple inequality reasoning first, then confirm empirically with a tiny regression harness over representative candle samples. Keep regression tests that (a) demonstrate the old predicates stay false across normal samples and (b) exercise the corrected fade/rebound branches with explicit re-entry fixtures.
+4. In `--fetch-market` paths, derive `prior_high`, `prior_low`, `probe_high`, and `probe_low` from separated prior/probe candle windows before calling the decision engine. Without those levels, fetched-market inputs can silently lose fade/rebound eligibility even when explicit manual fixtures still pass.
+5. In risk-based sizing, notional can now be reduced by stop distance and an ATR-derived floor in the sizing path may dominate tiny-price assets. For low-priced tier3 fixtures such as DOGE, shrinking ATR alone may not raise size because the implementation clamps ATR to a minimum before deriving stop distance. When writing regression tests, do not assume the default DOGE fixture will still produce `open_long` after sizing changes; instead, use a clearly tradeable fixture (for example a higher price / tighter stop-ratio combination that still reflects tier3 behavior) and assert the intended invariant, such as `tier3 notional < tier1 notional` plus the presence of sizing diagnostics.
+6. Account validation must not reject `free_collateral=0` when an existing position is present. Defensive position-management paths still need to evaluate `reduce`, `close_all`, or normalized `observe` outcomes even when no fresh collateral is available. Keep a regression test for zero free collateral plus an open position so payload validation does not accidentally block position defense flows.
+7. Risk-based sizing should incorporate stop distance instead of relying only on a fixed equity ratio. A robust pattern here is: derive a base target notional from `per_trade_ratio * risk_mult * news position_mult`, compute `stop_distance_usd = atr * stop_mult`, convert that to `stop_distance_ratio = stop_distance_usd / price`, shrink the base target with a bounded volatility scalar such as `target_stop_distance_ratio / (target_stop_distance_ratio + stop_distance_ratio)`, then cap by `per_trade_ratio_max` and free collateral. Surface diagnostics including `stop_distance_usd`, `stop_distance_ratio`, `target_stop_distance_ratio`, `volatility_scalar`, and `risk_budget_usd`. In regression tests, compare two ATR fixtures that both still clear the entry threshold so the assertion isolates sizing behavior rather than signal gating.
+8. `scan` outputs must preserve a consistent ordering contract across both normal and `--fetch-market` paths: `results` should be fully sorted by action priority and then `signal_score`, while `top_opportunities` should contain only actionable items (`open_long`, `open_short`, `scale_in`, `reduce`, `close_all`) when any exist, falling back to the first three sorted results only when no actionable entries are present. Keep a regression test that distinguishes these two expectations so future fetch-path edits do not silently drift from the documented scan behavior.
+9. In `--fetch-market` trend derivation, do not rely only on `price` versus a short SMA window. That underestimates structured advances on OKX hourly data and can suppress valid breakout candidates into `range/no_trade`. Prefer a blended trend feature using whole-window move, short-vs-long average spread, close location within the recent range, and directional consistency of closes; keep a regression test where the old SMA-bias logic would leave `trend_strength < trend_strength_min` but the corrected derivation upgrades the same fetched market into a breakout candidate.
+10. Breakout/breakdown detection must still respect overextension guardrails. Even if fetch-derived trend strength now qualifies a move as directional, overheated long breakouts above `rsi_overbought` and capitulation short breakdowns below `rsi_oversold` should degrade to no-trade rather than opening or promoting a chase entry. Keep a regression test for the overheated fetch-breakout case so future trend improvements do not silently re-enable momentum chasing.
+9. After migrating public fetch to OKX, do not treat passing parser/unit tests as evidence that live fetch-market signals are healthy. Run a live `scan --fetch-market` or per-coin fetch audit across the supported OKX symbols and inspect the derived fields (`price`, `recent_high`, `recent_low`, `atr`, `rsi`, `trend_bias`, `trend_strength`, `prior_*`, `probe_*`) alongside the resulting `action`, `market_regime`, and `signal_score`. A known failure mode is deriving `trend_strength` only from short-horizon SMA displacement, which can produce values near zero on real OKX hourly data and collapse most coins to `market_regime="range"` / `signal_score=32` even though fetch, probe-level derivation, and unit tests all pass. When this happens, treat it as a strategy-feature calibration gap: add a failing regression test for realistic fetched-market trend behavior before changing thresholds or trend-strength logic.
+10. Public fetch should include participation confirmation, not only price/funding/candles. Extend OKX fetch-market support with `rubik/stat/contracts/open-interest-history`, return normalized `oi_history_1h` plus current `oi_usd`, and derive `volume_ratio`, `oi_change_ratio`, and `participation_bias` from fetched candles and OI history before evaluating setups. Keep regression tests that verify parser coverage for the OI endpoint and that fetched-market builds surface these derived fields.
+11. `--fetch-market` audit export is a supported debugging workflow on both `evaluate` and `scan`. Add `--audit-output /path/to/file.json` when you need a durable artifact for handoff or root-cause analysis. For `evaluate`, the audit should capture `input_payload`, `fetch_result`, `derived_market` on success, optional `fetch_error` on failure, and the final `result`. For `scan`, the audit should capture top-level `input_payload`, `validation_errors`, final `result`, and per-coin entries with `request`, `fetch_result`, `fetch_status`, `derived_market` or `fetch_error`, and the per-coin `result`. Keep regression tests that patch `Path.write_text` and assert the audit schema for both commands so future refactors do not silently drop file export behavior.
+12. When adding export-only functionality to this project, follow the user's preferred flow: add targeted failing regression tests first, verify they fail for the intended reason, then implement the feature and rerun both the targeted tests and the full suite. For CLI export/report paths, prefer delivering long handoff material as a file instead of pasting large blobs in chat.
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Input payload validation failed.` | Missing, invalid, NaN, Infinity, or negative values in account / market / position fields | Fix the payload and rerun `evaluate` or `scan`. |
+| `market_fetch_not_supported_for_coin` | Public fetch requested for a coin not supported by the OKX swap fetcher | Return a safe observe result and do not generate a live execution plan. |
+| `no_trade_input_state` | Public market fetch or derived market state is incomplete | Keep `dry_run=true`, inspect the input or fetch source, and retry only after data is valid. |
+| Unsupported coin result | Coin is outside the strategy whitelist for live execution | Return `action="observe"` and no command template. |
+| Session loss / session action guardrail hit | Risk controls block new entries or scale-ins | Allow only safer outcomes such as `reduce` or `close_all` where applicable. |
+
+## Security Notices
+
+- This is a **high-risk strategy plugin** intended for derivatives planning and must be treated as an advanced trading workflow.
+- Default behavior is **dry-run first**. Any live write action requires explicit user confirmation.
+- Every live write path must preserve `--strategy-id an25hlq1` for attribution.
+- The skill must execute through `hyperliquid-plugin`; it must not bypass the dependent plugin with private exchange APIs.
+- Stop-loss, session loss caps, action-count caps, and notional guardrails are part of the safety design and must not be removed casually.
+- Plans may include take-profit and stop-loss levels, but those levels are strategy outputs, not proof that protective orders have already been placed.
+- No secrets, private keys, or undeclared external API calls may be committed in this project.
+
+## Additional Notes
+
+### Decision normalization
+
+- `no_trade` is a safe result, not an action.
+- Internal `hold` logic is normalized outward to `observe`.
+- `halt_new_entries` is a risk-state output, not a trading command.
+- Unsupported coins return `action="observe"` and `safe_result="unsupported_coin"` with no command template.
+- Session loss and per-session action caps can block new entries and scale-ins while still allowing `reduce` or `close_all`.
+
+### Project layout
+
+- `config/default.json` — strategy defaults and thresholds
+- `config/coins.json` — supported coins, tiers, and risk multipliers
+- `config/risk-tiers.json` — shared per-tier policy
+- `scripts/adaptive_hyperliquid_strategy.py` — CLI entrypoint
+- `scripts/input_adapter.py` — input adaptation layer
+- `scripts/decision_engine.py` — decision policy and scan logic
+- `scripts/market_engine.py` — ATR / RSI / bands helpers
+- `scripts/risk_engine.py` — sizing and risk policy
+- `scripts/position_engine.py` — open-position management
+- `scripts/execution_mapper.py` — Hyperliquid command templates
+- `scripts/validators.py` — config and payload validation
+- `tests/test_strategy.py` — regression suite
+
+### Verification reminders
+
+- Confirm every live template still contains `strategy-id`.
+- Confirm `SUMMARY.md` stays in English with `Overview`, `Prerequisites`, and `Quick Start`.
+- Confirm the competition submission quality bar remains intact after every change.

--- a/skills/hyperalpha-adaptive/SUMMARY.md
+++ b/skills/hyperalpha-adaptive/SUMMARY.md
@@ -1,0 +1,32 @@
+# hyperalpha-adaptive
+
+## Overview
+
+HyperAlpha Adaptive is a multi-asset Hyperliquid perpetual strategy plugin that evaluates market state, position state, and account risk before producing dry-run-first trading plans.
+
+Core operations:
+
+- Evaluate a single market and return an action such as `open_long`, `open_short`, `reduce`, `scale_in`, `close_all`, or `observe`
+- Scan multiple supported markets and rank the best opportunities by action priority and signal score
+- Generate Hyperliquid Plugin command templates with explicit strategy attribution through `--strategy-id an25hlq1`
+- Enforce risk-aware no-trade fallbacks for invalid payloads, unsupported coins, market-fetch failures, and session guardrail breaches
+
+Tags: `hyperliquid` `perpetuals` `strategy` `risk-management` `adaptive`
+
+## Prerequisites
+
+- Python 3 available for local validation and execution
+- Supported venue: Hyperliquid perpetuals via the dependent `hyperliquid-plugin`
+- Supported coins for live-capable planning: BTC, ETH, SOL, HYPE, XRP, DOGE, BNB, LINK, AVAX
+- Public market fetch source declared in metadata: `www.okx.com`
+- Dry-run mode should remain the default operating mode
+- Explicit user confirmation is required before any live write action
+- Protective TP/SL may need to be placed separately if the execution flow does not support bracket orders
+
+## Quick Start
+
+1. **Validate the configuration**: Run `python3 scripts/adaptive_hyperliquid_strategy.py validate-config --config config/default.json` to confirm the config bundle is internally consistent.
+2. **Run a single evaluation**: Use `python3 scripts/adaptive_hyperliquid_strategy.py evaluate --config config/default.json --input examples/single_evaluate_input.json` to inspect one market decision.
+3. **Run a market scan**: Use `python3 scripts/adaptive_hyperliquid_strategy.py scan --config config/default.json --input examples/scan_input.json` to compare multiple markets and rank opportunities.
+4. **Optionally fetch public market data**: Add `--fetch-market` to `evaluate` or `scan` when you want public OKX swap market data to override the input market block for supported symbols.
+5. **Review safety before execution**: Only consider a live action after confirming the result, the strategy attribution flag, and the risk controls such as stop-loss and session guardrails.

--- a/skills/hyperalpha-adaptive/config/coins.json
+++ b/skills/hyperalpha-adaptive/config/coins.json
@@ -1,0 +1,11 @@
+{
+  "BTC": {"tier": "tier1", "risk_mult": 1.0, "enabled": true},
+  "ETH": {"tier": "tier1", "risk_mult": 1.0, "enabled": true},
+  "SOL": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "HYPE": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "XRP": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "BNB": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "LINK": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "AVAX": {"tier": "tier2", "risk_mult": 0.7, "enabled": true},
+  "DOGE": {"tier": "tier3", "risk_mult": 0.45, "enabled": true}
+}

--- a/skills/hyperalpha-adaptive/config/default.json
+++ b/skills/hyperalpha-adaptive/config/default.json
@@ -1,0 +1,101 @@
+{
+  "strategy_id": "an25hlq1",
+  "dry_run_default": true,
+  "must_execute_via": "Hyperliquid Plugin / Onchain OS Agentic Wallet",
+  "risk": {
+    "per_trade_ratio": 0.3,
+    "per_trade_ratio_max": 0.8,
+    "soft_loss_pct": 0.02,
+    "emergency_loss_pct": 0.04,
+    "session_loss_limit_pct": 0.06,
+    "max_scaleins": 1,
+    "max_actions_per_session": 3,
+    "min_notional_usd": 10
+  },
+  "band_params": {
+    "breakout_mult": 0.3,
+    "breakdown_mult": 0.3,
+    "stop_mult": 1.3,
+    "take_profit_mult": 2.2
+  },
+  "thresholds": {
+    "trend_strength_min": 0.55,
+    "rsi_overbought": 74,
+    "rsi_oversold": 26,
+    "rsi_long_max": 71,
+    "rsi_short_min": 29,
+    "funding_hot_long": 0.0009,
+    "funding_cold_short": -0.0009,
+    "funding_hot_short": 0.0009,
+    "funding_cold_long": -0.0009,
+    "atr_ratio_min": 0.0005,
+    "atr_ratio_max": 0.08
+  },
+  "position_rules": {
+    "reduce_fraction": 0.5,
+    "close_fraction": 1.0,
+    "reduce_giveback_pct": 0.35,
+    "close_giveback_pct": 0.6
+  },
+  "scoring": {
+    "trend": 25,
+    "breakout": 20,
+    "atr": 15,
+    "rsi": 15,
+    "funding": 10,
+    "position": 10,
+    "participation": 10,
+    "news_max_penalty": 10
+  },
+  "news_risk": {
+    "none": {
+      "score_adjustment": 0,
+      "position_mult": 1.0,
+      "allow_new_entries": true,
+      "allow_scale_in": true
+    },
+    "low": {
+      "score_adjustment": -1,
+      "position_mult": 1.0,
+      "allow_new_entries": true,
+      "allow_scale_in": true
+    },
+    "medium": {
+      "score_adjustment": -3,
+      "position_mult": 0.85,
+      "open_score_threshold_adjustment": 2,
+      "allow_new_entries": true,
+      "allow_scale_in": true
+    },
+    "high": {
+      "score_adjustment": -5,
+      "position_mult": 0.7,
+      "open_score_threshold_adjustment": 4,
+      "allow_new_entries": true,
+      "allow_scale_in": false
+    },
+    "extreme": {
+      "score_adjustment": -10,
+      "position_mult": 0.5,
+      "open_score_threshold_adjustment": 100,
+      "allow_new_entries": false,
+      "allow_scale_in": false,
+      "allowed_actions": [
+        "reduce",
+        "close_all",
+        "observe",
+        "none"
+      ]
+    }
+  },
+  "supported_actions": [
+    "open_long",
+    "open_short",
+    "scale_in",
+    "reduce",
+    "close_all",
+    "halt_new_entries",
+    "observe",
+    "none"
+  ]
+}

--- a/skills/hyperalpha-adaptive/config/risk-tiers.json
+++ b/skills/hyperalpha-adaptive/config/risk-tiers.json
@@ -1,0 +1,5 @@
+{
+  "tier1": {"name": "Tier 1", "coins": ["BTC", "ETH"], "min_signal_score": 70},
+  "tier2": {"name": "Tier 2", "coins": ["SOL", "HYPE", "XRP", "BNB", "LINK", "AVAX"], "min_signal_score": 75},
+  "tier3": {"name": "Tier 3", "coins": ["DOGE"], "min_signal_score": 80}
+}

--- a/skills/hyperalpha-adaptive/examples/scan_input.json
+++ b/skills/hyperalpha-adaptive/examples/scan_input.json
@@ -1,0 +1,46 @@
+{
+  "account": {
+    "equity": 1000,
+    "free_collateral": 900,
+    "session_loss_pct": 0.01,
+    "session_actions": 0
+  },
+  "markets": [
+    {
+      "coin": "BTC",
+      "price": 70520,
+      "recent_high": 70460,
+      "recent_low": 69340,
+      "atr": 60,
+      "rsi": 64,
+      "funding_rate": 0.0002,
+      "trend_bias": 0.91,
+      "trend_strength": 0.86,
+      "news_risk": "none"
+    },
+    {
+      "coin": "SOL",
+      "price": 186,
+      "recent_high": 184.5,
+      "recent_low": 176,
+      "atr": 2.4,
+      "rsi": 68,
+      "funding_rate": 0.0004,
+      "trend_bias": 0.58,
+      "trend_strength": 0.66,
+      "news_risk": "low"
+    },
+    {
+      "coin": "DOGE",
+      "price": 0.182,
+      "recent_high": 0.180,
+      "recent_low": 0.169,
+      "atr": 0.004,
+      "rsi": 76,
+      "funding_rate": 0.0007,
+      "trend_bias": 0.61,
+      "trend_strength": 0.60,
+      "news_risk": "medium"
+    }
+  ]
+}

--- a/skills/hyperalpha-adaptive/examples/single_evaluate_input.json
+++ b/skills/hyperalpha-adaptive/examples/single_evaluate_input.json
@@ -1,0 +1,20 @@
+{
+  "account": {
+    "equity": 1000,
+    "free_collateral": 850,
+    "session_loss_pct": 0.01,
+    "session_actions": 0
+  },
+  "market": {
+    "coin": "ETH",
+    "price": 3260,
+    "recent_high": 3225,
+    "recent_low": 3090,
+    "atr": 28,
+    "rsi": 63,
+    "funding_rate": 0.0002,
+    "trend_bias": 0.84,
+    "trend_strength": 0.79,
+    "news_risk": "low"
+  }
+}

--- a/skills/hyperalpha-adaptive/plugin.yaml
+++ b/skills/hyperalpha-adaptive/plugin.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+name: hyperalpha-adaptive
+version: "1.0.0"
+description: "Multi-asset adaptive perpetual strategy skill for Hyperliquid Plugin with dry-run safety, dynamic risk controls, position management, and explicit strategy attribution."
+author:
+  name: "cw"
+  github: "AN25235"
+  email: "2100813zyw@gmail.com"
+license: MIT
+category: strategy
+type: community-developer
+tags:
+  - hyperliquid
+  - perpetuals
+  - multi-asset
+  - strategy
+  - risk-management
+  - adaptive
+
+dependent_plugin:
+  - name: hyperliquid-plugin
+    version: "^0.3.9"
+
+risk_level: high
+supported_venues:
+  - hyperliquid
+
+components:
+  skill:
+    dir: "."
+
+api_calls:
+  - "www.okx.com"

--- a/skills/hyperalpha-adaptive/references/input-schema.md
+++ b/skills/hyperalpha-adaptive/references/input-schema.md
@@ -1,0 +1,66 @@
+# Input Schema
+
+## `evaluate`
+
+```json
+{
+  "account": {
+    "equity": 1000,
+    "free_collateral": 700,
+    "session_loss_pct": 0.01,
+    "session_actions": 0
+  },
+  "market": {
+    "coin": "ETH",
+    "price": 3200,
+    "recent_high": 3180,
+    "recent_low": 3085,
+    "atr": 42,
+    "rsi": 61,
+    "funding_rate": 0.0002,
+    "trend_bias": 0.72,
+    "trend_strength": 0.66,
+    "news_risk": "low"
+  },
+  "position": {
+    "side": "long",
+    "entry_price": 3110,
+    "notional_usd": 300,
+    "unrealized_pnl": 28,
+    "peak_unrealized_pnl": 41,
+    "scale_ins_used": 0
+  }
+}
+```
+
+## `scan`
+
+```json
+{
+  "account": {...},
+  "markets": [{...}, {...}],
+  "positions": {
+    "BTC": {...},
+    "ETH": {...}
+  }
+}
+```
+
+## Notes
+
+- `no_trade` is returned only through `safe_result`, not as an action.
+- `hold` is an internal concept and is normalized outward to `observe`.
+- Unsupported coins return `action="observe"` with `safe_result="unsupported_coin"`.
+- `halt_new_entries` is a risk-state output with no live command template.
+- Signal-bearing results can also expose `upper_band`, `lower_band`, and `component_scores` for diagnostics.
+- `profit_giveback` / `position_risk` outcomes include explicit metrics such as `profit_giveback_pct` or `loss_pct_equity`.
+- `scale_in` outcomes include `current_notional_usd` and `post_scale_in_notional_usd` so the resulting size is visible before execution.
+
+
+## TP/SL Post-execution Note
+
+Open-long and open-short plans may include `take_profit`, `stop_loss`, and `post_execution_steps`.
+
+The `take_profit` and `stop_loss` levels are advisory risk levels in the strategy plan. They do not mean protective orders have already been placed.
+
+The user or agent must set protective TP/SL through Hyperliquid Plugin if the installed plugin supports bracket or protective orders. If the plugin flow does not support TP/SL orders, the user must manually confirm the risk before live execution.

--- a/skills/hyperalpha-adaptive/scripts/__init__.py
+++ b/skills/hyperalpha-adaptive/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Adaptive Hyperliquid Strategy package."""

--- a/skills/hyperalpha-adaptive/scripts/adaptive_hyperliquid_strategy.py
+++ b/skills/hyperalpha-adaptive/scripts/adaptive_hyperliquid_strategy.py
@@ -1,0 +1,623 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from decision_engine import evaluate_market, scan_markets
+from input_adapter import normalize_strategy_input_with_errors
+from market_fetcher import fetch_public_market_data
+from validators import (
+    load_json,
+    normalize_input_payload,
+    validate_account,
+    validate_position,
+    validate_config_bundle,
+)
+
+_ACTION_PRIORITY = {
+    "open_long": 5,
+    "open_short": 5,
+    "scale_in": 4,
+    "reduce": 3,
+    "close_all": 3,
+    "halt_new_entries": 2,
+    "observe": 1,
+    "none": 0,
+}
+
+
+def load_bundle(config_path: str | Path) -> Dict[str, Any]:
+    config_path = Path(config_path).resolve()
+    root = config_path.parent.parent
+    config = load_json(config_path)
+    coins = load_json(root / "config" / "coins.json")
+    tiers = load_json(root / "config" / "risk-tiers.json")
+    return {"config": config, "coins": coins, "tiers": tiers}
+
+
+def _clip(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return number if math.isfinite(number) else default
+
+
+def _extract_coin(payload: Dict[str, Any]) -> str:
+    coin = payload.get("coin")
+    if coin is None and isinstance(payload.get("market"), dict):
+        coin = payload["market"].get("coin")
+    if coin is None:
+        coin = payload.get("symbol")
+    if not isinstance(coin, str) or not coin.strip():
+        return ""
+    return coin.strip().upper()
+
+
+def _compute_atr(candles: List[Dict[str, Any]], period: int = 14) -> float:
+    if not candles:
+        return 0.0
+    true_ranges: List[float] = []
+    previous_close: Optional[float] = None
+    for candle in candles:
+        high = _safe_float(candle.get("high"))
+        low = _safe_float(candle.get("low"))
+        close = _safe_float(candle.get("close"))
+        if high <= 0 or low <= 0 or close <= 0:
+            continue
+        if previous_close is None:
+            tr = high - low
+        else:
+            tr = max(high - low, abs(high - previous_close), abs(low - previous_close))
+        true_ranges.append(max(tr, 0.0))
+        previous_close = close
+    window = true_ranges[-period:] if true_ranges else []
+    if not window:
+        last_close = _safe_float(candles[-1].get("close"), default=0.0)
+        return max(last_close * 0.01, 0.01)
+    atr = sum(window) / len(window)
+    return max(atr, 0.01)
+
+
+def _compute_rsi(candles: List[Dict[str, Any]], period: int = 14) -> float:
+    closes = [_safe_float(candle.get("close"), default=0.0) for candle in candles]
+    closes = [value for value in closes if value > 0]
+    if len(closes) < 2:
+        return 50.0
+    deltas = [current - previous for previous, current in zip(closes[:-1], closes[1:])]
+    window = deltas[-period:] if deltas else []
+    if not window:
+        return 50.0
+    gains = [delta for delta in window if delta > 0]
+    losses = [-delta for delta in window if delta < 0]
+    avg_gain = sum(gains) / len(window)
+    avg_loss = sum(losses) / len(window)
+    if avg_loss == 0:
+        return 100.0 if avg_gain > 0 else 50.0
+    rs = avg_gain / avg_loss
+    rsi = 100.0 - (100.0 / (1.0 + rs))
+    return round(_clip(rsi, 0.0, 100.0), 4)
+
+
+def _derive_probe_levels(closed_candles: List[Dict[str, Any]]) -> Dict[str, float]:
+    if not closed_candles:
+        return {}
+
+    lookback = closed_candles[-min(len(closed_candles), 12):]
+    probe_span = min(4, max(1, len(lookback) // 2))
+    probe_window = lookback[-probe_span:]
+    prior_window = lookback[:-probe_span]
+
+    if not prior_window and len(lookback) > 1:
+        prior_window = lookback[:-1]
+
+    probe_high = max(_safe_float(candle.get("high"), default=0.0) for candle in probe_window)
+    probe_low = min(_safe_float(candle.get("low"), default=0.0) for candle in probe_window)
+
+    if prior_window:
+        prior_high = max(_safe_float(candle.get("high"), default=0.0) for candle in prior_window)
+        prior_low = min(_safe_float(candle.get("low"), default=0.0) for candle in prior_window)
+    else:
+        prior_high = probe_high
+        prior_low = probe_low
+
+    if prior_high <= 0:
+        prior_high = probe_high
+    if prior_low <= 0:
+        prior_low = probe_low
+
+    return {
+        "prior_high": prior_high,
+        "prior_low": prior_low,
+        "probe_high": max(probe_high, prior_high),
+        "probe_low": min(probe_low, prior_low),
+    }
+
+
+def _derive_participation_features(
+    closed_candles: List[Dict[str, Any]],
+    oi_history: List[Dict[str, Any]],
+    trend_bias: float,
+) -> Dict[str, float]:
+    volumes = [_safe_float(candle.get("volume"), default=0.0) for candle in closed_candles]
+    volumes = [value for value in volumes if value >= 0]
+    if volumes:
+        lookback = volumes[-min(len(volumes), 12):]
+        latest_volume = lookback[-1]
+        average_volume = sum(lookback) / len(lookback)
+        volume_ratio = latest_volume / max(average_volume, 1e-9)
+    else:
+        volume_ratio = 1.0
+
+    oi_values = [_safe_float(row.get("oi_usd"), default=0.0) for row in oi_history if _safe_float(row.get("oi_usd"), default=0.0) > 0]
+    if len(oi_values) >= 2:
+        oi_change_ratio = (oi_values[-1] - oi_values[0]) / max(oi_values[0], 1e-9)
+    else:
+        oi_change_ratio = 0.0
+
+    direction = 0.0
+    if trend_bias > 0:
+        direction = 1.0
+    elif trend_bias < 0:
+        direction = -1.0
+
+    volume_signal = _clip((volume_ratio - 1.0) / 1.2, -1.0, 1.0)
+    oi_signal = _clip(oi_change_ratio / 0.15, -1.0, 1.0)
+    participation_bias = _clip(direction * (0.6 * volume_signal + 0.4 * oi_signal), -1.0, 1.0)
+
+    return {
+        "volume_ratio": round(max(volume_ratio, 0.0), 4),
+        "oi_change_ratio": round(oi_change_ratio, 4),
+        "participation_bias": round(participation_bias, 4),
+    }
+
+
+def _derive_trend_features(closed_candles: List[Dict[str, Any]], price: float) -> Tuple[float, float]:
+    closes = [_safe_float(candle.get("close"), default=0.0) for candle in closed_candles]
+    highs = [_safe_float(candle.get("high"), default=0.0) for candle in closed_candles]
+    lows = [_safe_float(candle.get("low"), default=0.0) for candle in closed_candles]
+    closes = [value for value in closes if value > 0]
+    highs = [value for value in highs if value > 0]
+    lows = [value for value in lows if value > 0]
+    if not closes or not highs or not lows or price <= 0:
+        return 0.0, 0.0
+
+    recent_high = max(highs)
+    recent_low = min(lows)
+    basis = max(recent_high - recent_low, price * 0.01, 1e-9)
+
+    first_close = closes[0]
+    last_close = closes[-1]
+    short_span = min(4, len(closes))
+    long_span = min(12, len(closes))
+    short_sma = sum(closes[-short_span:]) / short_span
+    long_sma = sum(closes[-long_span:]) / long_span
+
+    move = (last_close - first_close) / basis
+    spread = (short_sma - long_sma) / basis
+    close_location = _clip(((price - recent_low) / basis) * 2.0 - 1.0, -1.0, 1.0)
+
+    deltas = [current - previous for previous, current in zip(closes[:-1], closes[1:])]
+    if deltas:
+        positive_steps = sum(1 for delta in deltas if delta > 0)
+        negative_steps = sum(1 for delta in deltas if delta < 0)
+        consistency = (positive_steps - negative_steps) / len(deltas)
+    else:
+        consistency = 0.0
+
+    raw_bias = 0.4 * move + 0.35 * (spread * 1.6) + 0.2 * close_location + 0.05 * consistency
+    trend_bias = _clip(raw_bias, -1.0, 1.0)
+
+    aligned_strength = 0.0
+    for value, weight in ((move, 0.4), (spread * 1.6, 0.35), (close_location, 0.2), (consistency, 0.05)):
+        if trend_bias == 0.0 or value == 0.0 or (value > 0) == (trend_bias > 0):
+            aligned_strength += abs(value) * weight
+        else:
+            aligned_strength += max(0.0, 0.4 - abs(value)) * weight * 0.2
+
+    trend_strength = _clip(aligned_strength, 0.0, 1.0)
+    return trend_bias, trend_strength
+
+
+def _build_market_from_fetch(fetch_result: Dict[str, Any], requested_coin: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    if not fetch_result.get("ok"):
+        return None, str(fetch_result.get("reason", "no_trade_input_state"))
+    candles = fetch_result.get("candles_1h")
+    if not isinstance(candles, list) or not candles:
+        return None, "no_trade_input_state"
+    price = _safe_float(fetch_result.get("price"), default=0.0)
+    if price <= 0:
+        return None, "no_trade_input_state"
+    # Exclude the last candle when enough candles are present; it may still be forming.
+    closed_candles = candles[:-1] if len(candles) > 2 else candles
+    highs = [_safe_float(candle.get("high"), default=0.0) for candle in closed_candles]
+    lows = [_safe_float(candle.get("low"), default=0.0) for candle in closed_candles]
+    highs = [value for value in highs if value > 0]
+    lows = [value for value in lows if value > 0]
+    if not highs or not lows:
+        return None, "no_trade_input_state"
+    recent_high = max(highs)
+    recent_low = min(lows)
+    if recent_high < recent_low:
+        return None, "no_trade_input_state"
+    trend_bias, trend_strength = _derive_trend_features(closed_candles, price)
+    probe_levels = _derive_probe_levels(closed_candles)
+    oi_history = fetch_result.get("oi_history_1h") if isinstance(fetch_result.get("oi_history_1h"), list) else []
+    participation_features = _derive_participation_features(closed_candles, oi_history, trend_bias)
+    market = {
+        "coin": str(fetch_result.get("coin") or requested_coin).upper(),
+        "price": price,
+        "recent_high": recent_high,
+        "recent_low": recent_low,
+        "atr": _compute_atr(candles),
+        "rsi": _compute_rsi(candles),
+        "funding_rate": _safe_float(fetch_result.get("funding"), default=0.0),
+        "trend_bias": round(trend_bias, 4),
+        "trend_strength": round(trend_strength, 4),
+        "news_risk": "none",
+        "timestamp": fetch_result.get("timestamp"),
+        "source": fetch_result.get("source", "okx_swap_public"),
+        "oi_usd": _safe_float(fetch_result.get("oi_usd"), default=0.0),
+    }
+    market.update(probe_levels)
+    market.update(participation_features)
+    return market, None
+
+
+def _fetch_failure_result(strategy_id: str, coin: str, reason: str) -> Dict[str, Any]:
+    normalized_coin = (coin or "").upper()
+    if reason == "market_fetch_not_supported_for_coin":
+        return {
+            "strategy_id": strategy_id,
+            "coin": normalized_coin,
+            "action": "observe",
+            "safe_result": "unsupported_market_fetch",
+            "reason": reason,
+            "dry_run": True,
+            "requires_user_confirmation": False,
+        }
+    return {
+        "strategy_id": strategy_id,
+        "coin": normalized_coin,
+        "action": "observe" if normalized_coin else "none",
+        "safe_result": "no_trade",
+        "market_regime": "market_fetch_unavailable",
+        "signal_score": 0,
+        "confidence": "none",
+        "reason": reason,
+        "dry_run": True,
+        "requires_user_confirmation": False,
+    }
+
+
+def _validation_failure_result(strategy_id: str, errors: List[str]) -> Dict[str, Any]:
+    return {
+        "strategy_id": strategy_id,
+        "action": "none",
+        "safe_result": "no_trade",
+        "market_regime": "invalid_data",
+        "signal_score": 0,
+        "confidence": "none",
+        "reason": "Input payload validation failed.",
+        "validation_errors": errors,
+        "dry_run": True,
+        "requires_user_confirmation": False,
+    }
+
+
+def _sort_scan_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted(
+        results,
+        key=lambda item: (_ACTION_PRIORITY.get(item.get("action", "none"), 0), item.get("signal_score", 0)),
+        reverse=True,
+    )
+
+
+
+def _normalize_evaluate_payload(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    """Prefer flexible Hermes/agent input adapter, then fall back to legacy schema validation."""
+    if normalize_strategy_input_with_errors is not None:
+        adapted, adapter_errors = normalize_strategy_input_with_errors(payload)
+        if adapted is not None:
+            return {
+                "account": adapted["account"],
+                "market": adapted["market"],
+                "position": adapted.get("position"),
+            }, []
+    return normalize_input_payload("evaluate", payload)
+
+
+
+def _parse_coin_list(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    coins = []
+    for item in value.split(","):
+        coin = item.strip().upper()
+        if coin:
+            coins.append(coin)
+    return list(dict.fromkeys(coins))
+
+
+def _scan_requested_markets(payload: Dict[str, Any], coins_config: Dict[str, Any], coins_arg: Optional[str]) -> List[Dict[str, Any]]:
+    requested = _parse_coin_list(coins_arg)
+    if requested:
+        return [{"coin": coin} for coin in requested]
+
+    raw_markets = payload.get("markets")
+    if isinstance(raw_markets, list) and raw_markets:
+        return raw_markets
+
+    return [
+        {"coin": coin}
+        for coin, info in coins_config.items()
+        if isinstance(info, dict) and info.get("enabled", False)
+    ]
+
+
+def _write_audit_output(path: Optional[str], payload: Dict[str, Any]) -> None:
+    if not path:
+        return
+    output_path = Path(path).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def cmd_validate_config(args: argparse.Namespace) -> int:
+    bundle = load_bundle(args.config)
+    errors = validate_config_bundle(bundle["config"], bundle["coins"], bundle["tiers"])
+    result = {"ok": not errors, "errors": errors}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if not errors else 1
+
+
+def cmd_evaluate(args: argparse.Namespace) -> int:
+    bundle = load_bundle(args.config)
+    payload = load_json(args.input)
+    audit_output = getattr(args, "audit_output", None)
+    original_payload = payload
+    audit_context: Dict[str, Any] = {}
+
+    if args.fetch_market:
+        coin = _extract_coin(payload)
+        if not coin:
+            result = _validation_failure_result(bundle["config"]["strategy_id"], ["coin must be provided when --fetch-market is used"])
+            _write_audit_output(audit_output, {
+                "mode": "evaluate",
+                "coin": "",
+                "fetch_status": "invalid_request",
+                "input_payload": original_payload,
+                "result": result,
+            })
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return 0
+        fetch_result = fetch_public_market_data(coin)
+        market, fetch_error = _build_market_from_fetch(fetch_result, coin)
+        audit_context = {
+            "mode": "evaluate",
+            "coin": coin,
+            "input_payload": original_payload,
+            "fetch_result": fetch_result,
+        }
+        if fetch_error:
+            result = _fetch_failure_result(bundle["config"]["strategy_id"], coin, fetch_error)
+            audit_context.update({
+                "fetch_status": "error",
+                "fetch_error": fetch_error,
+                "result": result,
+            })
+            _write_audit_output(audit_output, audit_context)
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return 0
+        payload = dict(payload)
+        # Explicit policy: when --fetch-market is set, fetched public market data overrides input market JSON.
+        payload["market"] = market
+        audit_context.update({
+            "fetch_status": "ok",
+            "derived_market": market,
+        })
+
+    normalized, errors = normalize_strategy_input_with_errors(payload)
+    if errors:
+        normalized, errors = _normalize_evaluate_payload(payload)
+
+    if errors:
+        result = _validation_failure_result(bundle["config"]["strategy_id"], errors)
+    else:
+        result = evaluate_market(bundle, normalized["account"], normalized["market"], normalized.get("position"))
+
+    if args.fetch_market:
+        audit_context["result"] = result
+        _write_audit_output(audit_output, audit_context)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    bundle = load_bundle(args.config)
+    payload = load_json(args.input)
+    strategy_id = bundle["config"]["strategy_id"]
+    audit_output = getattr(args, "audit_output", None)
+
+    if not args.fetch_market:
+        normalized, errors = normalize_input_payload("scan", payload)
+        if errors:
+            result = {
+                "strategy_id": strategy_id,
+                "dry_run": True,
+                "results": [],
+                "top_opportunities": [],
+                "validation_errors": errors,
+            }
+        else:
+            result = scan_markets(bundle, normalized["account"], normalized["markets"], normalized.get("positions"))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    raw_account = payload.get("account")
+    raw_positions = payload.get("positions", {})
+    raw_markets = _scan_requested_markets(payload, bundle["coins"], getattr(args, "coins", None))
+    validation_errors: List[str] = []
+    audit_entries: List[Dict[str, Any]] = []
+    result_by_coin: Dict[str, Dict[str, Any]] = {}
+
+    if not isinstance(raw_account, dict):
+        validation_errors.append("account object is required")
+        account = {}
+    else:
+        account = raw_account
+        validation_errors.extend(validate_account(account))
+
+    if raw_positions is None:
+        raw_positions = {}
+    if not isinstance(raw_positions, dict):
+        validation_errors.append("positions must be an object when provided")
+        positions: Dict[str, Dict[str, Any]] = {}
+    else:
+        positions = raw_positions
+        for coin_key, position in positions.items():
+            if not isinstance(position, dict):
+                validation_errors.append(f"positions.{coin_key} must be an object")
+                continue
+            position_errors = validate_position(position)
+            validation_errors.extend([f"positions.{coin_key}.{err}" for err in position_errors])
+
+    if not isinstance(raw_markets, list) or not raw_markets:
+        validation_errors.append("markets must be a non-empty list for scan")
+        raw_markets = []
+
+    fetched_markets: List[Dict[str, Any]] = []
+    fetch_failures: List[Dict[str, Any]] = []
+    for idx, raw_market in enumerate(raw_markets):
+        if not isinstance(raw_market, dict):
+            validation_errors.append(f"markets[{idx}] must be an object")
+            continue
+        coin = _extract_coin(raw_market)
+        if not coin:
+            validation_errors.append(f"markets[{idx}].coin must be a non-empty string")
+            continue
+        fetch_result = fetch_public_market_data(coin)
+        market, fetch_error = _build_market_from_fetch(fetch_result, coin)
+        audit_entry: Dict[str, Any] = {
+            "coin": coin,
+            "request": raw_market,
+            "fetch_result": fetch_result,
+        }
+        if fetch_error:
+            failure_result = _fetch_failure_result(strategy_id, coin, fetch_error)
+            fetch_failures.append(failure_result)
+            audit_entry.update({
+                "fetch_status": "error",
+                "fetch_error": fetch_error,
+                "result": failure_result,
+            })
+            audit_entries.append(audit_entry)
+            continue
+        fetched_markets.append(market)
+        audit_entry.update({
+            "fetch_status": "ok",
+            "derived_market": market,
+        })
+        audit_entries.append(audit_entry)
+
+    if validation_errors:
+        result = {
+            "strategy_id": strategy_id,
+            "dry_run": True,
+            "results": fetch_failures,
+            "top_opportunities": fetch_failures[:3],
+            "validation_errors": validation_errors,
+        }
+        for entry in audit_entries:
+            if "result" not in entry:
+                entry["result"] = _fetch_failure_result(strategy_id, entry["coin"], "validation_blocked")
+        _write_audit_output(audit_output, {
+            "mode": "scan",
+            "input_payload": payload,
+            "validation_errors": validation_errors,
+            "coins": audit_entries,
+            "result": result,
+        })
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    if fetched_markets:
+        result = scan_markets(bundle, account, fetched_markets, positions)
+        merged_results = result["results"] + fetch_failures
+        result_by_coin = {item.get("coin"): item for item in result["results"] if isinstance(item, dict)}
+    else:
+        merged_results = list(fetch_failures)
+        result = {
+            "strategy_id": strategy_id,
+            "dry_run": True,
+            "results": [],
+            "top_opportunities": [],
+        }
+
+    sorted_results = _sort_scan_results(merged_results)
+    actionable = [item for item in sorted_results if item.get("action") in {"open_long", "open_short", "scale_in", "reduce", "close_all"}]
+    result["results"] = sorted_results
+    result["top_opportunities"] = actionable[:3] if actionable else sorted_results[:3]
+
+    for entry in audit_entries:
+        if entry.get("fetch_status") == "ok":
+            coin = entry.get("coin")
+            entry["result"] = result_by_coin.get(coin, _fetch_failure_result(strategy_id, str(coin), "missing_scan_result"))
+
+    _write_audit_output(audit_output, {
+        "mode": "scan",
+        "input_payload": payload,
+        "validation_errors": validation_errors,
+        "coins": audit_entries,
+        "result": result,
+    })
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Adaptive Hyperliquid Strategy CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-config", help="Validate config bundle")
+    validate_parser.add_argument("--config", required=True)
+    validate_parser.set_defaults(func=cmd_validate_config)
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="Evaluate a single market input")
+    evaluate_parser.add_argument("--config", required=True)
+    evaluate_parser.add_argument("--input", required=True)
+    evaluate_parser.add_argument("--fetch-market", action="store_true", help="Fetch public OKX swap market data and override input market JSON")
+    evaluate_parser.add_argument("--audit-output", default=None, help="Optional path to write evaluate --fetch-market audit JSON")
+    evaluate_parser.set_defaults(func=cmd_evaluate)
+
+    scan_parser = subparsers.add_parser("scan", help="Scan multiple markets")
+    scan_parser.add_argument("--config", required=True)
+    scan_parser.add_argument("--input", required=True)
+    scan_parser.add_argument("--fetch-market", action="store_true", help="Fetch public OKX swap market data per coin and override input market JSON")
+    scan_parser.add_argument("--audit-output", default=None, help="Optional path to write scan --fetch-market audit JSON")
+    scan_parser.add_argument("--coins", default=None, help="Optional comma-separated coin list for scan --fetch-market, e.g. BTC,ETH,SOL,HYPE")
+    scan_parser.set_defaults(func=cmd_scan)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/hyperalpha-adaptive/scripts/decision_engine.py
+++ b/skills/hyperalpha-adaptive/scripts/decision_engine.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from execution_mapper import attach_execution_fields, build_order_command
+from market_engine import compute_bands, determine_setup, score_setup
+from position_engine import manage_existing_position
+from risk_engine import compute_position_size, evaluate_session_guard, get_news_policy
+from validators import validate_account, validate_market, validate_position
+
+
+def _signal_context(signal: Dict[str, Any]) -> Dict[str, Any]:
+    context = {
+        "market_regime": signal["market_regime"],
+        "signal_score": signal["signal_score"],
+        "confidence": signal["confidence"],
+    }
+    if signal.get("entry_profile") is not None:
+        context["entry_profile"] = signal["entry_profile"]
+    if signal.get("component_scores"):
+        context["component_scores"] = signal["component_scores"]
+    if "upper_band" in signal:
+        context["upper_band"] = signal["upper_band"]
+    if "lower_band" in signal:
+        context["lower_band"] = signal["lower_band"]
+    return context
+
+
+def _invalid_result(strategy_id: str, coin: str, errors: List[str]) -> Dict[str, Any]:
+    return {
+        "strategy_id": strategy_id,
+        "coin": coin,
+        "action": "none",
+        "safe_result": "no_trade",
+        "market_regime": "invalid_data",
+        "signal_score": 0,
+        "confidence": "none",
+        "reason": "Market data validation failed.",
+        "validation_errors": errors,
+        "dry_run": True,
+        "requires_user_confirmation": False,
+    }
+
+
+def _observe_result(strategy_id: str, coin: str, signal: Dict[str, Any], reason: str, safe_result: str = "threshold_not_met") -> Dict[str, Any]:
+    result = {
+        "strategy_id": strategy_id,
+        "coin": coin,
+        "action": "observe",
+        "safe_result": safe_result,
+        "reason": reason,
+        "dry_run": True,
+        "requires_user_confirmation": False,
+    }
+    result.update(_signal_context(signal))
+    return result
+
+
+def _halt_result(strategy_id: str, coin: str, signal: Dict[str, Any], reason: str) -> Dict[str, Any]:
+    result = {
+        "strategy_id": strategy_id,
+        "coin": coin,
+        "action": "halt_new_entries",
+        "reason": reason,
+        "dry_run": True,
+        "requires_user_confirmation": False,
+    }
+    result.update(_signal_context(signal))
+    return result
+
+
+def evaluate_market(bundle: Dict[str, Any], account: Dict[str, Any], market: Dict[str, Any], position: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    config = bundle["config"]
+    coins = bundle["coins"]
+    tiers = bundle["tiers"]
+    strategy_id = config["strategy_id"]
+    must_execute_via = config["must_execute_via"]
+    coin = str(market.get("coin", "UNKNOWN")).upper()
+
+    errors = validate_account(account) + validate_market(market)
+    if position is not None:
+        errors.extend(validate_position(position))
+    if errors:
+        return _invalid_result(strategy_id, coin, errors)
+
+    coin_policy = coins.get(coin)
+    if not coin_policy or not coin_policy.get("enabled", False):
+        return {
+            "strategy_id": strategy_id,
+            "coin": coin,
+            "action": "observe",
+            "safe_result": "unsupported_coin",
+            "market_regime": "range",
+            "signal_score": 0,
+            "confidence": "none",
+            "reason": "Coin is outside the whitelist for live execution plans.",
+            "dry_run": True,
+            "requires_user_confirmation": False,
+        }
+
+    tier_policy = tiers[coin_policy["tier"]]
+    news_policy = get_news_policy(market.get("news_risk", "none"), config)
+    session_guard = evaluate_session_guard(account, config)
+    bands = compute_bands(market, config)
+    setup = determine_setup(market, bands, config)
+    signal = score_setup(market, setup, config, news_policy)
+
+    signal["upper_band"] = round(bands["upper_band"], 4)
+    signal["lower_band"] = round(bands["lower_band"], 4)
+
+    if position is not None:
+        return manage_existing_position(
+            strategy_id,
+            must_execute_via,
+            account,
+            market,
+            position,
+            signal,
+            coin_policy,
+            tier_policy,
+            news_policy,
+            session_guard,
+            config,
+        )
+
+    if not news_policy.get("allow_new_entries", True):
+        return _halt_result(strategy_id, coin, signal, "Extreme news risk blocks new entries.")
+
+    if session_guard["block_new_entries"]:
+        return _halt_result(strategy_id, coin, signal, f"Session guard blocks new entries because {session_guard['reason']}.")
+
+    min_signal_score = tier_policy["min_signal_score"] + int(news_policy.get("open_score_threshold_adjustment", 0))
+    if signal["signal_score"] < 40:
+        result = {
+            "strategy_id": strategy_id,
+            "coin": coin,
+            "action": "none",
+            "safe_result": "no_trade",
+            "reason": "No tradable signal was detected.",
+            "dry_run": True,
+            "requires_user_confirmation": False,
+        }
+        result.update(_signal_context(signal))
+        return result
+
+    if signal["signal_score"] < min_signal_score or not signal.get("direction"):
+        reason = f"Signal score {signal['signal_score']} is below the entry threshold {min_signal_score} for {coin_policy['tier']}."
+        return _observe_result(strategy_id, coin, signal, reason)
+
+    size_info = compute_position_size(account, market, coin_policy, news_policy, config)
+    if size_info.get("size_blocked"):
+        result = _observe_result(
+            strategy_id,
+            coin,
+            signal,
+            "Calculated notional is below the configured minimum order notional.",
+            safe_result="below_min_notional",
+        )
+        result["sizing_reason"] = size_info.get("sizing_reason", {})
+        return result
+    action = "open_long" if signal["direction"] == "long" else "open_short"
+    result = {
+        "strategy_id": strategy_id,
+        "coin": coin,
+        "action": action,
+        "reason": f"{coin} generated a {signal['market_regime']} {signal['direction']} setup with acceptable RSI and funding.",
+        "notional_usd": size_info["notional_usd"],
+        "sizing_reason": size_info["sizing_reason"],
+        "take_profit": round(float(market["price"]) + float(market["atr"]) * config["band_params"]["take_profit_mult"] * (1 if signal["direction"] == "long" else -1), 4),
+        "stop_loss": round(float(market["price"]) - float(market["atr"]) * config["band_params"]["stop_mult"] * (1 if signal["direction"] == "long" else -1), 4),
+        "dry_run": True,
+        "requires_user_confirmation": True,
+        "post_execution_steps": [
+            "This plan includes take_profit and stop_loss levels.",
+            "After user confirmation, route execution through Hyperliquid Plugin with the required strategy ID.",
+            "Set protective TP/SL through Hyperliquid Plugin if the installed plugin supports bracket or protective orders.",
+            "If protective TP/SL is not supported by the execution flow, the user must manually confirm the risk before live execution."
+        ],
+    }
+    result.update(_signal_context(signal))
+    command = build_order_command(coin, signal["direction"], size_info["notional_usd"], strategy_id)
+    return attach_execution_fields(result, command, must_execute_via)
+
+
+_ACTION_PRIORITY = {
+    "open_long": 5,
+    "open_short": 5,
+    "scale_in": 4,
+    "reduce": 3,
+    "close_all": 3,
+    "halt_new_entries": 2,
+    "observe": 1,
+    "none": 0,
+}
+
+
+def scan_markets(bundle: Dict[str, Any], account: Dict[str, Any], markets: List[Dict[str, Any]], positions: Optional[Dict[str, Dict[str, Any]]] = None) -> Dict[str, Any]:
+    positions = positions or {}
+    results: List[Dict[str, Any]] = []
+    for market in markets:
+        coin = str(market.get("coin", "")).upper()
+        result = evaluate_market(bundle, account, market, positions.get(coin))
+        results.append(result)
+
+    sorted_results = sorted(results, key=lambda item: (_ACTION_PRIORITY.get(item["action"], 0), item.get("signal_score", 0)), reverse=True)
+    top_opportunities = [item for item in sorted_results if item["action"] in {"open_long", "open_short", "scale_in", "reduce", "close_all"}][:3]
+    if not top_opportunities:
+        top_opportunities = sorted_results[:3]
+    return {
+        "strategy_id": bundle["config"]["strategy_id"],
+        "dry_run": True,
+        "results": sorted_results,
+        "top_opportunities": top_opportunities,
+    }

--- a/skills/hyperalpha-adaptive/scripts/execution_mapper.py
+++ b/skills/hyperalpha-adaptive/scripts/execution_mapper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _format_number(value: float) -> str:
+    text = f"{value:.8f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def validate_fraction(fraction: float) -> None:
+    if not isinstance(fraction, (int, float)):
+        raise ValueError("fraction must be numeric")
+    if fraction <= 0 or fraction > 1:
+        raise ValueError("fraction must be in the range (0, 1]")
+
+
+def build_order_command(coin: str, side: str, size: float, strategy_id: str) -> str:
+    if side not in {"long", "short"}:
+        raise ValueError("side must be 'long' or 'short'")
+    if not isinstance(size, (int, float)) or size <= 0:
+        raise ValueError("size must be positive")
+    return (
+        f"hyperliquid-plugin order --coin {coin.upper()} --side {side} "
+        f"--size {_format_number(float(size))} --strategy-id {strategy_id}"
+    )
+
+
+def build_close_command(coin: str, fraction: float, strategy_id: str) -> str:
+    validate_fraction(fraction)
+    return (
+        f"hyperliquid-plugin close --coin {coin.upper()} --fraction {_format_number(float(fraction))} "
+        f"--reduce-only --strategy-id {strategy_id}"
+    )
+
+
+def attach_execution_fields(result: dict, command_template: Optional[str], must_execute_via: str) -> dict:
+    if command_template:
+        result["must_execute_via"] = must_execute_via
+        result["hyperliquid_command_template"] = command_template
+    return result

--- a/skills/hyperalpha-adaptive/scripts/input_adapter.py
+++ b/skills/hyperalpha-adaptive/scripts/input_adapter.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Tuple
+
+ALLOWED_RISK_PREFERENCES = {"conservative", "balanced", "aggressive"}
+ALLOWED_POSITION_SIDES = {"flat", "long", "short"}
+
+
+class InputAdapterValidationError(ValueError):
+    """Raised when raw input cannot be normalized safely."""
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _to_float(value: Any, field: str, *, allow_zero: bool = True, min_value: float | None = None) -> float:
+    if value is None:
+        raise InputAdapterValidationError(f"{field} is required")
+    if not _is_finite_number(value):
+        raise InputAdapterValidationError(f"{field} must be a finite number")
+    number = float(value)
+    if not allow_zero and number == 0:
+        raise InputAdapterValidationError(f"{field} must be non-zero")
+    if min_value is not None and number < min_value:
+        raise InputAdapterValidationError(f"{field} must be >= {min_value}")
+    return number
+
+
+def _to_non_negative_float(value: Any, field: str, default: float = 0.0) -> float:
+    if value is None:
+        return float(default)
+    if not _is_finite_number(value):
+        raise InputAdapterValidationError(f"{field} must be a finite number")
+    number = float(value)
+    if number < 0:
+        raise InputAdapterValidationError(f"{field} must be >= 0")
+    return number
+
+
+def _to_int(value: Any, field: str, default: int = 0, min_value: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InputAdapterValidationError(f"{field} must be an integer")
+    if value < min_value:
+        raise InputAdapterValidationError(f"{field} must be >= {min_value}")
+    return value
+
+
+def _first_present(payload: Dict[str, Any], keys: List[str]) -> Any:
+    for key in keys:
+        if key in payload and payload[key] is not None:
+            return payload[key]
+    return None
+
+
+def _normalize_coin(raw: Dict[str, Any]) -> str:
+    coin = _first_present(raw, ["coin", "symbol", "asset"])
+    if not isinstance(coin, str) or not coin.strip():
+        raise InputAdapterValidationError("coin must be a non-empty string")
+    return coin.strip().upper()
+
+
+def _normalize_account(raw: Dict[str, Any]) -> Dict[str, Any]:
+    account = raw.get("account") if isinstance(raw.get("account"), dict) else {}
+    equity = _first_present(raw, ["equity"])
+    if equity is None:
+        equity = _first_present(account, ["equity", "account_value", "balance"])
+    equity_value = _to_non_negative_float(equity, "account.equity", default=0.0)
+
+    available = _first_present(raw, ["available_balance", "free_collateral"])
+    if available is None:
+        available = _first_present(account, ["available_balance", "free_collateral", "available", "withdrawable"])
+    available_value = _to_non_negative_float(available, "account.available_balance", default=equity_value)
+
+    session_loss_pct = _first_present(account, ["session_loss_pct", "daily_loss_pct"])
+    session_loss = 0.0 if session_loss_pct is None else _to_float(session_loss_pct, "account.session_loss_pct")
+    if session_loss < -1 or session_loss > 1:
+        raise InputAdapterValidationError("account.session_loss_pct must be between -1 and 1")
+
+    session_actions = _first_present(account, ["session_actions", "actions_taken"])
+
+    return {
+        "equity": equity_value,
+        "free_collateral": available_value,
+        "session_loss_pct": session_loss,
+        "session_actions": _to_int(session_actions, "account.session_actions", default=0, min_value=0),
+    }
+
+
+def _normalize_position(raw: Dict[str, Any], market_price: float) -> Dict[str, Any] | None:
+    position = raw.get("position")
+    if position is None:
+        return None
+    if not isinstance(position, dict):
+        raise InputAdapterValidationError("position must be an object when provided")
+
+    side = _first_present(position, ["side", "direction"])
+    if side is None:
+        size = _first_present(position, ["size", "sz", "contracts"])
+        if size is None:
+            side = "flat"
+        else:
+            size_value = _to_float(size, "position.size")
+            side = "flat" if size_value == 0 else ("long" if size_value > 0 else "short")
+    if not isinstance(side, str):
+        raise InputAdapterValidationError("position.side must be a string")
+    side = side.strip().lower()
+    if side not in ALLOWED_POSITION_SIDES:
+        raise InputAdapterValidationError("position.side must be one of flat/long/short")
+    if side == "flat":
+        return None
+
+    entry_price = _first_present(position, ["entry_price", "avg_entry_price", "average_entry_price"])
+    notional = _first_present(position, ["notional_usd", "position_value_usd", "usd_value"])
+    if notional is None:
+        size = _first_present(position, ["size", "sz", "contracts"])
+        if size is not None:
+            notional = abs(_to_float(size, "position.size")) * market_price
+
+    unrealized_pnl = _first_present(position, ["unrealized_pnl", "pnl", "unrealizedPnl"])
+    peak_unrealized_pnl = _first_present(position, ["peak_unrealized_pnl", "max_unrealized_pnl", "peakPnl"])
+    scale_ins_used = _first_present(position, ["scale_ins_used", "adds_count", "scaleInCount"])
+
+    return {
+        "side": side,
+        "entry_price": _to_float(entry_price, "position.entry_price", min_value=0.0),
+        "notional_usd": _to_non_negative_float(notional, "position.notional_usd", default=0.0),
+        "unrealized_pnl": 0.0 if unrealized_pnl is None else _to_float(unrealized_pnl, "position.unrealized_pnl"),
+        "peak_unrealized_pnl": 0.0 if peak_unrealized_pnl is None else _to_float(peak_unrealized_pnl, "position.peak_unrealized_pnl"),
+        "scale_ins_used": _to_int(scale_ins_used, "position.scale_ins_used", default=0, min_value=0),
+    }
+
+
+def _normalize_market(raw: Dict[str, Any], coin: str) -> Dict[str, Any]:
+    market = raw.get("market") if isinstance(raw.get("market"), dict) else {}
+
+    price = _first_present(raw, ["price", "mark_price", "mid_price"])
+    if price is None:
+        price = _first_present(market, ["price", "mark_price", "mid_price", "last_price"])
+    price_value = _to_float(price, "market.price", min_value=0.0)
+    if price_value <= 0:
+        raise InputAdapterValidationError("market.price must be > 0")
+
+    recent_high = _first_present(market, ["recent_high", "high", "day_high"])
+    recent_low = _first_present(market, ["recent_low", "low", "day_low"])
+    atr = _first_present(market, ["atr", "atr_value"])
+    rsi = _first_present(market, ["rsi"])
+    funding_rate = _first_present(market, ["funding_rate", "funding"])
+    trend_bias = _first_present(market, ["trend_bias", "bias"])
+    trend_strength = _first_present(market, ["trend_strength", "strength"])
+    news_risk = _first_present(market, ["news_risk", "event_risk"]) or "none"
+
+    recent_high_value = _to_non_negative_float(recent_high, "market.recent_high", default=price_value)
+    recent_low_value = _to_non_negative_float(recent_low, "market.recent_low", default=price_value)
+    if recent_high_value < recent_low_value:
+        raise InputAdapterValidationError("market.recent_high must be >= market.recent_low")
+
+    atr_value = _to_non_negative_float(atr, "market.atr", default=max(price_value * 0.01, 0.0))
+    rsi_value = 50.0 if rsi is None else _to_float(rsi, "market.rsi")
+    if rsi_value < 0 or rsi_value > 100:
+        raise InputAdapterValidationError("market.rsi must be between 0 and 100")
+
+    funding_value = 0.0 if funding_rate is None else _to_float(funding_rate, "market.funding_rate")
+    trend_bias_value = 0.0 if trend_bias is None else _to_float(trend_bias, "market.trend_bias")
+    if trend_bias_value < -1 or trend_bias_value > 1:
+        raise InputAdapterValidationError("market.trend_bias must be between -1 and 1")
+    trend_strength_value = 0.0 if trend_strength is None else _to_float(trend_strength, "market.trend_strength")
+    if trend_strength_value < 0 or trend_strength_value > 1:
+        raise InputAdapterValidationError("market.trend_strength must be between 0 and 1")
+
+    if not isinstance(news_risk, str) or not news_risk.strip():
+        raise InputAdapterValidationError("market.news_risk must be a non-empty string")
+
+    return {
+        "coin": coin,
+        "price": price_value,
+        "recent_high": recent_high_value,
+        "recent_low": recent_low_value,
+        "atr": atr_value,
+        "rsi": rsi_value,
+        "funding_rate": funding_value,
+        "trend_bias": trend_bias_value,
+        "trend_strength": trend_strength_value,
+        "news_risk": news_risk.strip().lower(),
+    }
+
+
+def _normalize_user_preferences(raw: Dict[str, Any]) -> Dict[str, Any]:
+    preferences = raw.get("user_preferences")
+    if preferences is None:
+        preferences = raw.get("risk_preference")
+    if preferences is None:
+        return {"risk_preference": "balanced"}
+    if isinstance(preferences, str):
+        risk_preference = preferences.strip().lower()
+        if risk_preference not in ALLOWED_RISK_PREFERENCES:
+            raise InputAdapterValidationError("user risk preference must be conservative/balanced/aggressive")
+        return {"risk_preference": risk_preference}
+    if not isinstance(preferences, dict):
+        raise InputAdapterValidationError("user_preferences must be an object or string")
+
+    risk_preference = _first_present(preferences, ["risk_preference", "profile", "mode"]) or "balanced"
+    if not isinstance(risk_preference, str) or risk_preference.strip().lower() not in ALLOWED_RISK_PREFERENCES:
+        raise InputAdapterValidationError("user risk preference must be conservative/balanced/aggressive")
+
+    max_leverage = _first_present(preferences, ["max_leverage", "leverage_cap"])
+    per_trade_risk = _first_present(preferences, ["per_trade_risk", "risk_per_trade"])
+
+    normalized = {
+        "risk_preference": risk_preference.strip().lower(),
+    }
+    if max_leverage is not None:
+        normalized["max_leverage"] = _to_non_negative_float(max_leverage, "user_preferences.max_leverage", default=0.0)
+    if per_trade_risk is not None:
+        value = _to_non_negative_float(per_trade_risk, "user_preferences.per_trade_risk", default=0.0)
+        if value > 1:
+            raise InputAdapterValidationError("user_preferences.per_trade_risk must be between 0 and 1")
+        normalized["per_trade_risk"] = value
+    return normalized
+
+
+def normalize_strategy_input(raw: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise InputAdapterValidationError("input payload must be an object")
+
+    coin = _normalize_coin(raw)
+    account = _normalize_account(raw)
+    market = _normalize_market(raw, coin)
+    position = _normalize_position(raw, market_price=market["price"])
+    user_preferences = _normalize_user_preferences(raw)
+
+    return {
+        "coin": coin,
+        "account": account,
+        "position": position,
+        "market": market,
+        "user_preferences": user_preferences,
+    }
+
+
+def normalize_strategy_input_with_errors(raw: Dict[str, Any]) -> Tuple[Dict[str, Any] | None, List[str]]:
+    try:
+        return normalize_strategy_input(raw), []
+    except InputAdapterValidationError as exc:
+        return None, [str(exc)]

--- a/skills/hyperalpha-adaptive/scripts/market_engine.py
+++ b/skills/hyperalpha-adaptive/scripts/market_engine.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+
+def clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    if not math.isfinite(value):
+        return low if low <= 0 <= high else low
+    return max(low, min(high, value))
+
+
+def _optional_level(market: Dict[str, Any], key: str, fallback: float) -> float:
+    value = market.get(key, fallback)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return parsed if math.isfinite(parsed) else fallback
+
+
+def compute_bands(market: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, float]:
+    params = config["band_params"]
+    atr = float(market["atr"])
+    recent_high = float(market["recent_high"])
+    recent_low = float(market["recent_low"])
+    return {
+        "upper_band": recent_high + atr * float(params["breakout_mult"]),
+        "lower_band": recent_low - atr * float(params["breakdown_mult"]),
+    }
+
+
+def _atr_quality_score(price: float, atr: float, config: Dict[str, Any]) -> float:
+    ratio = atr / price
+    low = config["thresholds"]["atr_ratio_min"]
+    high = config["thresholds"]["atr_ratio_max"]
+    if ratio < low:
+        return 0.35
+    if ratio > high:
+        return 0.45
+    midpoint = (low + high) / 2
+    spread = max((high - low) / 2, 1e-9)
+    distance = abs(ratio - midpoint) / spread
+    return clamp(1 - 0.4 * distance)
+
+
+def _rsi_score(direction: str, regime: str, rsi: float, config: Dict[str, Any]) -> float:
+    thresholds = config["thresholds"]
+    if direction == "long":
+        if regime == "rebound":
+            return clamp((45 - rsi) / 20) if rsi <= 45 else 0.3
+        if rsi > thresholds["rsi_overbought"]:
+            return 0.15
+        if rsi > thresholds["rsi_long_max"]:
+            return 0.45
+        return clamp((rsi - 40) / 30)
+    if regime == "fade":
+        return clamp((rsi - 55) / 20) if rsi >= 55 else 0.25
+    if rsi < thresholds["rsi_oversold"]:
+        return 0.15
+    if rsi < thresholds["rsi_short_min"]:
+        return 0.45
+    return clamp((60 - rsi) / 30)
+
+
+def _funding_score(direction: str, funding_rate: float, config: Dict[str, Any]) -> float:
+    thresholds = config["thresholds"]
+    if direction == "long":
+        if funding_rate > thresholds["funding_hot_long"]:
+            return 0.2
+        if funding_rate < thresholds["funding_cold_long"]:
+            return 0.8
+        return 1.0 - min(abs(funding_rate) / max(thresholds["funding_hot_long"], 1e-9), 0.8)
+    if funding_rate < thresholds["funding_cold_short"]:
+        return 0.2
+    if funding_rate > thresholds["funding_hot_short"]:
+        return 0.75
+    return 1.0 - min(abs(funding_rate) / max(abs(thresholds["funding_cold_short"]), 1e-9), 0.8)
+
+
+def _participation_score(direction: str, market: Dict[str, Any]) -> float:
+    participation_bias = _optional_level(market, "participation_bias", 0.0)
+    volume_ratio = max(_optional_level(market, "volume_ratio", 1.0), 0.0)
+    oi_change_ratio = _optional_level(market, "oi_change_ratio", 0.0)
+    directional_participation = participation_bias if direction == "long" else -participation_bias
+    directional_oi = oi_change_ratio if direction == "long" else -oi_change_ratio
+
+    bias_component = clamp(directional_participation, -1.0, 1.0)
+    volume_component = clamp((volume_ratio - 1.0) / 0.8, -1.0, 1.0)
+    oi_component = clamp(directional_oi / 0.15, -1.0, 1.0)
+    return clamp(0.5 * bias_component + 0.3 * volume_component + 0.2 * oi_component, -1.0, 1.0)
+
+
+def determine_setup(market: Dict[str, Any], bands: Dict[str, float], config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    price = float(market["price"])
+    recent_high = float(market["recent_high"])
+    recent_low = float(market["recent_low"])
+    atr = float(market["atr"])
+    rsi = float(market["rsi"])
+    trend_bias = float(market["trend_bias"])
+    trend_strength = float(market["trend_strength"])
+    thresholds = config["thresholds"]
+    params = config["band_params"]
+
+    if price >= bands["upper_band"] and trend_bias > 0 and trend_strength >= thresholds["trend_strength_min"]:
+        if rsi > thresholds["rsi_overbought"]:
+            return None
+        return {"direction": "long", "market_regime": "breakout"}
+    if price <= bands["lower_band"] and trend_bias < 0 and trend_strength >= thresholds["trend_strength_min"]:
+        if rsi < thresholds["rsi_oversold"]:
+            return None
+        return {"direction": "short", "market_regime": "breakdown"}
+
+    breakout_buffer = atr * float(params["breakout_mult"])
+    breakdown_buffer = atr * float(params["breakdown_mult"])
+    prior_high = _optional_level(market, "prior_high", recent_high)
+    prior_low = _optional_level(market, "prior_low", recent_low)
+    probe_high = _optional_level(market, "probe_high", recent_high)
+    probe_low = _optional_level(market, "probe_low", recent_low)
+
+    rejected_from_probe = probe_high >= prior_high + breakout_buffer and price <= probe_high - breakout_buffer
+    rebounded_from_probe = probe_low <= prior_low - breakdown_buffer and price >= probe_low + breakdown_buffer
+
+    if rejected_from_probe and price < bands["upper_band"] and rsi >= thresholds["rsi_overbought"] and trend_bias <= 0.2:
+        return {"direction": "short", "market_regime": "fade"}
+    if rebounded_from_probe and price > bands["lower_band"] and rsi <= thresholds["rsi_oversold"] and trend_bias >= -0.2:
+        return {"direction": "long", "market_regime": "rebound"}
+    return None
+
+
+def score_setup(
+    market: Dict[str, Any],
+    setup: Optional[Dict[str, Any]],
+    config: Dict[str, Any],
+    news_policy: Dict[str, Any],
+) -> Dict[str, Any]:
+    if not setup:
+        return {
+            "signal_score": 32,
+            "confidence": "low",
+            "market_regime": "range",
+            "direction": None,
+            "entry_profile": "no_trade",
+            "component_scores": {},
+        }
+
+    direction = setup["direction"]
+    regime = setup["market_regime"]
+    scoring = config["scoring"]
+    price = float(market["price"])
+    atr = float(market["atr"])
+    trend_bias = float(market["trend_bias"])
+    trend_strength = float(market["trend_strength"])
+    funding_rate = float(market["funding_rate"])
+    rsi = float(market["rsi"])
+    probe_high = _optional_level(market, "probe_high", float(market["recent_high"]))
+    probe_low = _optional_level(market, "probe_low", float(market["recent_low"]))
+
+    directional_bias = max(trend_bias, 0.0) if direction == "long" else max(-trend_bias, 0.0)
+    trend_component = clamp((directional_bias + trend_strength) / 2.0) * scoring["trend"]
+
+    bands = compute_bands(market, config)
+    if regime == "breakout":
+        breakout_ratio = (price - bands["upper_band"]) / max(atr, 1e-9)
+    elif regime == "breakdown":
+        breakout_ratio = (bands["lower_band"] - price) / max(atr, 1e-9)
+    elif regime == "fade":
+        breakout_ratio = (probe_high - price) / max(atr, 1e-9)
+    else:
+        breakout_ratio = (price - probe_low) / max(atr, 1e-9)
+    breakout_component = clamp(breakout_ratio / 1.5) * scoring["breakout"]
+
+    atr_component = _atr_quality_score(price, atr, config) * scoring["atr"]
+    rsi_component = _rsi_score(direction, regime, rsi, config) * scoring["rsi"]
+    funding_component = _funding_score(direction, funding_rate, config) * scoring["funding"]
+    position_component = scoring["position"]
+    participation_component = _participation_score(direction, market) * scoring.get("participation", 0)
+    news_penalty = abs(float(news_policy.get("score_adjustment", 0)))
+
+    raw_score = (
+        trend_component
+        + breakout_component
+        + atr_component
+        + rsi_component
+        + funding_component
+        + position_component
+        + participation_component
+        - news_penalty
+    )
+    signal_score = max(0, min(int(round(raw_score)), 100))
+    if signal_score >= 90:
+        confidence = "high"
+        entry_profile = "strong_signal"
+    elif signal_score >= 75:
+        confidence = "medium-high"
+        entry_profile = "normal_position"
+    elif signal_score >= 60:
+        confidence = "medium"
+        entry_profile = "small_position"
+    else:
+        confidence = "low"
+        entry_profile = "observe" if signal_score >= 40 else "no_trade"
+
+    return {
+        "signal_score": signal_score,
+        "confidence": confidence,
+        "market_regime": regime,
+        "direction": direction,
+        "entry_profile": entry_profile,
+        "component_scores": {
+            "trend": round(trend_component, 2),
+            "breakout": round(breakout_component, 2),
+            "atr": round(atr_component, 2),
+            "rsi": round(rsi_component, 2),
+            "funding": round(funding_component, 2),
+            "position": round(position_component, 2),
+            "participation": round(participation_component, 2),
+            "news_penalty": round(news_penalty, 2),
+        },
+    }

--- a/skills/hyperalpha-adaptive/scripts/market_fetcher.py
+++ b/skills/hyperalpha-adaptive/scripts/market_fetcher.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import math
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List
+
+OKX_PUBLIC_BASE = "https://www.okx.com"
+SUPPORTED_COINS = {"BTC", "ETH", "SOL", "XRP", "DOGE", "BNB", "LINK", "AVAX"}
+UNSUPPORTED_PUBLIC_FETCH = {"HYPE"}
+DEFAULT_TIMEOUT = 10
+CANDLE_LIMIT = 24
+OI_HISTORY_LIMIT = 24
+ONE_HOUR_MS = 60 * 60 * 1000
+
+
+class MarketFetchError(Exception):
+    """Raised when public market data cannot be fetched safely."""
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _symbol_for_coin(coin: str) -> str:
+    return f"{coin.upper()}-USDT-SWAP"
+
+
+def _http_get_json(path: str, params: Dict[str, Any], timeout: int = DEFAULT_TIMEOUT) -> Any:
+    query = urllib.parse.urlencode(params)
+    url = f"{OKX_PUBLIC_BASE}{path}?{query}" if query else f"{OKX_PUBLIC_BASE}{path}"
+    request = urllib.request.Request(url, headers={"User-Agent": "HermesMarketFetcher/1.0"}, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return json.loads(response.read().decode(charset))
+
+
+def _okx_data_rows(payload: Any) -> List[Any]:
+    if not isinstance(payload, dict):
+        raise MarketFetchError("market_data_missing")
+    if payload.get("code") != "0":
+        raise MarketFetchError("market_data_missing")
+    rows = payload.get("data")
+    if not isinstance(rows, list) or not rows:
+        raise MarketFetchError("market_data_missing")
+    return rows
+
+
+def _to_positive_float(value: Any, field: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise MarketFetchError(f"{field}_missing_or_invalid") from exc
+    if not math.isfinite(number) or number <= 0:
+        raise MarketFetchError(f"{field}_missing_or_invalid")
+    return number
+
+
+def _to_finite_float(value: Any, field: str, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise MarketFetchError(f"{field}_missing_or_invalid") from exc
+    if not math.isfinite(number):
+        raise MarketFetchError(f"{field}_missing_or_invalid")
+    return number
+
+
+def _to_int(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise MarketFetchError(f"{field}_missing_or_invalid")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise MarketFetchError(f"{field}_missing_or_invalid") from exc
+
+
+def _normalize_candle(row: List[Any]) -> Dict[str, Any]:
+    if not isinstance(row, list) or len(row) < 5:
+        raise MarketFetchError("candles_missing_or_invalid")
+    open_time = _to_int(row[0], "candle_open_time")
+    open_price = _to_positive_float(row[1], "candle_open")
+    high_price = _to_positive_float(row[2], "candle_high")
+    low_price = _to_positive_float(row[3], "candle_low")
+    close_price = _to_positive_float(row[4], "candle_close")
+    volume = _to_finite_float(row[5] if len(row) > 5 else None, "candle_volume", default=0.0)
+    if low_price > high_price:
+        raise MarketFetchError("candles_missing_or_invalid")
+    return {
+        "open_time": open_time,
+        "open": open_price,
+        "high": high_price,
+        "low": low_price,
+        "close": close_price,
+        "volume": volume,
+        "close_time": open_time + ONE_HOUR_MS,
+    }
+
+
+def _normalize_oi_history_row(row: List[Any]) -> Dict[str, Any]:
+    if not isinstance(row, list) or len(row) < 2:
+        raise MarketFetchError("open_interest_missing_or_invalid")
+    timestamp = _to_int(row[0], "oi_timestamp")
+    oi_usd = _to_positive_float(row[-1], "oi_usd")
+    return {
+        "timestamp": timestamp,
+        "oi_usd": oi_usd,
+    }
+
+
+def _request_failed_result(coin: str, reason: str) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "coin": coin,
+        "input_state": "no_trade",
+        "safe_result": "no_trade",
+        "reason": reason,
+    }
+
+
+def fetch_public_market_data(coin: str, timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    normalized_coin = (coin or "").strip().upper()
+    if not normalized_coin:
+        return _request_failed_result("", "no_trade_input_state")
+    if normalized_coin in UNSUPPORTED_PUBLIC_FETCH:
+        return {
+            "ok": False,
+            "reason": "market_fetch_not_supported_for_coin",
+            "coin": normalized_coin,
+        }
+    if normalized_coin not in SUPPORTED_COINS:
+        return _request_failed_result(normalized_coin, "no_trade_input_state")
+
+    symbol = _symbol_for_coin(normalized_coin)
+    try:
+        mark_rows = _okx_data_rows(
+            _http_get_json("/api/v5/public/mark-price", {"instType": "SWAP", "instId": symbol}, timeout=timeout)
+        )
+        funding_rows = _okx_data_rows(
+            _http_get_json("/api/v5/public/funding-rate", {"instId": symbol}, timeout=timeout)
+        )
+        candle_rows = _okx_data_rows(
+            _http_get_json(
+                "/api/v5/market/history-candles",
+                {"instId": symbol, "bar": "1H", "limit": CANDLE_LIMIT},
+                timeout=timeout,
+            )
+        )
+        oi_rows = _okx_data_rows(
+            _http_get_json(
+                "/api/v5/rubik/stat/contracts/open-interest-history",
+                {"instId": symbol, "period": "1H", "limit": OI_HISTORY_LIMIT},
+                timeout=timeout,
+            )
+        )
+
+        mark = mark_rows[0]
+        funding_info = funding_rows[0]
+        if not isinstance(mark, dict) or not isinstance(funding_info, dict):
+            raise MarketFetchError("market_data_missing")
+
+        price = _to_positive_float(mark.get("markPx"), "price")
+        funding = _to_finite_float(funding_info.get("fundingRate"), "funding", default=0.0)
+        timestamp = _to_int(mark.get("ts") or funding_info.get("ts"), "timestamp")
+        candles = sorted((_normalize_candle(row) for row in candle_rows), key=lambda candle: candle["open_time"])
+        if not candles:
+            raise MarketFetchError("market_data_missing")
+        oi_history = sorted((_normalize_oi_history_row(row) for row in oi_rows), key=lambda row: row["timestamp"])
+        if not oi_history:
+            raise MarketFetchError("open_interest_missing_or_invalid")
+
+        return {
+            "ok": True,
+            "coin": normalized_coin,
+            "symbol": symbol,
+            "source": "okx_swap_public",
+            "price": price,
+            "funding": funding,
+            "candles_1h": candles,
+            "oi_history_1h": oi_history,
+            "oi_usd": oi_history[-1]["oi_usd"],
+            "timestamp": timestamp,
+        }
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError):
+        return _request_failed_result(normalized_coin, "no_trade_input_state")
+    except (json.JSONDecodeError, MarketFetchError):
+        return _request_failed_result(normalized_coin, "no_trade_input_state")
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch public OKX swap market data")
+    parser.add_argument("coin", help="Coin symbol, e.g. BTC")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    args = parser.parse_args()
+    print(json.dumps(fetch_public_market_data(args.coin, timeout=args.timeout), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/hyperalpha-adaptive/scripts/position_engine.py
+++ b/skills/hyperalpha-adaptive/scripts/position_engine.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from execution_mapper import attach_execution_fields, build_close_command, build_order_command
+from risk_engine import compute_scale_in_allowance
+
+
+def _signal_context(signal: Dict[str, Any]) -> Dict[str, Any]:
+    context = {
+        "market_regime": signal["market_regime"],
+        "signal_score": signal["signal_score"],
+        "confidence": signal["confidence"],
+    }
+    if signal.get("entry_profile") is not None:
+        context["entry_profile"] = signal["entry_profile"]
+    if signal.get("component_scores"):
+        context["component_scores"] = signal["component_scores"]
+    if "upper_band" in signal:
+        context["upper_band"] = signal["upper_band"]
+    if "lower_band" in signal:
+        context["lower_band"] = signal["lower_band"]
+    return context
+
+
+def _base_result(strategy_id: str, coin: str, action: str, signal: Dict[str, Any], market_regime: str, reason: str) -> Dict[str, Any]:
+    result = {
+        "strategy_id": strategy_id,
+        "coin": coin,
+        "action": action,
+        "market_regime": market_regime,
+        "reason": reason,
+    }
+    result.update(_signal_context(signal))
+    result["market_regime"] = market_regime
+    return result
+
+
+def manage_existing_position(
+    strategy_id: str,
+    must_execute_via: str,
+    account: Dict[str, Any],
+    market: Dict[str, Any],
+    position: Dict[str, Any],
+    signal: Dict[str, Any],
+    coin_policy: Dict[str, Any],
+    tier_policy: Dict[str, Any],
+    news_policy: Dict[str, Any],
+    session_guard: Dict[str, Any],
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    coin = market["coin"].upper()
+    risk = config["risk"]
+    position_rules = config["position_rules"]
+    side = position["side"]
+    equity = float(account["equity"])
+    unrealized = float(position.get("unrealized_pnl", 0))
+    peak_unrealized = float(position.get("peak_unrealized_pnl", 0))
+    reduce_fraction = float(position_rules["reduce_fraction"])
+    close_fraction = float(position_rules["close_fraction"])
+
+    loss_pct_equity = max(0.0, -unrealized / max(equity, 1e-9))
+    if loss_pct_equity >= risk["emergency_loss_pct"]:
+        result = _base_result(strategy_id, coin, "close_all", signal, "position_risk", "Position loss exceeded emergency loss threshold.")
+        result["fraction"] = close_fraction
+        result["loss_pct_equity"] = round(loss_pct_equity, 4)
+        result["dry_run"] = True
+        result["requires_user_confirmation"] = True
+        command = build_close_command(coin, close_fraction, strategy_id)
+        return attach_execution_fields(result, command, must_execute_via)
+
+    if loss_pct_equity >= risk["soft_loss_pct"]:
+        result = _base_result(strategy_id, coin, "reduce", signal, "position_risk", "Position loss exceeded soft loss threshold.")
+        result["fraction"] = reduce_fraction
+        result["loss_pct_equity"] = round(loss_pct_equity, 4)
+        result["dry_run"] = True
+        result["requires_user_confirmation"] = True
+        command = build_close_command(coin, reduce_fraction, strategy_id)
+        return attach_execution_fields(result, command, must_execute_via)
+
+    if peak_unrealized > 0:
+        giveback = max(0.0, (peak_unrealized - unrealized) / peak_unrealized)
+        if giveback >= position_rules["close_giveback_pct"]:
+            result = _base_result(strategy_id, coin, "close_all", signal, "profit_giveback", "Position gave back more than 60% of peak unrealized profit.")
+            result["fraction"] = close_fraction
+            result["profit_giveback_pct"] = round(giveback, 4)
+            result["dry_run"] = True
+            result["requires_user_confirmation"] = True
+            command = build_close_command(coin, close_fraction, strategy_id)
+            return attach_execution_fields(result, command, must_execute_via)
+        if giveback >= position_rules["reduce_giveback_pct"]:
+            result = _base_result(strategy_id, coin, "reduce", signal, "profit_giveback", "Position gave back more than 35% of peak unrealized profit.")
+            result["fraction"] = reduce_fraction
+            result["profit_giveback_pct"] = round(giveback, 4)
+            result["dry_run"] = True
+            result["requires_user_confirmation"] = True
+            command = build_close_command(coin, reduce_fraction, strategy_id)
+            return attach_execution_fields(result, command, must_execute_via)
+
+    rsi = float(market["rsi"])
+    funding = float(market["funding_rate"])
+    thresholds = config["thresholds"]
+    if unrealized > 0 and side == "long" and rsi >= thresholds["rsi_overbought"] and funding >= thresholds["funding_hot_long"]:
+        result = _base_result(strategy_id, coin, "reduce", signal, "position_risk", "Profitable long is overheated on both RSI and funding.")
+        result["fraction"] = reduce_fraction
+        result["dry_run"] = True
+        result["requires_user_confirmation"] = True
+        command = build_close_command(coin, reduce_fraction, strategy_id)
+        return attach_execution_fields(result, command, must_execute_via)
+    if unrealized > 0 and side == "short" and rsi <= thresholds["rsi_oversold"] and funding <= thresholds["funding_cold_short"]:
+        result = _base_result(strategy_id, coin, "reduce", signal, "position_risk", "Profitable short is crowded on both RSI and funding.")
+        result["fraction"] = reduce_fraction
+        result["dry_run"] = True
+        result["requires_user_confirmation"] = True
+        command = build_close_command(coin, reduce_fraction, strategy_id)
+        return attach_execution_fields(result, command, must_execute_via)
+
+    side_alignment = (side == "long" and signal.get("direction") == "long") or (side == "short" and signal.get("direction") == "short")
+    if (
+        unrealized > 0
+        and side_alignment
+        and signal["signal_score"] >= tier_policy["min_signal_score"]
+        and position.get("scale_ins_used", 0) < risk["max_scaleins"]
+        and not session_guard["block_scale_in"]
+        and news_policy.get("allow_scale_in", True)
+        and not (
+            (side == "long" and funding >= thresholds["funding_hot_long"]) or
+            (side == "short" and funding <= thresholds["funding_cold_short"])
+        )
+    ):
+        allowance = compute_scale_in_allowance(account, market, float(position["notional_usd"]), coin_policy, news_policy, config)
+        if not allowance.get("size_blocked") and allowance["additional_notional"] > 0:
+            current_notional = round(float(position["notional_usd"]), 2)
+            result = _base_result(strategy_id, coin, "scale_in", signal, signal["market_regime"], "Existing position is profitable and trend confirmation allows one controlled scale-in.")
+            result["notional_usd"] = allowance["additional_notional"]
+            result["sizing_reason"] = allowance["sizing_reason"]
+            result["current_notional_usd"] = current_notional
+            result["post_scale_in_notional_usd"] = round(current_notional + allowance["additional_notional"], 2)
+            result["dry_run"] = True
+            result["requires_user_confirmation"] = True
+            command = build_order_command(coin, side, allowance["additional_notional"], strategy_id)
+            return attach_execution_fields(result, command, must_execute_via)
+
+    reason = "Existing position is healthy; hold normalized to observe."
+    if session_guard["block_scale_in"]:
+        reason = f"Existing position is healthy; new adds blocked because {session_guard['reason']}."
+    elif not news_policy.get("allow_scale_in", True):
+        reason = "Existing position is healthy; scale-in blocked by news risk."
+
+    result = _base_result(strategy_id, coin, "observe", signal, signal["market_regime"], reason)
+    result["safe_result"] = "hold_normalized"
+    result["dry_run"] = True
+    result["requires_user_confirmation"] = False
+    return result

--- a/skills/hyperalpha-adaptive/scripts/risk_engine.py
+++ b/skills/hyperalpha-adaptive/scripts/risk_engine.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+_DEFAULT_TARGET_STOP_DISTANCE_RATIO = 0.002
+
+
+def get_news_policy(level: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    return config["news_risk"].get(level, config["news_risk"]["none"])
+
+
+def evaluate_session_guard(account: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    risk = config["risk"]
+    reasons = []
+    block_new_entries = False
+    block_scale_in = False
+
+    if account.get("session_loss_pct", 0) >= risk["session_loss_limit_pct"]:
+        reasons.append("session loss limit reached")
+        block_new_entries = True
+        block_scale_in = True
+
+    if account.get("session_actions", 0) >= risk["max_actions_per_session"]:
+        reasons.append("max actions per session reached")
+        block_new_entries = True
+        block_scale_in = True
+
+    return {
+        "block_new_entries": block_new_entries,
+        "block_scale_in": block_scale_in,
+        "reason": "; ".join(reasons) if reasons else "session risk healthy",
+    }
+
+
+def compute_position_size(
+    account: Dict[str, Any],
+    market: Dict[str, Any],
+    coin_policy: Dict[str, Any],
+    news_policy: Dict[str, Any],
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    equity = float(account["equity"])
+    free_collateral = float(account.get("free_collateral", equity))
+    price = max(float(market["price"]), 1e-9)
+    atr = max(float(market["atr"]), 0.01)
+    risk = config["risk"]
+    band_params = config["band_params"]
+    base_ratio = float(risk["per_trade_ratio"])
+    tier_risk_mult = float(coin_policy["risk_mult"])
+    news_position_mult = float(news_policy.get("position_mult", 1.0))
+
+    base_target_notional = equity * base_ratio * tier_risk_mult * news_position_mult
+    max_cap_ratio = float(risk["per_trade_ratio_max"]) * tier_risk_mult * news_position_mult
+    max_cap_notional = round(equity * max_cap_ratio, 2)
+
+    stop_distance_usd = max(atr * float(band_params["stop_mult"]), 0.01)
+    stop_distance_ratio = stop_distance_usd / price
+    target_stop_distance_ratio = float(risk.get("target_stop_distance_ratio", _DEFAULT_TARGET_STOP_DISTANCE_RATIO))
+    volatility_scalar = target_stop_distance_ratio / (target_stop_distance_ratio + stop_distance_ratio)
+    risk_adjusted_notional = base_target_notional * volatility_scalar
+    capped_notional = min(risk_adjusted_notional, max_cap_notional)
+    notional_usd = round(min(capped_notional, free_collateral), 2)
+
+    min_notional_usd = float(risk.get("min_notional_usd", 0))
+    size_blocked = min_notional_usd > 0 and notional_usd < min_notional_usd
+    effective_ratio = 0.0 if equity <= 0 else capped_notional / equity
+    risk_budget_usd = round(base_target_notional * stop_distance_ratio, 2)
+    return {
+        "notional_usd": notional_usd,
+        "size_blocked": size_blocked,
+        "reason": "below_min_notional" if size_blocked else "sizing_ok",
+        "sizing_reason": {
+            "base_ratio": round(base_ratio, 4),
+            "tier_risk_mult": round(tier_risk_mult, 4),
+            "news_position_mult": round(news_position_mult, 4),
+            "final_ratio": round(effective_ratio, 4),
+            "free_collateral_cap": round(free_collateral, 2),
+            "min_notional_usd": round(min_notional_usd, 2),
+            "max_cap_notional": max_cap_notional,
+            "base_target_notional": round(base_target_notional, 2),
+            "risk_budget_usd": risk_budget_usd,
+            "stop_distance_usd": round(stop_distance_usd, 4),
+            "stop_distance_ratio": round(stop_distance_ratio, 6),
+            "target_stop_distance_ratio": round(target_stop_distance_ratio, 6),
+            "volatility_scalar": round(volatility_scalar, 4),
+        },
+    }
+
+
+def compute_scale_in_allowance(
+    account: Dict[str, Any],
+    market: Dict[str, Any],
+    current_notional: float,
+    coin_policy: Dict[str, Any],
+    news_policy: Dict[str, Any],
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    base = compute_position_size(account, market, coin_policy, news_policy, config)
+    max_cap_notional = base["sizing_reason"]["max_cap_notional"]
+    remaining_capacity = round(max(max_cap_notional - float(current_notional), 0.0), 2)
+    additional_notional = round(min(base["notional_usd"], remaining_capacity), 2)
+    min_notional_usd = float(config["risk"].get("min_notional_usd", 0))
+    size_blocked = additional_notional <= 0 or (min_notional_usd > 0 and additional_notional < min_notional_usd)
+    reason = "remaining_capacity_exhausted" if additional_notional <= 0 else ("below_min_notional" if size_blocked else "sizing_ok")
+    return {
+        "additional_notional": additional_notional,
+        "remaining_capacity": remaining_capacity,
+        "size_blocked": size_blocked,
+        "reason": reason,
+        "sizing_reason": base["sizing_reason"],
+    }

--- a/skills/hyperalpha-adaptive/scripts/validators.py
+++ b/skills/hyperalpha-adaptive/scripts/validators.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+ALLOWED_NEWS_RISKS = {"none", "low", "medium", "high", "extreme"}
+
+
+def load_json(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(value)
+
+
+def _require_positive(payload: dict, field: str, errors: List[str]) -> None:
+    value = payload.get(field)
+    if not _is_finite_number(value) or value <= 0:
+        errors.append(f"{field} must be a positive finite number")
+
+
+def validate_account(account: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    _require_positive(account, "equity", errors)
+    free_collateral = account.get("free_collateral", account.get("equity"))
+    if not _is_finite_number(free_collateral) or free_collateral < 0:
+        errors.append("free_collateral must be a finite number >= 0")
+    session_loss_pct = account.get("session_loss_pct", 0)
+    if not _is_finite_number(session_loss_pct) or session_loss_pct < -1 or session_loss_pct > 1:
+        errors.append("session_loss_pct must be a finite number between -1 and 1")
+    session_actions = account.get("session_actions", 0)
+    if not isinstance(session_actions, int) or session_actions < 0:
+        errors.append("session_actions must be a non-negative integer")
+    return errors
+
+
+def validate_market(market: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    coin = market.get("coin")
+    if not isinstance(coin, str) or not coin.strip():
+        errors.append("coin must be a non-empty string")
+    for field in ("price", "recent_high", "recent_low", "atr"):
+        _require_positive(market, field, errors)
+    if (
+        _is_finite_number(market.get("recent_high"))
+        and _is_finite_number(market.get("recent_low"))
+        and market.get("recent_high") < market.get("recent_low")
+    ):
+        errors.append("recent_high must be greater than or equal to recent_low")
+    rsi = market.get("rsi")
+    if not _is_finite_number(rsi) or rsi < 0 or rsi > 100:
+        errors.append("rsi must be in the range [0, 100]")
+    funding_rate = market.get("funding_rate")
+    if not _is_finite_number(funding_rate):
+        errors.append("funding_rate must be finite")
+    trend_bias = market.get("trend_bias")
+    if not _is_finite_number(trend_bias) or trend_bias < -1 or trend_bias > 1:
+        errors.append("trend_bias must be in the range [-1, 1]")
+    trend_strength = market.get("trend_strength")
+    if not _is_finite_number(trend_strength) or trend_strength < 0 or trend_strength > 1:
+        errors.append("trend_strength must be in the range [0, 1]")
+    news_risk = market.get("news_risk", "none")
+    if news_risk not in ALLOWED_NEWS_RISKS:
+        errors.append("news_risk must be one of none/low/medium/high/extreme")
+    return errors
+
+
+def validate_position(position: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    side = position.get("side")
+    if side not in {"long", "short"}:
+        errors.append("position.side must be 'long' or 'short'")
+    _require_positive(position, "entry_price", errors)
+    _require_positive(position, "notional_usd", errors)
+    for field in ("unrealized_pnl", "peak_unrealized_pnl"):
+        value = position.get(field, 0)
+        if not _is_finite_number(value):
+            errors.append(f"{field} must be finite")
+    scale_ins_used = position.get("scale_ins_used", 0)
+    if not isinstance(scale_ins_used, int) or scale_ins_used < 0:
+        errors.append("scale_ins_used must be a non-negative integer")
+    return errors
+
+
+def validate_config_bundle(config: dict, coins: dict, tiers: dict) -> List[str]:
+    errors: List[str] = []
+    if not config.get("strategy_id"):
+        errors.append("strategy_id missing")
+    risk = config.get("risk", {})
+    for key in (
+        "per_trade_ratio",
+        "per_trade_ratio_max",
+        "soft_loss_pct",
+        "emergency_loss_pct",
+        "session_loss_limit_pct",
+    ):
+        if key not in risk:
+            errors.append(f"risk.{key} missing")
+    if risk.get("per_trade_ratio", 0) <= 0:
+        errors.append("risk.per_trade_ratio must be positive")
+    if risk.get("per_trade_ratio_max", 0) < risk.get("per_trade_ratio", 0):
+        errors.append("risk.per_trade_ratio_max must be >= risk.per_trade_ratio")
+    if not coins:
+        errors.append("coins config must not be empty")
+    if not tiers:
+        errors.append("risk tiers config must not be empty")
+    for coin, info in coins.items():
+        tier = info.get("tier")
+        if tier not in tiers:
+            errors.append(f"coin {coin} references unknown tier {tier}")
+        if info.get("risk_mult", 0) <= 0:
+            errors.append(f"coin {coin} risk_mult must be positive")
+    for tier_name, tier_info in tiers.items():
+        if tier_info.get("min_signal_score", -1) < 0 or tier_info.get("min_signal_score", 101) > 100:
+            errors.append(f"{tier_name}.min_signal_score must be in [0, 100]")
+    return errors
+
+
+def normalize_input_payload(mode: str, payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    errors: List[str] = []
+    account = payload.get("account")
+    if not isinstance(account, dict):
+        errors.append("account object is required")
+        account = {}
+    else:
+        errors.extend(validate_account(account))
+
+    if mode == "evaluate":
+        market = payload.get("market")
+        if not isinstance(market, dict):
+            errors.append("market object is required for evaluate")
+        else:
+            errors.extend(validate_market(market))
+        position = payload.get("position")
+        if position is not None:
+            if not isinstance(position, dict):
+                errors.append("position must be an object when provided")
+            else:
+                errors.extend(validate_position(position))
+        return {"account": account, "market": market, "position": position}, errors
+
+    if mode == "scan":
+        markets = payload.get("markets")
+        if not isinstance(markets, list) or not markets:
+            errors.append("markets must be a non-empty list for scan")
+            markets = []
+        else:
+            for idx, market in enumerate(markets):
+                if not isinstance(market, dict):
+                    errors.append(f"markets[{idx}] must be an object")
+                    continue
+                market_errors = validate_market(market)
+                errors.extend([f"markets[{idx}].{err}" for err in market_errors])
+        positions = payload.get("positions", {})
+        if positions is None:
+            positions = {}
+        if not isinstance(positions, dict):
+            errors.append("positions must be an object when provided")
+            positions = {}
+        else:
+            for coin, position in positions.items():
+                if not isinstance(position, dict):
+                    errors.append(f"positions.{coin} must be an object")
+                    continue
+                pos_errors = validate_position(position)
+                errors.extend([f"positions.{coin}.{err}" for err in pos_errors])
+        return {"account": account, "markets": markets, "positions": positions}, errors
+
+    errors.append(f"unsupported mode: {mode}")
+    return {}, errors

--- a/skills/hyperalpha-adaptive/state/README.md
+++ b/skills/hyperalpha-adaptive/state/README.md
@@ -1,0 +1,6 @@
+State directory placeholder for future local strategy state.
+
+
+Plugin Name: hyperalpha-adaptive
+Display Name: HyperAlpha Adaptive
+Plugin/Strategy ID: an25hlq1

--- a/skills/hyperalpha-adaptive/tests/test_strategy.py
+++ b/skills/hyperalpha-adaptive/tests/test_strategy.py
@@ -1,0 +1,1002 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from adaptive_hyperliquid_strategy import (  # type: ignore
+    cmd_evaluate,
+    cmd_scan,
+    load_bundle,
+    _scan_requested_markets,
+    _build_market_from_fetch,
+)
+from decision_engine import evaluate_market, scan_markets  # type: ignore
+from execution_mapper import build_close_command  # type: ignore
+from market_engine import compute_bands  # type: ignore
+from market_fetcher import fetch_public_market_data  # type: ignore
+
+
+class StrategyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bundle = load_bundle(ROOT / "config" / "default.json")
+
+    def account(self, **overrides):
+        data = {
+            "equity": 1000,
+            "free_collateral": 900,
+            "session_loss_pct": 0.0,
+            "session_actions": 0,
+        }
+        data.update(overrides)
+        return data
+
+    def breakout_market(self, coin="BTC", **overrides):
+        if coin == "DOGE":
+            data = {
+                "coin": "DOGE",
+                "price": 0.198,
+                "recent_high": 0.192,
+                "recent_low": 0.17,
+                "atr": 0.0025,
+                "rsi": 68,
+                "funding_rate": 0.00005,
+                "trend_bias": 0.99,
+                "trend_strength": 0.99,
+                "news_risk": "none",
+            }
+        elif coin == "ETH":
+            data = {
+                "coin": "ETH",
+                "price": 3260,
+                "recent_high": 3225,
+                "recent_low": 3090,
+                "atr": 28,
+                "rsi": 63,
+                "funding_rate": 0.0002,
+                "trend_bias": 0.84,
+                "trend_strength": 0.79,
+                "news_risk": "low",
+            }
+        else:
+            data = {
+                "coin": coin,
+                "price": 70520,
+                "recent_high": 70460,
+                "recent_low": 69340,
+                "atr": 60,
+                "rsi": 64,
+                "funding_rate": 0.0002,
+                "trend_bias": 0.91,
+                "trend_strength": 0.86,
+                "news_risk": "none",
+            }
+        data.update(overrides)
+        return data
+
+    def position(self, side="long", **overrides):
+        data = {
+            "side": side,
+            "entry_price": 69000,
+            "notional_usd": 300,
+            "unrealized_pnl": 40,
+            "peak_unrealized_pnl": 50,
+            "scale_ins_used": 0,
+        }
+        data.update(overrides)
+        return data
+
+    def test_invalid_negative_price_no_trade(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market(price=-1))
+        self.assertEqual(result["action"], "none")
+        self.assertEqual(result["safe_result"], "no_trade")
+        self.assertEqual(result["market_regime"], "invalid_data")
+
+    def test_nan_market_data_no_trade(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market(price=float("nan")))
+        self.assertEqual(result["action"], "none")
+        self.assertEqual(result["market_regime"], "invalid_data")
+
+    def test_unknown_coin_rejected(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market(coin="ADA", price=1.2, recent_high=1.1, recent_low=1.0, atr=0.02))
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "unsupported_coin")
+
+    def test_btc_open_long_contains_strategy_id(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"))
+        self.assertEqual(result["action"], "open_long")
+        self.assertIn("--strategy-id an25hlq1", result["hyperliquid_command_template"])
+
+    def test_same_window_fade_predicate_is_structurally_unreachable_with_positive_breakout_buffer(self):
+        for market in (
+            self.breakout_market("BTC", price=70490, rsi=78, trend_bias=0.05, trend_strength=0.4),
+            self.breakout_market("ETH", price=3210, rsi=81, trend_bias=0.1, trend_strength=0.35),
+            self.breakout_market("DOGE", price=0.191, rsi=79, trend_bias=0.0, trend_strength=0.3),
+        ):
+            bands = compute_bands(market, self.bundle["config"])
+            self.assertGreater(bands["upper_band"], market["recent_high"])
+            self.assertFalse(market["recent_high"] > bands["upper_band"])
+
+    def test_same_window_rebound_predicate_is_structurally_unreachable_with_positive_breakdown_buffer(self):
+        for market in (
+            self.breakout_market("BTC", price=69410, rsi=24, trend_bias=-0.05, trend_strength=0.4),
+            self.breakout_market("ETH", price=3095, rsi=22, trend_bias=-0.1, trend_strength=0.35),
+            self.breakout_market("DOGE", price=0.171, rsi=25, trend_bias=0.0, trend_strength=0.3),
+        ):
+            bands = compute_bands(market, self.bundle["config"])
+            self.assertLess(bands["lower_band"], market["recent_low"])
+            self.assertFalse(market["recent_low"] < bands["lower_band"])
+
+    def test_failed_breakout_fade_short_can_open_short_with_explicit_probe_levels(self):
+        market = self.breakout_market(
+            "BTC",
+            price=70410,
+            recent_high=70460,
+            recent_low=69340,
+            atr=60,
+            rsi=80,
+            funding_rate=0.0001,
+            trend_bias=-0.15,
+            trend_strength=0.82,
+            prior_high=70460,
+            probe_high=70600,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "open_short")
+        self.assertEqual(result["market_regime"], "fade")
+
+    def test_failed_breakdown_rebound_long_can_open_long_with_explicit_probe_levels(self):
+        market = self.breakout_market(
+            "BTC",
+            price=69390,
+            recent_high=70460,
+            recent_low=69340,
+            atr=60,
+            rsi=22,
+            funding_rate=-0.0001,
+            trend_bias=0.15,
+            trend_strength=0.82,
+            prior_low=69340,
+            probe_low=69180,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "open_long")
+        self.assertEqual(result["market_regime"], "rebound")
+
+    def test_deeper_failed_breakout_ranks_above_shallower_failed_breakout(self):
+        deeper = self.breakout_market(
+            "BTC",
+            price=70410,
+            recent_high=70460,
+            recent_low=69340,
+            atr=60,
+            rsi=80,
+            funding_rate=0.0001,
+            trend_bias=-0.15,
+            trend_strength=0.82,
+            prior_high=70460,
+            probe_high=70620,
+        )
+        shallower = self.breakout_market(
+            "ETH",
+            price=3212,
+            recent_high=3225,
+            recent_low=3090,
+            atr=28,
+            rsi=79,
+            funding_rate=0.0001,
+            trend_bias=-0.12,
+            trend_strength=0.8,
+            prior_high=3225,
+            probe_high=3250,
+        )
+        scan = scan_markets(self.bundle, self.account(), [shallower, deeper])
+        self.assertEqual(scan["top_opportunities"][0]["coin"], "BTC")
+        self.assertGreater(scan["top_opportunities"][0]["signal_score"], scan["top_opportunities"][1]["signal_score"])
+
+    def test_existing_position_with_zero_free_collateral_is_treated_as_defensive_hold(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(free_collateral=0),
+            self.breakout_market("BTC"),
+            self.position(unrealized_pnl=50, peak_unrealized_pnl=50, notional_usd=120),
+        )
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "hold_normalized")
+        self.assertNotIn("hyperliquid_command_template", result)
+
+    def test_open_long_exposes_band_and_component_diagnostics(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"))
+        self.assertIn("upper_band", result)
+        self.assertIn("lower_band", result)
+        self.assertIn("component_scores", result)
+        self.assertIn("trend", result["component_scores"])
+
+    def test_eth_reduce_contains_strategy_id(self):
+        market = self.breakout_market("ETH", rsi=80, funding_rate=0.001)
+        position = self.position(entry_price=3180, unrealized_pnl=65, peak_unrealized_pnl=80)
+        result = evaluate_market(self.bundle, self.account(), market, position)
+        self.assertEqual(result["action"], "reduce")
+        self.assertIn("--strategy-id an25hlq1", result["hyperliquid_command_template"])
+
+    def test_close_all_contains_reduce_only(self):
+        market = self.breakout_market("BTC")
+        position = self.position(unrealized_pnl=-45, peak_unrealized_pnl=0)
+        result = evaluate_market(self.bundle, self.account(), market, position)
+        self.assertEqual(result["action"], "close_all")
+        self.assertIn("--reduce-only", result["hyperliquid_command_template"])
+
+    def test_position_risk_close_all_includes_loss_metric(self):
+        market = self.breakout_market("BTC")
+        position = self.position(unrealized_pnl=-45, peak_unrealized_pnl=0)
+        result = evaluate_market(self.bundle, self.account(), market, position)
+        self.assertEqual(result["market_regime"], "position_risk")
+        self.assertIn("loss_pct_equity", result)
+        self.assertGreater(result["loss_pct_equity"], 0)
+
+    def test_profit_giveback_reduce_includes_giveback_metric(self):
+        market = self.breakout_market("ETH", rsi=65, funding_rate=0.0002)
+        position = self.position(entry_price=3180, unrealized_pnl=48, peak_unrealized_pnl=80)
+        result = evaluate_market(self.bundle, self.account(), market, position)
+        self.assertEqual(result["action"], "reduce")
+        self.assertEqual(result["market_regime"], "profit_giveback")
+        self.assertIn("profit_giveback_pct", result)
+        self.assertGreaterEqual(result["profit_giveback_pct"], 0.35)
+
+    def test_tier3_coin_position_size_reduced(self):
+        btc = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"))
+        doge = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("DOGE", price=0.6, recent_high=0.59, recent_low=0.54),
+        )
+        self.assertEqual(doge["action"], "open_long")
+        self.assertLess(doge["notional_usd"], btc["notional_usd"])
+
+    def test_failed_market_fetch_no_trade(self):
+        market = self.breakout_market("BTC")
+        del market["atr"]
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "none")
+        self.assertEqual(result["market_regime"], "invalid_data")
+
+    def test_fetch_public_market_data_parses_okx_public_responses(self):
+        responses = [
+            {
+                "code": "0",
+                "data": [{"instId": "BTC-USDT-SWAP", "markPx": "100.5", "ts": "1700000000000"}],
+                "msg": "",
+            },
+            {
+                "code": "0",
+                "data": [{"instId": "BTC-USDT-SWAP", "fundingRate": "0.00012", "ts": "1700000000001"}],
+                "msg": "",
+            },
+            {
+                "code": "0",
+                "data": [
+                    ["1700000000000", "99", "101", "98", "100", "1", "1", "100", "1"],
+                    ["1700003600000", "100", "102", "99", "101", "4", "1", "101", "1"],
+                    ["1700007200000", "101", "103", "100", "102", "7", "1", "102", "1"],
+                ],
+                "msg": "",
+            },
+            {
+                "code": "0",
+                "data": [
+                    ["1700000000000", "2500000000"],
+                    ["1700003600000", "2550000000"],
+                    ["1700007200000", "2650000000"],
+                ],
+                "msg": "",
+            },
+        ]
+        with patch("market_fetcher._http_get_json", side_effect=responses):
+            result = fetch_public_market_data("BTC")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["symbol"], "BTC-USDT-SWAP")
+        self.assertEqual(result["source"], "okx_swap_public")
+        self.assertEqual(result["price"], 100.5)
+        self.assertEqual(result["funding"], 0.00012)
+        self.assertEqual(len(result["candles_1h"]), 3)
+        self.assertEqual(len(result["oi_history_1h"]), 3)
+        self.assertEqual(result["oi_usd"], 2650000000.0)
+
+    def test_build_market_from_fetch_derives_participation_metrics(self):
+        fetch_result = {
+            "ok": True,
+            "coin": "BTC",
+            "price": 102.0,
+            "funding": 0.0001,
+            "oi_usd": 2650000000.0,
+            "oi_history_1h": [
+                {"timestamp": 1700000000000, "oi_usd": 2500000000.0},
+                {"timestamp": 1700003600000, "oi_usd": 2550000000.0},
+                {"timestamp": 1700007200000, "oi_usd": 2650000000.0},
+            ],
+            "timestamp": 1700000000000,
+            "source": "okx_swap_public",
+            "candles_1h": [
+                {"high": 100.0, "low": 95.0, "close": 97.0, "volume": 1.0},
+                {"high": 101.0, "low": 95.5, "close": 98.0, "volume": 1.2},
+                {"high": 102.0, "low": 96.0, "close": 99.0, "volume": 1.4},
+                {"high": 103.0, "low": 96.5, "close": 100.0, "volume": 1.6},
+                {"high": 104.0, "low": 97.0, "close": 101.0, "volume": 2.2},
+                {"high": 105.0, "low": 97.5, "close": 102.0, "volume": 3.8},
+            ],
+        }
+        market, error = _build_market_from_fetch(fetch_result, "BTC")
+        self.assertIsNone(error)
+        self.assertGreater(market["volume_ratio"], 1.0)
+        self.assertGreater(market["oi_change_ratio"], 0.0)
+        self.assertGreater(market["participation_bias"], 0.0)
+
+    def test_build_market_from_fetch_derives_probe_levels_for_reversal_setups(self):
+        fetch_result = {
+            "ok": True,
+            "coin": "BTC",
+            "price": 100.0,
+            "funding": 0.0001,
+            "timestamp": 1700000000000,
+            "source": "okx_swap_public",
+            "candles_1h": [
+                {"high": 100.0, "low": 95.0, "close": 97.0},
+                {"high": 101.0, "low": 95.5, "close": 98.0},
+                {"high": 102.0, "low": 96.0, "close": 99.0},
+                {"high": 103.0, "low": 96.5, "close": 100.0},
+                {"high": 104.0, "low": 97.0, "close": 101.0},
+                {"high": 108.0, "low": 97.5, "close": 102.0},
+                {"high": 105.0, "low": 94.0, "close": 99.5},
+                {"high": 104.5, "low": 95.0, "close": 100.0},
+            ],
+        }
+        market, error = _build_market_from_fetch(fetch_result, "BTC")
+        self.assertIsNone(error)
+        self.assertEqual(market["source"], "okx_swap_public")
+        self.assertIn("prior_high", market)
+        self.assertIn("prior_low", market)
+        self.assertIn("probe_high", market)
+        self.assertIn("probe_low", market)
+        self.assertGreaterEqual(market["probe_high"], market["prior_high"])
+        self.assertLessEqual(market["probe_low"], market["prior_low"])
+
+    def test_fetch_market_trend_features_promote_breakout_candidate_over_old_sma_bias(self):
+        fetch_result = {
+            "ok": True,
+            "coin": "BTC",
+            "price": 104.95,
+            "funding": 0.0001,
+            "oi_usd": 2650000000.0,
+            "oi_history_1h": [
+                {"timestamp": 1, "oi_usd": 2500000000.0},
+                {"timestamp": 2, "oi_usd": 2550000000.0},
+                {"timestamp": 3, "oi_usd": 2650000000.0},
+            ],
+            "timestamp": 1,
+            "source": "okx_swap_public",
+            "candles_1h": [
+                {"high": 101.35, "low": 100.09, "close": 100.58, "volume": 1.0},
+                {"high": 101.7, "low": 100.6, "close": 101.03, "volume": 1.1},
+                {"high": 102.49, "low": 101.1, "close": 101.73, "volume": 1.2},
+                {"high": 102.3, "low": 100.66, "close": 101.51, "volume": 1.15},
+                {"high": 102.33, "low": 101.23, "close": 101.68, "volume": 1.2},
+                {"high": 102.46, "low": 101.21, "close": 101.59, "volume": 1.18},
+                {"high": 102.86, "low": 101.4, "close": 102.25, "volume": 1.22},
+                {"high": 102.94, "low": 101.22, "close": 102.1, "volume": 1.24},
+                {"high": 103.75, "low": 102.34, "close": 102.99, "volume": 1.35},
+                {"high": 103.36, "low": 102.2, "close": 102.85, "volume": 1.4},
+                {"high": 103.43, "low": 101.75, "close": 102.7, "volume": 1.38},
+                {"high": 102.77, "low": 101.5, "close": 102.33, "volume": 1.32},
+                {"high": 103.78, "low": 102.18, "close": 102.93, "volume": 1.55},
+                {"high": 103.62, "low": 102.18, "close": 102.91, "volume": 1.62},
+                {"high": 104.13, "low": 102.83, "close": 103.4, "volume": 1.78},
+                {"high": 104.3, "low": 102.9, "close": 103.61, "volume": 2.2},
+                {"high": 104.09, "low": 102.79, "close": 103.39, "volume": 2.6},
+            ],
+        }
+        market, error = _build_market_from_fetch(fetch_result, "BTC")
+        self.assertIsNone(error)
+        self.assertGreaterEqual(market["trend_strength"], 0.55)
+        self.assertGreater(market["trend_bias"], 0)
+        self.assertGreater(market["participation_bias"], 0)
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["market_regime"], "breakout")
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "threshold_not_met")
+
+    def test_fetch_market_breakout_entry_still_rejected_when_rsi_is_overheated(self):
+        fetch_result = {
+            "ok": True,
+            "coin": "BTC",
+            "price": 112.6,
+            "funding": 0.0001,
+            "oi_usd": 2750000000.0,
+            "oi_history_1h": [
+                {"timestamp": 1, "oi_usd": 2500000000.0},
+                {"timestamp": 2, "oi_usd": 2620000000.0},
+                {"timestamp": 3, "oi_usd": 2750000000.0},
+            ],
+            "timestamp": 1,
+            "source": "okx_swap_public",
+            "candles_1h": [
+                {"high": 100.8, "low": 99.2, "close": 100.0, "volume": 1.0},
+                {"high": 102.0, "low": 100.0, "close": 101.4, "volume": 1.1},
+                {"high": 101.8, "low": 100.6, "close": 101.0, "volume": 1.0},
+                {"high": 103.4, "low": 101.0, "close": 102.8, "volume": 1.2},
+                {"high": 103.0, "low": 101.8, "close": 102.2, "volume": 1.18},
+                {"high": 104.6, "low": 102.0, "close": 104.0, "volume": 1.28},
+                {"high": 104.4, "low": 103.0, "close": 103.6, "volume": 1.26},
+                {"high": 106.0, "low": 103.4, "close": 105.2, "volume": 1.4},
+                {"high": 105.8, "low": 104.2, "close": 105.0, "volume": 1.42},
+                {"high": 107.4, "low": 104.8, "close": 106.8, "volume": 1.52},
+                {"high": 107.0, "low": 105.8, "close": 106.2, "volume": 1.5},
+                {"high": 108.8, "low": 106.0, "close": 108.0, "volume": 1.7},
+                {"high": 108.4, "low": 107.0, "close": 107.8, "volume": 1.74},
+                {"high": 110.2, "low": 107.6, "close": 109.4, "volume": 1.95},
+                {"high": 110.0, "low": 108.6, "close": 109.0, "volume": 1.9},
+                {"high": 111.8, "low": 108.8, "close": 111.0, "volume": 2.3},
+            ],
+        }
+        market, error = _build_market_from_fetch(fetch_result, "BTC")
+        self.assertIsNone(error)
+        self.assertGreaterEqual(market["trend_strength"], 0.55)
+        self.assertGreater(market["rsi"], self.bundle["config"]["thresholds"]["rsi_long_max"])
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "none")
+        self.assertEqual(result["market_regime"], "range")
+
+    def test_breakout_with_rising_open_interest_and_volume_clears_entry_threshold(self):
+        market = self.breakout_market(
+            "BTC",
+            trend_bias=0.92,
+            trend_strength=0.88,
+            funding_rate=0.0001,
+            rsi=63,
+            news_risk="none",
+            volume_ratio=1.75,
+            oi_change_ratio=0.12,
+            participation_bias=0.7,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "open_long")
+        self.assertIn("participation", result["component_scores"])
+        self.assertGreater(result["component_scores"]["participation"], 0)
+
+    def test_breakout_without_participation_confirmation_stays_below_entry_threshold(self):
+        market = self.breakout_market(
+            "BTC",
+            trend_bias=0.92,
+            trend_strength=0.88,
+            funding_rate=0.0001,
+            rsi=63,
+            news_risk="none",
+            volume_ratio=0.65,
+            oi_change_ratio=-0.08,
+            participation_bias=-0.7,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "threshold_not_met")
+        self.assertIn("participation", result["component_scores"])
+        self.assertLess(result["component_scores"]["participation"], 6)
+
+    def test_nan_participation_inputs_are_neutralized_instead_of_boosting_signal(self):
+        baseline = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market(
+                "BTC",
+                trend_bias=0.92,
+                trend_strength=0.88,
+                funding_rate=0.0001,
+                rsi=63,
+                news_risk="none",
+            ),
+        )
+        corrupted = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market(
+                "BTC",
+                trend_bias=0.92,
+                trend_strength=0.88,
+                funding_rate=0.0001,
+                rsi=63,
+                news_risk="none",
+                volume_ratio=float("nan"),
+                oi_change_ratio=float("nan"),
+                participation_bias=float("nan"),
+            ),
+        )
+        self.assertEqual(corrupted["component_scores"]["participation"], 0.0)
+        self.assertEqual(corrupted["signal_score"], baseline["signal_score"])
+
+    def test_breakout_with_moderately_hot_rsi_still_can_open_when_technical_signal_is_strong(self):
+        market = self.breakout_market(
+            "BTC",
+            price=70580,
+            trend_bias=0.96,
+            trend_strength=0.92,
+            funding_rate=0.0001,
+            rsi=72,
+            news_risk="none",
+            volume_ratio=1.95,
+            oi_change_ratio=0.14,
+            participation_bias=0.85,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "open_long")
+        self.assertEqual(result["market_regime"], "breakout")
+
+    def test_breakout_with_high_news_risk_can_still_open_when_technical_signal_is_strong(self):
+        market = self.breakout_market(
+            "BTC",
+            price=70540,
+            trend_bias=0.97,
+            trend_strength=0.95,
+            funding_rate=0.0001,
+            rsi=64,
+            news_risk="high",
+            volume_ratio=2.0,
+            oi_change_ratio=0.14,
+            participation_bias=0.9,
+        )
+        result = evaluate_market(self.bundle, self.account(), market)
+        self.assertEqual(result["action"], "open_long")
+        self.assertLess(result["notional_usd"], 300)
+
+    def test_signal_score_range(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"))
+        self.assertGreaterEqual(result["signal_score"], 0)
+        self.assertLessEqual(result["signal_score"], 100)
+
+    def test_supported_coin_scan(self):
+        scan = scan_markets(
+            self.bundle,
+            self.account(),
+            [self.breakout_market("BTC"), self.breakout_market("ETH"), self.breakout_market("DOGE")],
+        )
+        self.assertTrue(len(scan["top_opportunities"]) >= 1)
+        self.assertIn(scan["top_opportunities"][0]["coin"], {"BTC", "ETH", "DOGE"})
+
+    def test_scan_markets_returns_results_sorted_by_action_priority_and_signal_score(self):
+        deeper = self.breakout_market(
+            "BTC",
+            price=70410,
+            recent_high=70460,
+            recent_low=69340,
+            atr=60,
+            rsi=80,
+            funding_rate=0.0001,
+            trend_bias=-0.15,
+            trend_strength=0.82,
+            prior_high=70460,
+            probe_high=70620,
+        )
+        shallower = self.breakout_market(
+            "ETH",
+            price=3212,
+            recent_high=3225,
+            recent_low=3090,
+            atr=28,
+            rsi=79,
+            funding_rate=0.0001,
+            trend_bias=-0.12,
+            trend_strength=0.8,
+            prior_high=3225,
+            probe_high=3250,
+        )
+        scan = scan_markets(self.bundle, self.account(), [shallower, deeper])
+        self.assertEqual([item["coin"] for item in scan["results"][:2]], ["BTC", "ETH"])
+
+    def test_every_live_command_contains_strategy_id(self):
+        open_result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"))
+        reduce_result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("ETH", rsi=80, funding_rate=0.001),
+            self.position(entry_price=3180),
+        )
+        close_result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"), self.position(unrealized_pnl=-45, peak_unrealized_pnl=0))
+        scale_result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC"), self.position(unrealized_pnl=50, peak_unrealized_pnl=50, notional_usd=120, trend_bias=0.91, trend_strength=0.86))
+        for result in (open_result, reduce_result, close_result, scale_result):
+            self.assertIn("--strategy-id an25hlq1", result["hyperliquid_command_template"])
+
+    def test_non_whitelist_coin_observe_or_reject(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market(coin="PEPE", price=0.00001, recent_high=0.000009, recent_low=0.000008, atr=0.0000005))
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "unsupported_coin")
+
+    def test_rsi_out_of_range_no_trade(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC", rsi=101))
+        self.assertEqual(result["action"], "none")
+        self.assertEqual(result["market_regime"], "invalid_data")
+
+    def test_fraction_out_of_range_rejected(self):
+        with self.assertRaises(ValueError):
+            build_close_command("ETH", 1.5, "adaptive-hyperliquid-strategy")
+
+    def test_session_loss_limit_blocks_new_entries(self):
+        result = evaluate_market(self.bundle, self.account(session_loss_pct=0.07), self.breakout_market("BTC"))
+        self.assertEqual(result["action"], "halt_new_entries")
+        self.assertNotIn("hyperliquid_command_template", result)
+
+    def test_max_actions_per_session_blocks_scalein(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(session_actions=3),
+            self.breakout_market("BTC"),
+            self.position(unrealized_pnl=55, peak_unrealized_pnl=55, notional_usd=120),
+        )
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "hold_normalized")
+
+    def test_extreme_news_risk_halts_new_entries_but_allows_reduce(self):
+        halted = evaluate_market(self.bundle, self.account(), self.breakout_market("BTC", news_risk="extreme"))
+        self.assertEqual(halted["action"], "halt_new_entries")
+        reduced = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("ETH", news_risk="extreme", rsi=80, funding_rate=0.001),
+            self.position(entry_price=3180, unrealized_pnl=65, peak_unrealized_pnl=80),
+        )
+        self.assertEqual(reduced["action"], "reduce")
+
+    def test_profitable_long_is_not_forced_to_reduce_on_single_mild_overheat_signal(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC", rsi=75, funding_rate=0.0002),
+            self.position(unrealized_pnl=35, peak_unrealized_pnl=35, notional_usd=300, scale_ins_used=1),
+        )
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "hold_normalized")
+
+    def test_hold_is_normalized_to_observe(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC", trend_bias=0.3, trend_strength=0.35, price=70000, recent_high=70500, recent_low=69400, rsi=55),
+            self.position(unrealized_pnl=10, peak_unrealized_pnl=12, notional_usd=300, scale_ins_used=1),
+        )
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "hold_normalized")
+
+    def test_non_whitelist_coin_has_no_command_template(self):
+        result = evaluate_market(self.bundle, self.account(), self.breakout_market(coin="ARB", price=2.1, recent_high=2.0, recent_low=1.8, atr=0.05))
+        self.assertNotIn("hyperliquid_command_template", result)
+
+    def test_scale_in_respects_per_trade_ratio_max(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC"),
+            self.position(unrealized_pnl=60, peak_unrealized_pnl=60, notional_usd=780),
+        )
+        self.assertEqual(result["action"], "scale_in")
+        self.assertLessEqual(result["notional_usd"], 20)
+
+    def test_scale_in_includes_post_scale_notional(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC"),
+            self.position(unrealized_pnl=50, peak_unrealized_pnl=50, notional_usd=120),
+        )
+        self.assertEqual(result["action"], "scale_in")
+        self.assertIn("current_notional_usd", result)
+        self.assertIn("post_scale_in_notional_usd", result)
+        self.assertAlmostEqual(
+            result["post_scale_in_notional_usd"],
+            result["current_notional_usd"] + result["notional_usd"],
+        )
+
+    def test_scale_in_below_min_notional_is_blocked_to_observe(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(free_collateral=5),
+            self.breakout_market("BTC"),
+            self.position(unrealized_pnl=50, peak_unrealized_pnl=50, notional_usd=120),
+        )
+        self.assertEqual(result["action"], "observe")
+        self.assertEqual(result["safe_result"], "hold_normalized")
+        self.assertNotIn("hyperliquid_command_template", result)
+
+    def test_wider_stop_distance_reduces_open_notional_for_same_market_and_account(self):
+        tighter = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC", atr=30),
+        )
+        wider = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC", atr=60),
+        )
+        self.assertEqual(tighter["action"], "open_long")
+        self.assertEqual(wider["action"], "open_long")
+        self.assertLess(wider["notional_usd"], tighter["notional_usd"])
+        self.assertIn("stop_distance_usd", tighter["sizing_reason"])
+        self.assertIn("risk_budget_usd", tighter["sizing_reason"])
+
+    def test_risk_based_sizing_reason_includes_stop_ratio_diagnostics(self):
+        result = evaluate_market(
+            self.bundle,
+            self.account(),
+            self.breakout_market("BTC", atr=60),
+        )
+        self.assertEqual(result["action"], "open_long")
+        self.assertIn("stop_distance_usd", result["sizing_reason"])
+        self.assertIn("stop_distance_ratio", result["sizing_reason"])
+        self.assertIn("volatility_scalar", result["sizing_reason"])
+
+    def test_scan_requested_markets_prefers_payload_markets_when_no_coin_arg(self):
+        payload = {
+            "markets": [
+                {"coin": "BTC", "price": 1},
+                {"coin": "ETH", "price": 2},
+            ]
+        }
+        result = _scan_requested_markets(payload, self.bundle["coins"], None)
+        self.assertEqual(result, payload["markets"])
+
+    def test_cmd_scan_fetch_market_prefers_payload_markets_over_enabled_coin_list(self):
+        payload = {
+            "account": self.account(),
+            "markets": [
+                {"coin": "BTC"},
+                {"coin": "ETH"},
+            ],
+            "positions": {},
+        }
+        fetch_calls = []
+
+        def fake_fetch(coin):
+            fetch_calls.append(coin)
+            return {
+                "ok": False,
+                "coin": coin,
+                "reason": "market_fetch_not_supported_for_coin",
+            }
+
+        args = argparse.Namespace(
+            config=str(ROOT / "config" / "default.json"),
+            input=str(ROOT / "examples" / "scan_input.json"),
+            fetch_market=True,
+            coins=None,
+        )
+
+        with patch("adaptive_hyperliquid_strategy.load_bundle", return_value=self.bundle), patch(
+            "adaptive_hyperliquid_strategy.load_json", return_value=payload
+        ), patch("adaptive_hyperliquid_strategy.fetch_public_market_data", side_effect=fake_fetch):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cmd_scan(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(fetch_calls, ["BTC", "ETH"])
+        result = json.loads(stdout.getvalue())
+        self.assertEqual([item["coin"] for item in result["results"]], ["BTC", "ETH"])
+
+    def test_cmd_scan_fetch_market_sorts_results_by_action_priority_and_signal_score(self):
+        payload = {
+            "account": self.account(),
+            "markets": [
+                {"coin": "BTC"},
+                {"coin": "ETH"},
+                {"coin": "DOGE"},
+            ],
+            "positions": {},
+        }
+
+        fake_results = {
+            "BTC": {
+                "coin": "BTC",
+                "action": "observe",
+                "signal_score": 88,
+                "safe_result": "threshold_not_met",
+            },
+            "ETH": {
+                "coin": "ETH",
+                "action": "open_long",
+                "signal_score": 76,
+                "safe_result": "tradable",
+            },
+            "DOGE": {
+                "coin": "DOGE",
+                "action": "open_long",
+                "signal_score": 91,
+                "safe_result": "tradable",
+            },
+        }
+
+        args = argparse.Namespace(
+            config=str(ROOT / "config" / "default.json"),
+            input=str(ROOT / "examples" / "scan_input.json"),
+            fetch_market=True,
+            coins=None,
+        )
+
+        def fake_fetch(coin):
+            return {
+                "ok": True,
+                "coin": coin,
+                "price": 1.0,
+                "funding": 0.0,
+                "candles_1h": [
+                    {"high": 1.1, "low": 0.9, "close": 1.0},
+                    {"high": 1.1, "low": 0.9, "close": 1.0},
+                    {"high": 1.1, "low": 0.9, "close": 1.0},
+                ],
+                "timestamp": 1,
+                "source": "okx_swap_public",
+            }
+
+        def fake_scan_markets(bundle, account, markets, positions):
+            return {
+                "strategy_id": bundle["config"]["strategy_id"],
+                "dry_run": True,
+                "results": [fake_results[market["coin"]] for market in markets],
+                "top_opportunities": [],
+            }
+
+        with patch("adaptive_hyperliquid_strategy.load_bundle", return_value=self.bundle), patch(
+            "adaptive_hyperliquid_strategy.load_json", return_value=payload
+        ), patch("adaptive_hyperliquid_strategy.fetch_public_market_data", side_effect=fake_fetch), patch(
+            "adaptive_hyperliquid_strategy.scan_markets", side_effect=fake_scan_markets
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cmd_scan(args)
+
+        self.assertEqual(exit_code, 0)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual([item["coin"] for item in result["results"]], ["DOGE", "ETH", "BTC"])
+        self.assertEqual([item["coin"] for item in result["top_opportunities"]], ["DOGE", "ETH"])
+        self.assertTrue(all(item["action"] in {"open_long", "open_short", "scale_in", "reduce", "close_all"} for item in result["top_opportunities"]))
+    def test_cmd_evaluate_fetch_market_can_write_audit_file(self):
+        payload = {
+            "account": self.account(),
+            "market": {"coin": "BTC"},
+        }
+        args = argparse.Namespace(
+            config=str(ROOT / "config" / "default.json"),
+            input=str(ROOT / "examples" / "single_evaluate_input.json"),
+            fetch_market=True,
+            audit_output=str(ROOT / "tmp-evaluate-audit.json"),
+        )
+        fetch_result = {
+            "ok": True,
+            "coin": "BTC",
+            "price": 100.0,
+            "funding": 0.0001,
+            "oi_usd": 2650000000.0,
+            "oi_history_1h": [
+                {"timestamp": 1, "oi_usd": 2500000000.0},
+                {"timestamp": 2, "oi_usd": 2550000000.0},
+                {"timestamp": 3, "oi_usd": 2650000000.0},
+            ],
+            "timestamp": 1,
+            "source": "okx_swap_public",
+            "candles_1h": [
+                {"high": 100.0, "low": 95.0, "close": 97.0, "volume": 1.0},
+                {"high": 101.0, "low": 95.5, "close": 98.0, "volume": 1.2},
+                {"high": 102.0, "low": 96.0, "close": 99.0, "volume": 1.4},
+                {"high": 103.0, "low": 96.5, "close": 100.0, "volume": 1.6},
+                {"high": 104.0, "low": 97.0, "close": 101.0, "volume": 2.2},
+                {"high": 105.0, "low": 97.5, "close": 102.0, "volume": 3.8},
+            ],
+        }
+        audit_captures = []
+
+        def fake_write_text(self, content, encoding="utf-8"):
+            audit_captures.append({"path": str(self), "content": content, "encoding": encoding})
+            return len(content)
+
+        with patch("adaptive_hyperliquid_strategy.load_bundle", return_value=self.bundle), patch(
+            "adaptive_hyperliquid_strategy.load_json", return_value=payload
+        ), patch("adaptive_hyperliquid_strategy.fetch_public_market_data", return_value=fetch_result), patch(
+            "pathlib.Path.write_text", new=fake_write_text
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cmd_evaluate(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(audit_captures), 1)
+        self.assertTrue(audit_captures[0]["path"].endswith("tmp-evaluate-audit.json"))
+        audit_payload = json.loads(audit_captures[0]["content"])
+        self.assertEqual(audit_payload["mode"], "evaluate")
+        self.assertEqual(audit_payload["coin"], "BTC")
+        self.assertIn("fetch_result", audit_payload)
+        self.assertIn("derived_market", audit_payload)
+        self.assertIn("result", audit_payload)
+
+    def test_cmd_scan_fetch_market_can_write_audit_file(self):
+        payload = {
+            "account": self.account(),
+            "markets": [
+                {"coin": "BTC"},
+                {"coin": "ETH"},
+            ],
+            "positions": {},
+        }
+        args = argparse.Namespace(
+            config=str(ROOT / "config" / "default.json"),
+            input=str(ROOT / "examples" / "scan_input.json"),
+            fetch_market=True,
+            coins=None,
+            audit_output=str(ROOT / "tmp-scan-audit.json"),
+        )
+
+        def fake_fetch(coin):
+            if coin == "BTC":
+                return {
+                    "ok": True,
+                    "coin": coin,
+                    "price": 100.0,
+                    "funding": 0.0001,
+                    "oi_usd": 2650000000.0,
+                    "oi_history_1h": [
+                        {"timestamp": 1, "oi_usd": 2500000000.0},
+                        {"timestamp": 2, "oi_usd": 2550000000.0},
+                        {"timestamp": 3, "oi_usd": 2650000000.0},
+                    ],
+                    "timestamp": 1,
+                    "source": "okx_swap_public",
+                    "candles_1h": [
+                        {"high": 100.0, "low": 95.0, "close": 97.0, "volume": 1.0},
+                        {"high": 101.0, "low": 95.5, "close": 98.0, "volume": 1.2},
+                        {"high": 102.0, "low": 96.0, "close": 99.0, "volume": 1.4},
+                        {"high": 103.0, "low": 96.5, "close": 100.0, "volume": 1.6},
+                        {"high": 104.0, "low": 97.0, "close": 101.0, "volume": 2.2},
+                        {"high": 105.0, "low": 97.5, "close": 102.0, "volume": 3.8},
+                    ],
+                }
+            return {
+                "ok": False,
+                "coin": coin,
+                "reason": "market_fetch_not_supported_for_coin",
+            }
+
+        audit_captures = []
+
+        def fake_write_text(self, content, encoding="utf-8"):
+            audit_captures.append({"path": str(self), "content": content, "encoding": encoding})
+            return len(content)
+
+        with patch("adaptive_hyperliquid_strategy.load_bundle", return_value=self.bundle), patch(
+            "adaptive_hyperliquid_strategy.load_json", return_value=payload
+        ), patch("adaptive_hyperliquid_strategy.fetch_public_market_data", side_effect=fake_fetch), patch(
+            "pathlib.Path.write_text", new=fake_write_text
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cmd_scan(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(audit_captures), 1)
+        self.assertTrue(audit_captures[0]["path"].endswith("tmp-scan-audit.json"))
+        audit_payload = json.loads(audit_captures[0]["content"])
+        self.assertEqual(audit_payload["mode"], "scan")
+        self.assertEqual([item["coin"] for item in audit_payload["coins"]], ["BTC", "ETH"])
+        self.assertEqual(audit_payload["coins"][0]["fetch_status"], "ok")
+        self.assertEqual(audit_payload["coins"][1]["fetch_status"], "error")
+        self.assertIn("derived_market", audit_payload["coins"][0])
+        self.assertIn("result", audit_payload["coins"][0])
+        self.assertEqual(audit_payload["coins"][1]["fetch_error"], "market_fetch_not_supported_for_coin")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new strategy plugin `hyperalpha-adaptive`
- dry-run-first Hyperliquid strategy skill with explicit `--strategy-id an25hlq1` attribution
- includes config, examples, tests, and OKX public market fetch support

## Validation
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/adaptive_hyperliquid_strategy.py validate-config --config config/default.json`
- `python3 -m unittest discover -s tests -v` (50/50 passed)
- `evaluate` / `scan` examples passed
- `--fetch-market` evaluate / scan passed

## Submission Notes
- this PR contains one plugin only
- changes are scoped to `skills/hyperalpha-adaptive/`
- `SUMMARY.md` is in English
- strategy write templates include `--strategy-id an25hlq1`
