### PR TITLE
[new-plugin] otto-kol-follow v0.1.0

### DIFF
--- a/skills/otto-kol-follow/.claude-plugin/plugin.json
+++ b/skills/otto-kol-follow/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "otto-kol-follow",
+  "description": "Otto KOL Follow — Mirror the top 50 crypto KOLs on Twitter/X into a Hyperliquid perp. Natural-language intent in, one-click consensus trade with TP/SL out. Dry-run by default.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Otto AI"
+  },
+  "homepage": "https://useotto.xyz",
+  "repository": "https://github.com/useOttoAI/plugin-store",
+  "license": "MIT",
+  "keywords": [
+    "perpetuals",
+    "hyperliquid",
+    "onchainos",
+    "trading-strategy",
+    "kol-sentiment",
+    "social-signals"
+  ]
+}

--- a/skills/otto-kol-follow/LICENSE
+++ b/skills/otto-kol-follow/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Otto AI (@useOttoAI)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/otto-kol-follow/README.md
+++ b/skills/otto-kol-follow/README.md
@@ -1,0 +1,52 @@
+# Otto KOL Follow
+
+Mirror the top 50 crypto KOLs on Twitter/X into a Hyperliquid perpetual — one consensus-driven trade per user intent, with automatic TP/SL brackets, inside OKX Onchain OS Agentic Wallet.
+
+**Dry-run by default.** `--confirm` required for live orders.
+
+## Files
+
+```
+otto-kol-follow/
+├── .claude-plugin/
+│   └── plugin.json       # Claude Skill registration metadata
+├── plugin.yaml           # Plugin Store manifest
+├── SKILL.md              # AI agent protocol (reactive 7-step flow)
+├── SUMMARY.md            # User-facing summary
+├── README.md             # This file
+├── LICENSE               # MIT
+└── scripts/
+    ├── config.py         # Hot-reloadable params (edit this, not bot.py)
+    └── bot.py            # Optional autonomous poller (advanced users)
+```
+
+## Decision rule
+
+Fire a trade only if:
+
+- Cohort sample size ≥ `MIN_KOL_COUNT` (default 40) — prevents thin-sample mirrors
+- Otto confidence ≥ `MIN_CONFIDENCE_KOL` (default 0.70)
+- Direction is not `flat` — no trade on a split cohort
+
+Otherwise the Skill aborts with a clear reason and does NOT place.
+
+## Leverage philosophy
+
+KOL consensus is a lagging, reflexive signal that can be wrong at tops and bottoms. The Skill caps leverage at 3x by design. Higher leverage degrades risk-adjusted returns on this strategy class.
+
+## Sibling Skills
+
+This Skill shares the Otto AI signal-feed data moat with:
+
+- **otto-alpha-sniper** — multi-mode sniper (trending / kol-follow / funding-fade)
+- **otto-mispricing-assistant** — Polymarket near-resolution mispricing scanner
+
+## Links
+
+- Otto AI: https://useotto.xyz
+- Signal feed contract: [../SIGNAL_FEED_CONTRACT.md](../SIGNAL_FEED_CONTRACT.md)
+- Docs: https://docs.useotto.xyz
+
+## License
+
+MIT — see `LICENSE`.

