### PR TITLE
submit: go-sol-price v1.0.0 (mirrored from mig-pre)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,6 +61,15 @@
       }
     },
     {
+      "name": "go-sol-price",
+      "description": "Query real-time SOL/USDT spot price via the OKX public ticker API (Go demo).",
+      "source": "./skills/go-sol-price",
+      "category": "utility",
+      "author": {
+        "name": "yz06276"
+      }
+    },
+    {
       "name": "hyperliquid-plugin",
       "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",
       "source": "./skills/hyperliquid-plugin",

--- a/registry.json
+++ b/registry.json
@@ -191,6 +191,37 @@
       }
     },
     {
+      "name": "go-sol-price",
+      "version": "1.0.0",
+      "description": "Query real-time SOL/USDT spot price via the OKX public ticker API (Go demo).",
+      "author": {
+        "name": "yz06276"
+      },
+      "category": "utility",
+      "tags": [
+        "solana",
+        "trading"
+      ],
+      "type": "official",
+      "components": {
+        "skill": {
+          "repo": "okx/plugin-store",
+          "dir": "skills/go-sol-price"
+        }
+      },
+      "github_link": "https://github.com/okx/plugin-store/tree/main/skills/go-sol-price",
+      "skill_md_link": "https://raw.githubusercontent.com/okx/plugin-store/main/skills/go-sol-price/SKILL.md",
+      "summary_md_link": "https://raw.githubusercontent.com/okx/plugin-store/main/skills/go-sol-price/SUMMARY.md",
+      "modify_date": "1777362886",
+      "extra": {
+        "chains": [
+          "solana"
+        ],
+        "protocols": [],
+        "risk_level": "high"
+      }
+    },
+    {
       "name": "hyperliquid-plugin",
       "version": "0.3.9",
       "description": "Hyperliquid on-chain perpetuals DEX — check positions, get market prices, place and cancel perpetual orders on Hyperliquid L1 (chain_id 999).",

--- a/skills/go-sol-price/.claude-plugin/plugin.json
+++ b/skills/go-sol-price/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "go-sol-price",
+  "version": "1.0.0",
+  "description": "Query real-time SOL/USDT spot price via the OKX public ticker API (Go demo).",
+  "author": {
+    "name": "yz06276"
+  }
+}

--- a/skills/go-sol-price/.gitignore
+++ b/skills/go-sol-price/.gitignore
@@ -1,0 +1,5 @@
+go-sol-price
+go-sol-price-*
+*.exe
+*.log
+*.tmp

