### PR TITLE
[new-plugin] polymarket-event-alpha v1.0.0

### DIFF
--- a/skills/polymarket-event-alpha/.claude-plugin/plugin.json
+++ b/skills/polymarket-event-alpha/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "polymarket-event-alpha",
+  "description": "Polymarket Event Alpha screens event markets, checks trading readiness, ranks opportunities, and prepares risk-aware Polymarket plans.",
+  "version": "1.0.0",
+  "author": {
+    "name": "cbl980712-coder"
+  },
+  "license": "MIT",
+  "keywords": [
+    "polymarket",
+    "prediction-market",
+    "event-trading",
+    "risk-management",
+    "onchainos",
+    "polygon"
+  ]
+}

--- a/skills/polymarket-event-alpha/LICENSE
+++ b/skills/polymarket-event-alpha/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/polymarket-event-alpha/README.md
+++ b/skills/polymarket-event-alpha/README.md
@@ -1,0 +1,38 @@
+# Polymarket Event Alpha
+
+Polymarket Event Alpha helps users make better Polymarket decisions before they click into a market.
+
+It checks whether the user is ready, whether the right asset is available, whether the market has usable liquidity, and whether the opportunity is strong enough to act on. If the answer is no, it says no clearly.
+
+## What Users Get
+
+- A readiness answer: can I trade now?
+- Asset preparation guidance: what am I missing?
+- Top 3 event markets worth watching.
+- A Top 1 explanation in plain language.
+- A trade plan only when the setup is strong enough.
+- An exit playbook before entering.
+- A platform access check that prevents invalid live attempts.
+
+## Why It Is Useful
+
+Most event-market mistakes are not just bad predictions. They are bad preparation:
+
+- wrong asset
+- poor spread
+- thin liquidity
+- unclear direction
+- no exit plan
+- trying to trade when access is restricted
+
+Polymarket Event Alpha is built to reduce those mistakes.
+
+## Strategy
+
+- Product Name: Polymarket Event Alpha
+- Strategy ID: `event-alpha-xy`
+- Underlying Plugin: Polymarket Plugin
+
+## Safety
+
+This product does not promise profit, does not force trades, and does not bypass platform access restrictions.