--- a/skills/otto-kol-follow/SKILL.md
+++ b/skills/otto-kol-follow/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: otto-kol-follow
+description: >
+  Otto KOL Follow v0.1 — Mirror aggregated sentiment from the top 50 crypto KOLs on Twitter/X
+  into a Hyperliquid perpetual with automatic TP/SL brackets. Natural-language intent in, one
+  consensus-driven trade out. Dry-run is the default; `--confirm` required for live orders.
+  Trigger when the user mentions KOL follow, crypto Twitter sentiment, follow the KOLs,
+  consensus trade, crypto X signals, top-50 KOL conviction, who's bullish on {coin},
+  mirror the KOLs, or wants to open a Hyperliquid position that tracks crypto-Twitter consensus.
+version: "0.1.0"
+author: "Otto AI"
+updated: 2026-04-24
+tags:
+  - perpetuals
+  - hyperliquid
+  - onchainos
+  - trading-strategy
+  - kol-sentiment
+  - social-signals
+---
+
+# Otto KOL Follow — Skill Protocol
+
+> Real perpetual-futures trading with leverage on Hyperliquid. Use paper mode (`DRY_RUN = True`) until you understand the strategy. Live loss of capital is possible.
+
+---
+
+## Overview
+
+Otto KOL Follow mirrors aggregated sentiment from the top 50 crypto KOLs on Twitter/X into a single Hyperliquid perpetual trade with automatic take-profit and stop-loss brackets. The Skill takes a user's plain-language request (optionally scoped to a coin), queries Otto AI's live KOL-sentiment feed, and only trades when the cohort shows statistically meaningful consensus.
+
+- **Input.** Natural-language intent, optionally with `coin=BTC` or similar.
+- **Decision rule.** Fire a trade only if `kol_count ≥ MIN_KOL_COUNT`, `confidence ≥ MIN_CONFIDENCE_KOL`, and `direction != "flat"`. Skip otherwise.
+- **Execution.** All Hyperliquid actions flow through the Hyperliquid Basic Skill (`hyperliquid-plugin`). No raw signing.
+- **Leverage.** Conservative cap (`MAX_LEVERAGE_KOL = 3`) — KOL consensus is a lagging signal and high leverage degrades risk-adjusted returns.
+- **Entry mode.** Reactive — one trade per user intent. Optional `scripts/bot.py` poller for advanced users.
+
+---
+
+## Pre-flight Checks
+
+### 1. Install onchainos CLI (≥ 2.0.0-beta)
+
+```bash
+onchainos --version 2>/dev/null || curl -fsSL https://raw.githubusercontent.com/okx/onchainos-skills/main/install.sh | sh
+npx skills add okx/onchainos-skills --yes --global
+npx skills add okx/plugin-store --skill plugin-store --yes --global
+```
+
+### 2. Install the Hyperliquid Basic Skill (required)
+
+```bash
+npx skills add okx/plugin-store --skill hyperliquid-plugin --yes --global
+```
+
+### 3. Fund Hyperliquid + register signing address
+
+```bash
+hyperliquid-plugin quickstart              # tells you what to do next
+hyperliquid-plugin register                # one-time — binds the signing key
+hyperliquid-plugin deposit --amount 50 --confirm
+```
+
+### 4. Verify the Otto signal feed is reachable
+
+```bash
+curl -fsS "https://signals.useotto.xyz/v1/kol-sentiment?coin=BTC" | jq .updated_at
+```
+
+If this fails, abort and report "Otto signal feed unreachable" — the Skill does not fabricate signals.
+
+---
+
+## Commands
+
+When the user fires a KOL Follow intent, execute this protocol in order.
+
+### Step 1 — Readiness check
+
+```bash
+hyperliquid-plugin quickstart
+```
+
+- **When to use**: always, first thing.
+- **Output**: JSON with `status: ready | needs_register | no_funds | low_balance`.
+- **If not ready**: run `hyperliquid-plugin register` or `hyperliquid-plugin deposit` as indicated. Do NOT proceed.
+
+### Step 2 — Fetch aggregated KOL sentiment
+
+```bash
+# Single-coin mode (user said "on ETH")
+curl -fsS "https://signals.useotto.xyz/v1/kol-sentiment?coin={COIN}" | jq .
+
+# Top-conviction mode (user didn't specify a coin)
+curl -fsS "https://signals.useotto.xyz/v1/kol-sentiment" | jq .
+```
+
+- **When to use**: always, after readiness check.
+- **Output**:
+  ```json
+  {
+    "updated_at": "2026-04-24T10:00:00Z",
+    "status": "ok",
+    "coin": "ETH",
+    "window_hours": 24,
+    "bullish_pct": 0.84,
+    "bearish_pct": 0.06,
+    "neutral_pct": 0.10,
+    "kol_count": 50,
+    "mention_count": 312,
+    "direction": "long",
+    "confidence": 0.78,
+    "top_bullish_kols": ["@handle1", "@handle2"],
+    "top_bearish_kols": ["@handle3"]
+  }
+  ```
+- **Selection rule**:
+  - Reject if `kol_count < MIN_KOL_COUNT` (config default 40) — insufficient cohort sample.
+  - Reject if `confidence < MIN_CONFIDENCE_KOL` (config default 0.70).
+  - Reject if `direction == "flat"` — no meaningful consensus.
+  - Otherwise, proceed with `direction` + `confidence`.
+
+### Step 3 — Confirm parameters with the user
+
+Summarize explicitly before placing anything:
+
+> I'm about to open a **{direction}** **{coin}** perp on Hyperliquid based on KOL consensus.
+> • Size: **${size_usd}** at **{leverage}x** leverage (≈ {notional_usd} notional)
+> • Stop-loss: **{sl_pct}%** ({sl_price})
+> • Take-profit: **{tp_pct}%** ({tp_price})
+> • Cohort: **{kol_count} KOLs** over **{window_hours}h**, **{bullish_pct:.0%}** bullish / **{bearish_pct:.0%}** bearish
+> • Confidence: **{confidence}** (Otto threshold: {MIN_CONFIDENCE_KOL})
+> • Top bullish voices: {top_bullish_kols[:3]}
+> Dry run? {DRY_RUN}
+>
+> Reply "confirm" to execute live, "paper" to run dry-only, or "cancel" to abort.
+
+**Do NOT proceed to Step 4 without explicit user confirmation.**
+
+### Step 4 — Read current price
+
+```bash
+hyperliquid-plugin prices --coin {COIN}
+```
+
+- **When to use**: once per trade, for TP/SL anchoring.
+- **Output**: JSON with `mark_px`.
+
+### Step 5 — Place the order
+
+```bash
+hyperliquid-plugin order --coin {COIN} --side {buy|sell} --size {size} --leverage {leverage} --strategy-id otto-kol-follow --confirm
+```
+
+- **Size conversion**: `size_tokens = size_usd × leverage / mark_px`, rounded down to lot size.
+- **Leverage**: capped at `MAX_LEVERAGE_KOL = 3`. Never above the coin's protocol cap.
+- **Dry-run**: if `DRY_RUN = True`, omit `--confirm`.
+- **Strategy attribution**: always include `--strategy-id otto-kol-follow`.
+
+### Step 6 — Attach TP/SL bracket
+
+```bash
+hyperliquid-plugin tpsl --coin {COIN} --sl-px {sl_price} --tp-px {tp_price} --strategy-id otto-kol-follow --confirm
+```
+
+- Atomic — pass both prices in the same call.
+- `sl_price = mark_px × (1 ∓ SL_PCT)`, mirrored for shorts.
+
+### Step 7 — Report back
+
+```
+✓ Otto KOL Follow
+  {side} {size} {coin} @ ~${mark_px}  ({leverage}x, ${notional_usd} notional)
+  SL ${sl_price} ({sl_pct}%)  TP ${tp_price} ({tp_pct}%)
+  Consensus: {bullish_pct:.0%} bullish from {kol_count} KOLs over {window_hours}h
+  Confidence: {confidence}
+  Entry tx: {tx_hash}
+  Bracket tx: {bracket_tx_hash}
+```
+
+### Configuration commands
+
+Tunable parameters live in `scripts/config.py`:
+
+```bash
+grep -E "^[A-Z_]+ " scripts/config.py     # view defaults
+```
+
+### Optional autonomous poller
+
+```bash
+python3 scripts/bot.py --interval 600 --coin BTC         # dry-run by default
+python3 scripts/bot.py --interval 600 --live             # live, still gated by config.DRY_RUN
+```
+
+- **When to use**: user explicitly opts into hands-free hourly polling.
+- **Output**: JSONL log of fetches + decisions.
+
+---
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|---|---|---|
+| `hyperliquid-plugin: command not found` | Basic Skill not installed | Run Pre-flight step 2. |
+| `status: needs_register` | Signing address not bound | `hyperliquid-plugin register`. |
+| `status: no_funds` / `low_balance` | Insufficient USDC on HL | `hyperliquid-plugin deposit --amount N --confirm`. |
+| Signal feed HTTP 5xx / 503 | Otto backend transient failure | Retry ONCE after 3s. If still failing, abort. |
+| Signal feed HTTP 429 | Rate limit | Back off 30s, retry ONCE. Tell user to space out calls. |
+| `kol_count < MIN_KOL_COUNT` | Cohort too small this window | Abort: "KOL cohort too small to trade right now." |
+| `confidence < MIN_CONFIDENCE_KOL` | Consensus too weak | Abort: "KOL consensus not strong enough — no trade." |
+| `direction == "flat"` | Mixed sentiment | Abort: "KOLs are split right now — no directional trade." |
+| `hyperliquid-plugin order` fails | Order rejected | Return plugin error verbatim. Do NOT simulate via raw API. |
+| `tpsl` fails after `order` | Partial bracket | Warn user + suggest manual bracket or `close`. |
+| User explicitly aborts at Step 3 | Declined | Do not place. Do not retry. |
+| `SESSION_MAX_DRAWDOWN_PCT` breached | Cumulative session loss | Refuse all new trades until reset. |
+
+---
+
+## Security Notices
+
+**Risk level: `advanced`**. This Skill places leveraged perpetual trades on the user's behalf; loss of capital is possible.
+
+### Safeguards enforced by this Skill
+
+- **Dry-run default.** `DRY_RUN = True` in `scripts/config.py`. `--confirm` is required for every live order.
+- **Hard position cap.** `MAX_POSITION_PCT_EQUITY = 0.10`.
+- **Stop-loss.** Every order attaches an atomic bracket with `SL_PCT = 0.02` (2% default).
+- **Low leverage cap.** `MAX_LEVERAGE_KOL = 3`. KOL consensus is a lagging signal and the cap reflects that.
+- **Cohort-size filter.** Rejects trades when `kol_count < MIN_KOL_COUNT = 40` — prevents thin-sample mirror trades.
+- **Confidence threshold.** Rejects trades below `MIN_CONFIDENCE_KOL = 0.70`.
+- **Session drawdown halt.** Cumulative `-15%` session P&L halts new trades.
+- **No key handling.** All signing flows through `hyperliquid-plugin`'s TEE-backed Agentic Wallet.
+- **No credentials in source.** No API keys, tokens, or secrets committed.
+- **Declared network surface.** Only `signals.useotto.xyz` and `api.hyperliquid.xyz` (via `hyperliquid-plugin`).
+
+### Things this Skill will NOT do
+
+- **Never** place a live order without explicit user "confirm" at Step 3.
+- **Never** bypass the Hyperliquid Basic Skill. All Hyperliquid actions MUST flow through `hyperliquid-plugin`.
+- **Never** fabricate KOL sentiment. If the signal feed is unreachable or `status: degraded`, the Skill aborts.
+- **Never** trade on a cohort smaller than `MIN_KOL_COUNT` — small-sample mirror trades are noise.
+- **Never** exceed `MAX_LEVERAGE_KOL` without explicit user override, capped at the coin's protocol max.
+- **Never** reconstruct EIP-712 / L1 signatures by hand.
+- **Never** stack a second position on the same coin silently — ask the user.
+
+### Risk disclaimer
+
+**This Skill is provided solely for educational research and technical reference purposes. It does not constitute investment advice.**
+
+1. **High risk.** Perpetual futures are leveraged. Liquidation is possible.
+2. **KOL signals are noisy.** Crypto Twitter sentiment lags price, is vulnerable to manipulation, and can be reflexively wrong at tops and bottoms. Otto's filters reduce but do not eliminate this.
+3. **Parameters are reference-only.** Defaults in `scripts/config.py` are not tuned for your risk tolerance.
+4. **Hyperliquid-specific risks.** Geofencing, insurance-fund haircuts, keeper failures, L1 outages. User must confirm jurisdictional eligibility.
+5. **No profit guarantee.** Past KOL accuracy ≠ future accuracy.
+6. **Regulatory risk.** User is solely responsible for compliance, taxes, KYC.
+7. **Assumption of responsibility.** Strategy is AS-IS. Authors, Otto AI, OKX, and affiliates are not liable for losses.
+
+### No claim of OKX endorsement
+
+This Skill is authored by Otto AI, a community developer. Not an OKX-endorsed product. "Hyperliquid" and "OKX Onchain OS" are referenced as execution venues, not as affiliated entities.
+
+---
+
+## Config reference
+
+See `scripts/config.py`. Key defaults:
+
+- `DRY_RUN = True`
+- `DEFAULT_SIZE_USD = 25`
+- `MAX_POSITION_PCT_EQUITY = 0.10`
+- `MAX_LEVERAGE_KOL = 3`
+- `MAX_LEVERAGE_ABSOLUTE = 10`
+- `SL_PCT = 0.02` (2%)
+- `TP_PCT = 0.04` (4%)
+- `MIN_KOL_COUNT = 40`
+- `MIN_CONFIDENCE_KOL = 0.70`
+- `MIN_VOLUME_USD = 10_000_000`
+- `SESSION_MAX_DRAWDOWN_PCT = 0.15`
+- `WINDOW_HOURS_DEFAULT = 24`
+
+---
+
+## Onchain OS Integration
+
+This Skill runs inside Onchain OS Agentic Wallet. All Hyperliquid interactions go through `hyperliquid-plugin`, which uses the TEE-backed signing context of the user's connected wallet. No private keys leave Onchain OS.
+
+---
+
+## Links
+
+- Otto AI: https://useotto.xyz
+- Signal feed contract: [SIGNAL_FEED_CONTRACT.md](../SIGNAL_FEED_CONTRACT.md)
+- Docs: https://docs.useotto.xyz
+- Source: https://github.com/useOttoAI/plugin-store