--- a/skills/go-sol-price/LICENSE
+++ b/skills/go-sol-price/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 yz06276
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/go-sol-price/SKILL.md
+++ b/skills/go-sol-price/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: go-sol-price
+description: Query the current SOL/USDT spot price from OKX's public ticker API. Trigger when the user asks "SOL price", "Solana price", "查 SOL 价格", or wants a quick on-demand spot quote without an API key.
+version: "1.0.0"
+---
+
+
+## Pre-flight Dependencies (auto-injected by Plugin Store CI)
+
+> Run once per session before first use. These checks ensure required tools are installed.
+
+### Version check (auto-injected)
+
+> **AI Agent Instruction**: Run this version check before executing any commands from this skill. If an update is applied, re-read this SKILL.md before proceeding — the instructions may have changed.
+
+```bash
+# Check for skill updates (1-hour cache)
+UPDATE_CACHE="$HOME/.plugin-store/update-cache/go-sol-price"
+CACHE_MAX=3600
+LOCAL_VER="1.0.0"
+DO_CHECK=true
+
+if [ -f "$UPDATE_CACHE" ]; then
+  CACHE_MOD=$(stat -f %m "$UPDATE_CACHE" 2>/dev/null || stat -c %Y "$UPDATE_CACHE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  AGE=$(( NOW - CACHE_MOD ))
+  [ "$AGE" -lt "$CACHE_MAX" ] && DO_CHECK=false
+fi
+
+if [ "$DO_CHECK" = true ]; then
+  REMOTE_VER=$(curl -sf --max-time 3 "https://raw.githubusercontent.com/okx/plugin-store/main/skills/go-sol-price/plugin.yaml" | grep '^version' | head -1 | tr -d '"' | awk '{print $2}')
+  if [ -n "$REMOTE_VER" ]; then
+    mkdir -p "$HOME/.plugin-store/update-cache"
+    echo "$REMOTE_VER" > "$UPDATE_CACHE"
+  fi
+fi
+
+REMOTE_VER=$(cat "$UPDATE_CACHE" 2>/dev/null || echo "$LOCAL_VER")
+if [ "$REMOTE_VER" != "$LOCAL_VER" ]; then
+  echo "Update available: go-sol-price v$LOCAL_VER -> v$REMOTE_VER. Updating..."
+  npx skills add okx/plugin-store --skill go-sol-price --yes --global 2>/dev/null || true
+  echo "Updated go-sol-price to v$REMOTE_VER. Please re-read this SKILL.md."
+fi
+```
+
+### Install go-sol-price binary + launcher (auto-injected)
+
+```bash
+# Install shared infrastructure (launcher + update checker, only once)
+LAUNCHER="$HOME/.plugin-store/launcher.sh"
+CHECKER="$HOME/.plugin-store/update-checker.py"
+if [ ! -f "$LAUNCHER" ]; then
+  mkdir -p "$HOME/.plugin-store"
+  curl -fsSL "https://raw.githubusercontent.com/okx/plugin-store/main/scripts/launcher.sh" -o "$LAUNCHER" 2>/dev/null || true
+  chmod +x "$LAUNCHER"
+fi
+if [ ! -f "$CHECKER" ]; then
+  curl -fsSL "https://raw.githubusercontent.com/okx/plugin-store/main/scripts/update-checker.py" -o "$CHECKER" 2>/dev/null || true
+fi
+
+# Clean up old installation
+rm -f "$HOME/.local/bin/go-sol-price" "$HOME/.local/bin/.go-sol-price-core" 2>/dev/null
+
+# Download binary
+OS=$(uname -s | tr A-Z a-z)
+ARCH=$(uname -m)
+EXT=""
+case "${OS}_${ARCH}" in
+  darwin_arm64)  TARGET="aarch64-apple-darwin" ;;
+  darwin_x86_64) TARGET="x86_64-apple-darwin" ;;
+  linux_x86_64)  TARGET="x86_64-unknown-linux-musl" ;;
+  linux_i686)    TARGET="i686-unknown-linux-musl" ;;
+  linux_aarch64) TARGET="aarch64-unknown-linux-musl" ;;
+  linux_armv7l)  TARGET="armv7-unknown-linux-musleabihf" ;;
+  mingw*_x86_64|msys*_x86_64|cygwin*_x86_64)   TARGET="x86_64-pc-windows-msvc"; EXT=".exe" ;;
+  mingw*_i686|msys*_i686|cygwin*_i686)           TARGET="i686-pc-windows-msvc"; EXT=".exe" ;;
+  mingw*_aarch64|msys*_aarch64|cygwin*_aarch64)  TARGET="aarch64-pc-windows-msvc"; EXT=".exe" ;;
+esac
+mkdir -p ~/.local/bin
+curl -fsSL "https://github.com/okx/plugin-store/releases/download/plugins/go-sol-price@1.0.0/go-sol-price-${TARGET}${EXT}" -o ~/.local/bin/.go-sol-price-core${EXT}
+chmod +x ~/.local/bin/.go-sol-price-core${EXT}
+
+# Symlink CLI name to universal launcher
+ln -sf "$LAUNCHER" ~/.local/bin/go-sol-price
+
+# Register version
+mkdir -p "$HOME/.plugin-store/managed"
+echo "1.0.0" > "$HOME/.plugin-store/managed/go-sol-price"
+```
+
+---
+
+
+# go-sol-price
+
+A minimal Go CLI that prints the current `SOL/USDT` spot price by hitting OKX's public ticker endpoint. No API key, no third-party Go dependencies — single self-contained binary, ~3 MB.
+
+## When to use
+
+Say one of these to trigger:
+- "what's the SOL price"
+- "Solana current price"
+- "查 SOL 现价"
+- "SOL/USDT 报价"
+
+## Usage
+
+```bash
+go-sol-price                # → SOL/USDT: 178.42
+go-sol-price --version      # → go-sol-price 1.0.0
+go-sol-price --help
+```
+
+## How it works
+
+Single `GET https://www.okx.com/api/v5/market/ticker?instId=SOL-USDT`, parses `data[0].last`, prints. 10-second timeout, exits non-zero on network or API error.
+
+## Limitations
+
+- Read-only — no trading, no signing, no on-chain action
+- Single instrument hardcoded (`SOL-USDT`) — extend to other pairs if needed
+- Public endpoint, no auth, subject to OKX rate limits (generous for public API)