--- a/skills/polymarket-event-alpha/SKILL.md
+++ b/skills/polymarket-event-alpha/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: polymarket-event-alpha
+description: "Use Polymarket Event Alpha when a user wants help finding, screening, planning, and risk-checking Polymarket event trades without forcing poor markets or unsafe execution."
+version: "1.0.0"
+author: "cbl980712-coder"
+tags:
+  - polymarket
+  - prediction-market
+  - event-trading
+  - risk-management
+  - onchainos
+---
+
+# Polymarket Event Alpha
+
+Polymarket Event Alpha is a user-facing event market trading skill built on the official Polymarket Plugin and Onchain OS.
+
+It helps users answer a simple question:
+
+> "Can I safely consider an event trade right now, and if yes, which market is actually worth looking at?"
+
+It does not claim guaranteed outcomes, high win rate, or automatic profit. Its value is execution quality: fewer bad markets, fewer bad spreads, fewer wrong-asset mistakes, clearer risk checks, and a concrete exit plan before any confirmed trade.
+
+## What It Does
+
+Use this skill to:
+
+- Check whether the user is ready to trade Polymarket.
+- Identify whether the required asset is available.
+- Detect missing USDC.e, gas, or setup requirements.
+- Rank event markets with a three-part score:
+  - market quality
+  - directional edge
+  - execution feasibility
+- Produce a Top 3 event-market shortlist.
+- Explain the Top 1 market in plain language.
+- Build a proposed trade plan with budget, side, price boundary, and risk notes.
+- Build an exit playbook with TP1, TP2, invalidation exit, and time exit.
+- Stop invalid live attempts when platform access conditions are not satisfied.
+
+## Product Rules
+
+- Strategy ID: `event-alpha-xy`
+- Underlying official plugin: `polymarket-plugin`
+- Supported first version market pools:
+  - politics
+  - macro
+  - crypto event
+- Sports are excluded in v1.
+- The skill must not force a YES/NO direction when directional edge is weak.
+- The skill must not default to automatic swap.
+- The skill must not default to automatic betting.
+- Live execution is only allowed when platform access, account readiness, asset readiness, risk checks, and user confirmation all pass.
+
+## Public Command Assumptions
+
+The user should have the official plugin installed and available on PATH:
+
+```bash
+polymarket-plugin
+onchainos
+```
+
+Do not use project-local wrappers, copied binaries, relays, or diagnostic tools for formal execution.
+
+## Normal User Flow
+
+1. Readiness check:
+   - account status
+   - required asset
+   - gas/setup condition
+   - platform access condition
+
+2. Asset preparation advice:
+   - explain what is missing
+   - prefer direct USDC.e preparation when needed
+   - only discuss swap as a confirmed, separately reviewed action
+
+3. Market shortlist:
+   - rank markets by quality and execution feasibility
+   - return Top 3
+   - explain why some markets should only be watched
+
+4. Trade plan:
+   - proposed side only when directional edge is strong enough
+   - budget
+   - entry price boundary
+   - maximum acceptable execution price
+   - risk notes
+
+5. Exit playbook:
+   - TP1
+   - TP2
+   - invalidation exit
+   - time exit
+
+6. Confirmation:
+   - no live trade without explicit user confirmation
+
+## Output Style
+
+Write for a normal user, not for a developer.
+
+Preferred one-screen answer:
+
+- Can I trade now?
+- What is missing, if anything?
+- What are the Top 3 markets?
+- Which one is most worth watching?
+- Why not force a trade?
+- If trading is allowed, what is the plan?
+- How should the user exit?
+
+## Safety Boundaries
+
+- Do not promise profit.
+- Do not claim a market is certain.
+- Do not bypass access restrictions.
+- Do not trade if assets, setup, or platform access are not ready.
+- Do not hide bad spread, thin orderbook, or weak directional edge.
+- Do not expose private wallet data, local machine paths, API keys, sessions, or logs to the user.
+
+## Error Handling
+
+| Condition | Meaning | Response |
+|---|---|---|
+| Missing required asset | User lacks usable USDC.e or gas | Explain the missing asset and safest preparation path |
+| Weak directional edge | Market may be interesting but not actionable | Output watch-only or price-target-only |
+| Wide spread or thin book | Execution quality is poor | Reject or keep on watchlist |
+| Access restricted | Live trading is not available | Keep readiness, shortlist, plan, risk, and dry-run as product outputs; do not push live |
+| Incomplete market data | Not enough evidence | Say insufficient data and avoid a forced direction |
+
+## Example User Request
+
+> "Find me the best small Polymarket event trade today."
+
+Good response:
+
+- "You are not ready because USDC.e is missing."
+- or "You are ready, but the best markets are watch-only because directional edge is weak."
+- or "This market is a small-trade candidate. Here is the budget, side, entry price, risk limit, and exit playbook. Confirm before execution."

--- a/skills/polymarket-event-alpha/SUMMARY.md
+++ b/skills/polymarket-event-alpha/SUMMARY.md
@@ -1,0 +1,32 @@
+# Polymarket Event Alpha
+
+## Overview
+
+Polymarket Event Alpha is a Polymarket event-market trading product built on the official Polymarket Plugin and Onchain OS. It helps users check readiness, prepare assets, rank event markets, avoid bad spreads and weak directional setups, and create a risk-aware plan before any confirmed trade.
+
+It is not a high-win-rate claim. It is a practical event trading assistant that helps users avoid bad execution and bad market selection.
+
+## Prerequisites
+
+- Official Polymarket Plugin installed.
+- Onchain OS available.
+- A wallet/account that can use the supported Polymarket flow.
+- Platform access conditions must allow live trading before any live action.
+
+## Quick Start
+
+Ask:
+
+> "Use Polymarket Event Alpha to find the best small event trade today."
+
+The skill should answer:
+
+1. whether the user is ready;
+2. what asset/setup is missing, if anything;
+3. the Top 3 markets to watch;
+4. whether the Top 1 is actionable or watch-only;
+5. the trade plan and exit playbook if a trade is allowed.
+
+## Safety
+
+Polymarket Event Alpha does not bypass platform restrictions, does not promise profit, and does not submit a live trade without explicit confirmation.

--- a/skills/polymarket-event-alpha/plugin.yaml
+++ b/skills/polymarket-event-alpha/plugin.yaml
@@ -6,7 +6,7 @@ author:
   name: "cbl980712-coder"
   github: "cbl980712-coder"
 license: MIT
-category: defi-protocol
+category: strategy
 tags:
   - polymarket
   - prediction-market
@@ -14,6 +14,14 @@ tags:
   - risk-management
   - onchainos
   - polygon
+
+dependent_plugin:
+  - name: polymarket-plugin
+    version: "^0.5.1"
+
+risk_level: high
+supported_venues:
+  - polymarket
 
 components:
   skill:

--- a/skills/polymarket-event-alpha/plugin.yaml
+++ b/skills/polymarket-event-alpha/plugin.yaml
@@ -1,0 +1,29 @@
+schema_version: 1
+name: polymarket-event-alpha
+version: "1.0.0"
+description: "Polymarket Event Alpha screens event markets, checks trading readiness, ranks opportunities, and prepares risk-aware Polymarket plans."
+author:
+  name: "cbl980712-coder"
+  github: "cbl980712-coder"
+license: MIT
+category: defi-protocol
+tags:
+  - polymarket
+  - prediction-market
+  - event-trading
+  - risk-management
+  - onchainos
+  - polygon
+
+components:
+  skill:
+    dir: "."
+
+api_calls:
+  - "https://clob.polymarket.com"
+  - "https://gamma-api.polymarket.com"
+  - "https://data-api.polymarket.com"
+  - "https://bridge.polymarket.com"
+  - "coins.llama.fi"
+  - "polygon.drpc.org"
+  - "polygon-bor-rpc.publicnode.com"


### PR DESCRIPTION

Plugin Submission
Plugin name: polymarket-event-alpha
Product name: Polymarket Event Alpha
Strategy ID: event-alpha-xy
Version: 1.0.0
Type: Skill-only

Checklist
 plugin-store lint passes locally with no errors
 I have read the Development Guide
 My plugin does NOT use reserved prefixes (okx-, official-, plugin-store-)
 LICENSE file is included
 SKILL.md has YAML frontmatter with name and description
English
What does this plugin do?
Polymarket Event Alpha is an event-market trading product built on top of the official Polymarket Plugin and Onchain OS.

It helps users answer a practical question:

“Can I safely consider an event trade now, and which market is actually worth looking at?”

The product is not designed to promise profit, high win rate, or magic prediction. Its core value is improving trading quality before execution. It helps users avoid wrong assets, poor spreads, thin order books, weak directional setups, and invalid live attempts when platform access conditions are not satisfied.

Core capabilities:

readiness check
asset preparation guidance
market quality score
directional edge score
execution feasibility score
Top 3 event-market shortlist
Top 1 plain-language explanation
trade plan
risk check
exit playbook
platform access condition detection and invalid-action blocking
Which commands does it use?
This skill is designed to work with official command names:

polymarket-plugin
onchainos
It does not rely on local wrappers, copied binaries, private wallet files, or development-only relay tools.

Safety considerations
No private keys are handled by the skill.
No wallet seed phrase or local session data is required by the public skill.
The skill does not bypass Polymarket platform access restrictions.
The skill does not default to automatic swap.
The skill does not default to automatic betting.
The skill avoids forcing a YES/NO recommendation when directional edge is weak.
Public documentation does not include private wallet addresses, API keys, local machine paths, or private logs.
Testing / Package
Prepared as a Skill-only Plugin Store submission under:

skills/polymarket-event-alpha/
Included files:

plugin.yaml
.claude-plugin/plugin.json
SKILL.md
SUMMARY.md
README.md
LICENSE
Please run:

plugin-store lint skills/polymarket-event-alpha
中文说明
这个插件是做什么的？
Polymarket Event Alpha 是一个基于官方 Polymarket Plugin 和 Onchain OS 的事件市场交易产品。

它不是“预测之神”，也不承诺收益或胜率。它解决的是用户在 Polymarket 交易前最容易踩坑的问题：

当前到底能不能交易？
钱包和资产是否准备正确？
是否缺 USDC.e、gas 或 setup？
这个市场是不是烂盘口？
价差和流动性是否适合小额执行？
方向优势是否足够？
如果要做，预算、入场价、风控和退出应该怎么安排？
如果平台访问条件不满足，是否应该阻止无效 live 尝试？
核心能力
readiness 检查
资产准备建议
市场质量评分
方向边际评分
执行可行性评分
Top 3 市场短名单
Top 1 用户版解释
下注计划
风控检查
exit playbook
平台访问条件识别与无效操作拦截
产品价值
Polymarket Event Alpha 的价值不是替用户“猜对一切”，而是帮助用户少做烂单、少踩执行坑：

不拿错资产
不硬进坏价差市场
不在方向优势弱的时候强推 YES/NO
不在平台访问受限时反复尝试 live
下单前先知道怎么退出
安全边界
不承诺收益
不承诺高胜率
不绕过平台访问限制
不默认自动 swap
不默认自动下注
没有明确方向优势时，只输出 watch / price-target-only
真实写操作必须经过 readiness、risk check 和用户确认