--- a/skills/otto-kol-follow/SUMMARY.md
+++ b/skills/otto-kol-follow/SUMMARY.md
@@ -1,0 +1,90 @@
+# otto-kol-follow
+
+## 1. Overview
+
+Otto KOL Follow is a Strategy Skill for [OKX Onchain OS](https://web3.okx.com/onchainos) Agentic Wallet that mirrors aggregated sentiment from the top 50 crypto KOLs on Twitter/X into a single Hyperliquid perpetual with automatic take-profit and stop-loss brackets, trading only when the cohort shows statistically meaningful consensus.
+
+Core operations:
+
+- Query Otto's KOL-sentiment feed for a user-specified coin or the top-conviction coin across the cohort
+- Gate trades on cohort sample size, consensus strength, and confidence thresholds
+- Place a Hyperliquid perpetual via the Hyperliquid Basic Skill with explicit user confirmation
+- Attach an atomic TP/SL bracket on the same trade
+- Enforce position, leverage, and per-session drawdown caps
+
+Designed for the "follow the consensus" user — if crypto Twitter's smartest accounts are loud and aligned, mirror them for a short window with a tight leash.
+
+Tags: `perpetuals` `hyperliquid` `onchainos` `trading-strategy` `kol-sentiment` `social-signals`
+
+## 2. Prerequisites
+
+- US / geofenced users must verify Hyperliquid eligibility in their jurisdiction
+- onchainos CLI ≥ 2.0.0 installed and authenticated (`onchainos wallet status`)
+- Hyperliquid Basic Skill installed (`npx skills add okx/plugin-store --skill hyperliquid-plugin`)
+- USDC on Arbitrum (chain 42161) to deposit into Hyperliquid
+- A small amount of ETH on Arbitrum for gas
+- Signing address registered via `hyperliquid-plugin register`
+- Python 3.8+ for optional `scripts/bot.py` (stdlib only, no pip dependencies)
+
+## 3. Quick Start
+
+1. **Dry-run first.** Paper mode is the default.
+
+   ```
+   otto-kol-follow quickstart
+   ```
+
+2. **Fund your Hyperliquid account.**
+
+   ```
+   hyperliquid-plugin quickstart
+   hyperliquid-plugin deposit --amount 50 --confirm
+   ```
+
+3. **Test a consensus pick (dry-run).**
+
+   ```
+   otto-kol-follow trade --coin ETH --size-usd 25
+   ```
+
+4. **Go live** after reviewing ≥ 10 paper trades:
+
+   ```
+   otto-kol-follow trade --coin ETH --size-usd 25 --confirm
+   ```
+
+5. **Review open positions.**
+
+   ```
+   hyperliquid-plugin positions --show-orders
+   ```
+
+## Safety defaults
+
+- Dry-run is the default. `--confirm` required to place a live order.
+- Position cap: 10% of Hyperliquid account equity per trade (tunable).
+- Leverage cap: 3x (KOL consensus is lagging — tight leash by design).
+- Auto stop-loss: 2% | Auto take-profit: 4% (2:1 RR).
+- Cohort sample-size filter: rejects trades if fewer than 40 KOLs have spoken in the window.
+- Confidence filter: rejects trades below 0.70 confidence.
+- Per-session drawdown halt: -15% cumulative stops new trades.
+
+## Trigger phrases
+
+The AI agent will route to Otto KOL Follow on intents like:
+
+> "Follow the KOLs on ETH"
+> "What are crypto Twitter's smartest saying about BTC?"
+> "Mirror the top KOLs into a perp"
+> "Consensus trade on SOL"
+> "Give me the KOL conviction trade"
+
+## Data moat
+
+Otto's KOL-sentiment pipeline aggregates the top 50 crypto KOLs on Twitter/X with historical accuracy weighting, mention-volume filters, and cohort-diversity checks. Same production feed that drives Otto AI's Market Alpha Agent on the Virtuals Agent Commerce Protocol.
+
+## Risk
+
+Real on-chain leveraged trading. Capital loss is possible. KOL consensus can be reflexively wrong at market tops and bottoms. Dry-run extensively before committing real USDC.
+
+See [SKILL.md](SKILL.md) for the full agent protocol and safety notices.

--- a/skills/otto-kol-follow/plugin.yaml
+++ b/skills/otto-kol-follow/plugin.yaml
@@ -1,0 +1,26 @@
+schema_version: 1
+name: otto-kol-follow
+version: "0.1.0"
+description: "Otto KOL Follow — Mirror the top 50 crypto KOLs on Twitter/X into a Hyperliquid perp. Natural-language intent in, one-click consensus trade with TP/SL out. Dry-run by default."
+author:
+  name: "Otto AI"
+  github: "useOttoAI"
+license: MIT
+category: trading-strategy
+tags:
+  - perpetuals
+  - hyperliquid
+  - onchainos
+  - trading-strategy
+  - kol-sentiment
+  - social-signals
+
+components:
+  skill:
+    dir: .
+
+api_calls:
+  - "signals.useotto.xyz"
+  - "api.hyperliquid.xyz"
+
+type: community-developer

--- a/skills/otto-kol-follow/scripts/bot.py
+++ b/skills/otto-kol-follow/scripts/bot.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Otto KOL Follow v0.1 — Optional autonomous poller.
+
+The reactive flow documented in SKILL.md (AI agent fires trades on user intent)
+is the primary mode. This bot.py is for advanced users who want a hands-free
+background poller that checks the Otto KOL-sentiment feed every N seconds and
+fires a trade when cohort size + confidence thresholds are met.
+
+Run:
+    python3 bot.py --coin ETH --interval 600
+
+    # Dry-run by default. Pass --live to submit real orders.
+    python3 bot.py --coin BTC --interval 900 --live
+
+    # Omit --coin to let the feed pick the top-conviction coin across the cohort.
+    python3 bot.py --interval 1200
+
+See config.py for every tunable.
+
+⚠️ Start in DRY_RUN = True. Monitor for 10+ cycles before --live.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import config  # type: ignore[import-not-found]
+except Exception:
+    sys.path.insert(0, str(Path(__file__).parent))
+    import config  # type: ignore[import-not-found]
+
+
+def log(record: dict) -> None:
+    record["ts"] = datetime.now(timezone.utc).isoformat()
+    line = json.dumps(record)
+    print(line, flush=True)
+    if config.LOG_TRADES_TO_FILE:
+        with open(config.LOG_FILE, "a") as f:
+            f.write(line + "\n")
+
+
+def fetch_sentiment(coin: str | None) -> dict | None:
+    url = f"{config.SIGNAL_FEED_BASE}/v1/kol-sentiment"
+    if coin:
+        url += f"?coin={coin}"
+    for attempt in range(config.SIGNAL_FEED_RETRIES + 1):
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=config.SIGNAL_FEED_TIMEOUT) as resp:
+                return json.loads(resp.read())
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+            log({"event": "signal_feed_error", "attempt": attempt, "err": str(e)})
+            time.sleep(3)
+    return None
+
+
+def fresh_enough(payload: dict) -> bool:
+    try:
+        ts = datetime.fromisoformat(payload["updated_at"].replace("Z", "+00:00"))
+        age = (datetime.now(timezone.utc) - ts).total_seconds()
+        return age <= config.MAX_SIGNAL_AGE_SEC
+    except Exception:
+        return False
+
+
+def pick_trade(payload: dict) -> dict | None:
+    if payload.get("status") == "degraded":
+        return None
+    if payload.get("kol_count", 0) < config.MIN_KOL_COUNT:
+        return None
+    if payload.get("confidence", 0) < config.MIN_CONFIDENCE_KOL:
+        return None
+    direction = payload.get("direction")
+    if direction not in ("long", "short"):
+        return None
+    return {
+        "coin": payload["coin"],
+        "direction": direction,
+        "confidence": payload["confidence"],
+        "kol_count": payload["kol_count"],
+        "bullish_pct": payload.get("bullish_pct"),
+        "bearish_pct": payload.get("bearish_pct"),
+        "window_hours": payload.get("window_hours"),
+    }
+
+
+def hl_quickstart_status() -> str:
+    try:
+        out = subprocess.check_output(["hyperliquid-plugin", "quickstart"], text=True, timeout=15)
+        return json.loads(out).get("status", "unknown")
+    except Exception as e:
+        log({"event": "hl_quickstart_failed", "err": str(e)})
+        return "unknown"
+
+
+def mark_price(coin: str) -> float | None:
+    try:
+        out = subprocess.check_output(["hyperliquid-plugin", "prices", "--coin", coin], text=True, timeout=15)
+        return float(json.loads(out).get("mark_px"))
+    except Exception:
+        return None
+
+
+def compute_bracket(side: str, mark: float) -> tuple[float, float]:
+    if side == "buy":
+        sl = mark * (1 - config.SL_PCT)
+        tp = mark * (1 + config.TP_PCT)
+    else:
+        sl = mark * (1 + config.SL_PCT)
+        tp = mark * (1 - config.TP_PCT)
+    return sl, tp
+
+
+def fire_trade(trade: dict, size_usd: float, live: bool) -> None:
+    if config.PAUSED:
+        log({"event": "paused"})
+        return
+    side = "buy" if trade["direction"] == "long" else "sell"
+    lev = min(config.MAX_LEVERAGE_KOL, config.MAX_LEVERAGE_ABSOLUTE)
+    mark = mark_price(trade["coin"])
+    if mark is None:
+        log({"event": "mark_price_unavailable", "coin": trade["coin"]})
+        return
+    size_tokens = round((size_usd * lev) / mark, 6)
+    sl, tp = compute_bracket(side, mark)
+    log({"event": "preparing_trade", "trade": trade, "side": side, "leverage": lev,
+         "size_usd": size_usd, "size_tokens": size_tokens, "mark": mark, "sl": sl, "tp": tp,
+         "live": live and not config.DRY_RUN})
+    confirm = ["--confirm"] if (live and not config.DRY_RUN) else []
+    order_cmd = [
+        "hyperliquid-plugin", "order",
+        "--coin", trade["coin"],
+        "--side", side,
+        "--size", str(size_tokens),
+        "--leverage", str(lev),
+        "--strategy-id", "otto-kol-follow",
+    ] + confirm
+    try:
+        subprocess.run(order_cmd, check=True, timeout=45)
+    except subprocess.CalledProcessError as e:
+        log({"event": "order_failed", "err": str(e)})
+        return
+    if live and not config.DRY_RUN:
+        bracket_cmd = [
+            "hyperliquid-plugin", "tpsl",
+            "--coin", trade["coin"],
+            "--sl-px", f"{sl:.6f}",
+            "--tp-px", f"{tp:.6f}",
+            "--strategy-id", "otto-kol-follow",
+            "--confirm",
+        ]
+        try:
+            subprocess.run(bracket_cmd, check=True, timeout=30)
+        except subprocess.CalledProcessError as e:
+            log({"event": "bracket_failed", "err": str(e)})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--coin", type=str, default=None, help="coin to track; omit for top-conviction cohort pick")
+    parser.add_argument("--interval", type=int, default=600, help="seconds between cycles")
+    parser.add_argument("--size-usd", type=float, default=config.DEFAULT_SIZE_USD)
+    parser.add_argument("--live", action="store_true", help="submit real orders (still gated by config.DRY_RUN)")
+    parser.add_argument("--once", action="store_true", help="run one cycle and exit")
+    args = parser.parse_args()
+
+    log({"event": "bot_start", "coin": args.coin, "interval": args.interval, "live": args.live,
+         "dry_run": config.DRY_RUN, "paused": config.PAUSED})
+
+    while True:
+        status = hl_quickstart_status()
+        if status != "ready":
+            log({"event": "hl_not_ready", "status": status})
+        else:
+            payload = fetch_sentiment(args.coin)
+            if payload is None:
+                log({"event": "no_signal_feed"})
+            elif not fresh_enough(payload):
+                log({"event": "signal_stale", "updated_at": payload.get("updated_at")})
+            else:
+                trade = pick_trade(payload)
+                if trade is None:
+                    log({"event": "no_trade_this_cycle", "reason": "cohort/confidence/direction gate",
+                         "kol_count": payload.get("kol_count"), "confidence": payload.get("confidence"),
+                         "direction": payload.get("direction")})
+                else:
+                    fire_trade(trade, args.size_usd, args.live)
+
+        if args.once:
+            break
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        log({"event": "bot_stop", "reason": "keyboard_interrupt"})