--- a/skills/go-sol-price/SUMMARY.md
+++ b/skills/go-sol-price/SUMMARY.md
@@ -1,0 +1,13 @@
+## Overview
+
+`go-sol-price` is a tiny Go CLI that queries the OKX public spot ticker for `SOL-USDT` and prints the current price. No API key required, no third-party Go dependencies — a single self-contained binary you can drop in your `$PATH`.
+
+## Prerequisites
+- Network access to `https://www.okx.com/api/v5/market/ticker`
+- Go is **not** required at runtime — the published release ships the compiled binary for your platform
+
+## Quick Start
+1. Install the skill: `npx skills add okx/plugin-store --skill go-sol-price`
+2. Verify the binary: `go-sol-price --version` → `go-sol-price 1.0.0`
+3. Query the price: `go-sol-price` → e.g. `SOL/USDT: 178.42`
+4. Build locally (optional): `go build -o go-sol-price ./...`

--- a/skills/go-sol-price/go.mod
+++ b/skills/go-sol-price/go.mod
@@ -1,0 +1,3 @@
+module github.com/okx/plugin-store/skills/go-sol-price
+
+go 1.22

--- a/skills/go-sol-price/main.go
+++ b/skills/go-sol-price/main.go
@@ -1,0 +1,59 @@
+// go-sol-price — query SOL/USDT spot price via OKX public ticker.
+// No API key, no third-party deps — single self-contained Go binary.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	version = "1.0.0"
+	apiURL  = "https://www.okx.com/api/v5/market/ticker?instId=SOL-USDT"
+)
+
+type tickerResp struct {
+	Code string `json:"code"`
+	Msg  string `json:"msg"`
+	Data []struct {
+		InstID string `json:"instId"`
+		Last   string `json:"last"`
+		Ts     string `json:"ts"`
+	} `json:"data"`
+}
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "-V", "version":
+			fmt.Printf("go-sol-price %s\n", version)
+			return
+		case "--help", "-h", "help":
+			fmt.Println("Usage: go-sol-price [--version]")
+			fmt.Println("Prints the current SOL/USDT spot price from OKX.")
+			return
+		}
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(apiURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetch error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	var r tickerResp
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		fmt.Fprintf(os.Stderr, "decode error: %v\n", err)
+		os.Exit(1)
+	}
+	if r.Code != "0" || len(r.Data) == 0 {
+		fmt.Fprintf(os.Stderr, "api error: code=%s msg=%s\n", r.Code, r.Msg)
+		os.Exit(1)
+	}
+	fmt.Printf("SOL/USDT: %s\n", r.Data[0].Last)
+}

--- a/skills/go-sol-price/plugin.yaml
+++ b/skills/go-sol-price/plugin.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+name: go-sol-price
+version: "1.0.0"
+description: "Query real-time SOL/USDT spot price via the OKX public ticker API (Go demo)."
+author:
+  name: "yz06276"
+  github: "yz06276"
+license: MIT
+category: analytics
+tags: [solana, price, go, demo]
+components:
+  skill:
+    dir: .
+build:
+  lang: go
+  binary_name: go-sol-price
+api_calls:
+  - "https://www.okx.com/api/v5/market/ticker"


### PR DESCRIPTION
## go-sol-price v1.0.0 — mirrored from mig-pre

This PR mirrors the **post-merge** state of `mig-pre/plugin-store` for the `go-sol-price` plugin at version `1.0.0`.

### Why this PR doesn't go through CI
`okx/plugin-store` automation has been paused following a security incident. All checks (Phase 1–4 + post-merge `update-registry.yml`) ran on `mig-pre/plugin-store` instead. This PR transfers the verified outputs:

- `skills/go-sol-price/` — exact tree from mig-pre's main after CI auto-injected the `## Pre-flight Dependencies (auto-injected by Plugin Store CI)` block into SKILL.md
- `registry.json` — entry for `go-sol-price` extracted from mig-pre's auto-regenerated registry (URLs already point to `okx/plugin-store`)
- `.claude-plugin/marketplace.json` — same pattern

### Upstream verification trail
- mig-pre PR: https://github.com/mig-pre/plugin-store/pull/36
- mig-pre release: `https://github.com/mig-pre/plugin-store/releases/tag/plugins/go-sol-price@1.0.0`

### Reviewer checklist
- [ ] `skills/go-sol-price/SKILL.md` contains the auto-injected pre-flight block
- [ ] No `mig-pre` strings in any file under `skills/go-sol-price/`, `registry.json`, or `.claude-plugin/marketplace.json` (anti-pollution)
- [ ] Diff to `registry.json` and `marketplace.json` only adds/replaces the `go-sol-price` entry
- [ ] Version field consistent across `plugin.yaml`, source manifest (e.g. `Cargo.toml`), and registry entry

### After merge
A separate step (Phase 7 of `plugin-store-publish` skill) creates the tag `plugins/go-sol-price@1.0.0` on okx pointing to this PR's merge commit, and uploads the byte-identical 9 cross-platform binaries from mig-pre's release as okx assets.

---
*Mirrored via plugin-store-publish skill.*