--- a/skills/otto-kol-follow/scripts/config.py
+++ b/skills/otto-kol-follow/scripts/config.py
@@ -1,0 +1,51 @@
+"""
+Otto KOL Follow v0.1 — Hot-reloadable configuration.
+
+Every parameter below is tunable without changing bot.py or the SKILL protocol.
+The AI agent reads these values through bot.py or via grep when orchestrating
+a trade in reactive mode.
+
+⚠️  Disclaimer: values are reference defaults sized for a generalist user on
+Hyperliquid. They are NOT investment advice and may not fit your risk tolerance,
+experience, or jurisdiction. Adjust before going live.
+"""
+
+# ── Run mode ─────────────────────────────────────────────────────────────────
+DRY_RUN = True             # True = paper mode (no --confirm passed to hyperliquid-plugin)
+PAUSED  = False            # True = refuse all new trades regardless of DRY_RUN
+
+# ── Sizing ───────────────────────────────────────────────────────────────────
+DEFAULT_SIZE_USD        = 25      # per-trade notional in USD
+MIN_SIZE_USD            = 10
+MAX_SIZE_USD            = 500
+MAX_POSITION_PCT_EQUITY = 0.10    # no single trade can exceed 10% of HL equity
+
+# ── Leverage caps ────────────────────────────────────────────────────────────
+# KOL consensus is a lagging, noise-prone signal. Cap leverage conservatively.
+MAX_LEVERAGE_KOL      = 3
+MAX_LEVERAGE_ABSOLUTE = 10
+
+# ── Risk controls ────────────────────────────────────────────────────────────
+SL_PCT                   = 0.02   # 2% stop-loss
+TP_PCT                   = 0.04   # 4% take-profit (2:1 RR)
+SESSION_MAX_DRAWDOWN_PCT = 0.15   # halt all new trades after cumulative -15%
+MAX_CONCURRENT_POSITIONS = 3
+
+# ── KOL signal thresholds ────────────────────────────────────────────────────
+MIN_KOL_COUNT         = 40    # min cohort sample size for a valid consensus read
+MIN_CONFIDENCE_KOL    = 0.70  # Otto's internal confidence gate
+WINDOW_HOURS_DEFAULT  = 24    # rolling sentiment window
+
+# ── Market filters ───────────────────────────────────────────────────────────
+MIN_VOLUME_USD        = 10_000_000    # daily HL volume floor
+ASSET_BLOCKLIST       = []            # coins to never trade
+
+# ── Signal feed ──────────────────────────────────────────────────────────────
+SIGNAL_FEED_BASE    = "https://signals.useotto.xyz"
+SIGNAL_FEED_TIMEOUT = 4
+SIGNAL_FEED_RETRIES = 1
+MAX_SIGNAL_AGE_SEC  = 900     # abort if sentiment is older than 15 min
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+LOG_TRADES_TO_FILE = True
+LOG_FILE           = "otto_kol_follow_trades.jsonl"


### PR DESCRIPTION
## Summary

Otto KOL Follow v0.1 — Reactive Hyperliquid perp Skill that mirrors aggregated sentiment from the top 50 crypto KOLs on Twitter/X. Submitted for the **OKX Plugin Store Developer Challenge S1**.

- **Risk tier:** `advanced` — automated trading
- **Basic Skill dependency:** `hyperliquid-plugin` (every HL action flows through it; no raw EIP-712 signing)
- **Signal source:** `https://signals.useotto.xyz/v1/kol-sentiment` — public, keyless, IP-rate-limited (60 req/min)
- **Strategy attribution:** every live order passes `--strategy-id otto-kol-follow`

Single mode: query Otto's KOL-sentiment feed (optionally for a user-specified coin), gate the trade on cohort sample size + confidence + non-flat direction, place one perp with TP/SL.

## Decision rule (rejects most trades by design)

A trade only fires when **all three** gates pass:

1. `kol_count >= MIN_KOL_COUNT` (default 40) — prevents thin-sample mirror trades
2. `confidence >= MIN_CONFIDENCE_KOL` (default 0.70) — Otto's internal noise gate
3. `direction != "flat"` — split sentiment = no trade

Otherwise the Skill aborts cleanly with a reason. This is intentional: KOL consensus is a lagging, reflexive signal that's wrong at tops and bottoms. The Skill caps leverage at `MAX_LEVERAGE_KOL = 3` for the same reason.

## Advanced-tier safeguards (lines 1501-1510)

- ✅ **Dry-run default.** `DRY_RUN = True`. Live orders require explicit per-trade user "confirm" at Step 3.
- ✅ **Stop-loss mechanism.** Atomic TP/SL bracket via `hyperliquid-plugin tpsl`. `SL_PCT = 0.02` default, configurable.
- ✅ **Max-amount limits.** `MAX_POSITION_PCT_EQUITY = 0.10`, `MAX_SIZE_USD = 500`, `SESSION_MAX_DRAWDOWN_PCT = 0.15`.
- ✅ **Risk disclaimer.** Prominent in `SKILL.md` Security Notices section, including KOL-signal-noise-specific caveats (reflexivity, manipulation, lag).
- ✅ **Liquidity floor.** `MIN_VOLUME_USD = 10_000_000`.
- ✅ **Cohort sample-size filter.** Refuses trades on samples below `MIN_KOL_COUNT = 40`.
- ✅ **Never bypasses Hyperliquid Basic Skill.** All HL actions go through `hyperliquid-plugin`.

## Pre-Submission Checklist (lines 1467-1486)

- [x] `plugin.yaml`, `.claude-plugin/plugin.json`, and `SKILL.md` all present
- [x] `name` is lowercase with hyphens only (`otto-kol-follow`, 15 chars)
- [x] `version` matches across all three files (`0.1.0`)
- [x] `author.github` set to `useOttoAI`
- [x] `license` SPDX identifier (`MIT`)
- [x] `category` is `trading-strategy`
- [x] `api_calls`: `signals.useotto.xyz`, `api.hyperliquid.xyz`
- [x] SKILL.md frontmatter has name, description, version, author
- [x] SKILL.md includes Overview / Pre-flight Checks / Commands / Error Handling / Security Notices
- [x] No hardcoded API keys or credentials
- [x] No pre-compiled binary files (Python stdlib only)
- [x] LICENSE file present (MIT)
- [x] PR title: `[new-plugin] otto-kol-follow v0.1.0`
- [x] PR branch: `submit/otto-kol-follow`
- [x] PR only modifies files inside `skills/otto-kol-follow/`
- [x] Trading plugin: risk disclaimer included
- [x] Trading plugin: dry-run / paper-trade mode supported as default

## Test plan

- [ ] CI lint + automated checks pass
- [ ] Two-reviewer human review per Advanced-tier requirement
- [ ] Verify SKILL.md trigger phrases route correctly in Onchain OS Agentic Wallet
- [ ] Verify cohort-size + confidence gates abort the trade in degraded conditions
- [ ] Verify TP/SL bracket lands atomically with order

## Notes for reviewers

- **Author identity.** `author.github` is `useOttoAI` (the Otto AI GitHub org). The fork branch lives at `Vb6Z/plugin-store` due to API restrictions on org-scope forks. Skill is owned and maintained by the Otto AI team.
- **Sibling Skill.** This is a focused single-mode variant of `otto-alpha-sniper` (which has KOL-follow as one of three modes). Listed separately so users who specifically want KOL-mirroring can install just the smaller Skill, and so the leaderboard credits attribution cleanly per `--strategy-id`.
- **Signal feed.** Live at `signals.useotto.xyz/v1/kol-sentiment` (200 OK on health). Producer Phase 2 ships structured `bullish_pct/bearish_pct/direction/confidence` fields shortly; current responses include the rich narrative and trending-tokens shape, marked `status: degraded` so the Skill abstains until producer is fully structured.