### PR TITLE
[new-plugin] hyperliquid-risk-alpha v1.0.0

### DIFF
--- a/skills/hyperliquid-risk-alpha/.claude-plugin/plugin.json
+++ b/skills/hyperliquid-risk-alpha/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "hyperliquid-risk-alpha",
+  "description": "Hyperliquid Risk Alpha checks readiness, scores BTC/ETH opportunities, plans small trades, and manages risk before and after entry.",
+  "version": "1.0.0",
+  "author": {
+    "name": "cbl980712-coder"
+  },
+  "license": "MIT",
+  "keywords": [
+    "hyperliquid",
+    "perpetuals",
+    "trading",
+    "risk-management",
+    "onchainos",
+    "derivatives"
+  ]
+}

--- a/skills/hyperliquid-risk-alpha/LICENSE
+++ b/skills/hyperliquid-risk-alpha/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/hyperliquid-risk-alpha/README.md
+++ b/skills/hyperliquid-risk-alpha/README.md
@@ -1,0 +1,40 @@
+# Hyperliquid Risk Alpha
+
+Hyperliquid Risk Alpha helps users approach small BTC/ETH perp trades with more discipline.
+
+It checks whether the account is ready, whether funds are usable, whether the market setup is worth considering, and whether the trade can be protected after entry.
+
+## What Users Get
+
+- Account, funding, and trading readiness.
+- BTC/ETH market data summary.
+- Fresh opportunity score.
+- Small order plan.
+- Risk check and dry-run before live action.
+- Final confirmation before any live order.
+- Post-entry guard.
+- Executable exit plan.
+- Trade journal and final review.
+
+## Why It Is Useful
+
+Many trading losses come from execution mistakes, not just wrong direction:
+
+- trading before funds are ready
+- entering during poor spread or weak liquidity
+- opening too small or too large for the plan
+- forgetting stop protection
+- opening another trade while the first one is unmanaged
+- never reviewing what happened
+
+Hyperliquid Risk Alpha is built to reduce those mistakes.
+
+## Strategy
+
+- Product Name: Hyperliquid Risk Alpha
+- Strategy ID: `risk-alpha-xy`
+- Underlying Plugin: Hyperliquid Plugin
+
+## Safety
+
+This product does not promise profit, does not force trades, and does not bypass confirmation.

--- a/skills/hyperliquid-risk-alpha/SKILL.md
+++ b/skills/hyperliquid-risk-alpha/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: hyperliquid-risk-alpha
+description: "Use Hyperliquid Risk Alpha when a user wants a small, risk-controlled BTC or ETH Hyperliquid trade workflow with readiness checks, opportunity scoring, confirmation, protection, and lifecycle review."
+version: "1.0.0"
+author: "cbl980712-coder"
+tags:
+  - hyperliquid
+  - perpetuals
+  - trading
+  - risk-management
+  - onchainos
+---
+
+# Hyperliquid Risk Alpha
+
+Hyperliquid Risk Alpha is a small-size, risk-first trading skill built on the official Hyperliquid Plugin and Onchain OS.
+
+It helps users answer:
+
+> "Am I ready to trade, is there a reasonable BTC or ETH opportunity, and how do I avoid entering an unmanaged position?"
+
+It does not promise profit or high win rate. It focuses on readiness, execution quality, position protection, and lifecycle review.
+
+## What It Does
+
+Use this skill to:
+
+- Check account, funding, and trading readiness.
+- Detect whether funds are in the correct trading layer.
+- Read BTC and ETH market data.
+- Score fresh opportunities as:
+  - no_trade
+  - watch
+  - tradable_light
+  - tradable_full
+- Build a small order plan.
+- Run risk check and dry-run before any live order.
+- Require final user confirmation before live trading.
+- Submit a small live trade only after confirmation.
+- Run post-entry guard.
+- Build an executable exit plan.
+- Prefer reduce-only protection.
+- Track trade lifecycle.
+- Update trade journal and guard state.
+- Produce a final review after exit.
+
+## Product Rules
+
+- Strategy ID: `risk-alpha-xy`
+- Underlying official plugin: `hyperliquid-plugin`
+- First version markets:
+  - BTC
+  - ETH
+- Default style:
+  - small size
+  - low leverage
+  - single position
+  - no automatic add-on
+  - no continuous trading loop
+- Readiness ready means trading is possible, not that trading is required.
+- No live order without explicit user confirmation.
+
+## Public Command Assumptions
+
+The user should have the official plugin installed and available on PATH:
+
+```bash
+hyperliquid-plugin
+onchainos
+```
+
+Do not use project-local wrappers, copied binaries, relays, or diagnostic tools for formal execution.
+
+## Normal User Flow
+
+1. Readiness:
+   - account readiness
+   - funding readiness
+   - trading readiness
+
+2. Market data:
+   - candles
+   - ATR
+   - funding
+   - spread
+   - basic orderbook depth
+   - tiny price impact
+
+3. Opportunity score:
+   - no_trade
+   - watch
+   - tradable_light
+   - tradable_full
+
+4. Order plan:
+   - symbol
+   - direction
+   - size
+   - maximum acceptable price
+   - leverage
+   - risk boundary
+
+5. Risk and dry-run:
+   - platform minimum size
+   - balance
+   - leverage
+   - spread
+   - liquidity
+   - execution path
+
+6. Final confirmation:
+   - no live order without explicit confirmation
+
+7. Post-entry management:
+   - check whether a position exists
+   - detect naked position risk
+   - build executable exit plan
+   - prefer reduce-only protection
+   - update journal/state
+
+8. Final review:
+   - entry
+   - exit
+   - PnL
+   - exit attribution
+   - whether the trade followed plan
+
+## Output Style
+
+Write for a normal user, not for a developer.
+
+Preferred one-screen answer:
+
+- Is the account ready?
+- Is funding ready?
+- Is trading ready?
+- Is there an open position?
+- Is the position protected?
+- Is a new trade allowed?
+- Which of BTC/ETH is better, if any?
+- If no trade, why?
+- If trade is possible, what is the plan and exit?
+
+## Safety Boundaries
+
+- Do not promise profit.
+- Do not claim high win rate.
+- Do not open a live trade without final confirmation.
+- Do not open a second trade if an existing position is unmanaged.
+- Do not hide insufficient market data.
+- Do not expose private wallet data, local machine paths, API keys, sessions, or logs to the user.
+- If a trade is too small for meaningful exit management, use a simpler full-position protection plan instead of fake multi-target exits.
+
+## Error Handling
+
+| Condition | Meaning | Response |
+|---|---|---|
+| account_ready is false | Account is not ready | Stop and explain the one required next action |
+| funding_ready is false | Funds are not in the usable trading layer | Stop before order planning |
+| trading_ready is false | Trading path is not ready | Stop before order planning |
+| weak opportunity | Setup is not worth forcing | Output watch or no_trade |
+| open position unprotected | Risk is unmanaged | Prioritize post-entry guard and protection |
+| dry-run fails | Execution path is not safe | Do not request final confirmation |
+| user does not confirm | No live order permission | Stop without submitting |
+
+## Example User Request
+
+> "Use Hyperliquid Risk Alpha to see if BTC or ETH is worth a small trade today."
+
+Good response:
+
+- "Account and funding are ready."
+- "ETH has better structure, but this is only tradable_light."
+- "Here is the small order plan and exit."
+- "Run risk check and dry-run first."
+- "No live order will be submitted until you confirm."

--- a/skills/hyperliquid-risk-alpha/SUMMARY.md
+++ b/skills/hyperliquid-risk-alpha/SUMMARY.md
@@ -1,0 +1,34 @@
+# Hyperliquid Risk Alpha
+
+## Overview
+
+Hyperliquid Risk Alpha is a small, risk-controlled BTC/ETH trading product built on the official Hyperliquid Plugin and Onchain OS. It checks readiness, reads market data, scores fresh opportunities, prepares small order plans, runs risk checks and dry-runs, requires final confirmation, and manages position protection after entry.
+
+It is not a high-win-rate strategy claim. It is a disciplined trading workflow for reducing execution mistakes and unmanaged-position risk.
+
+## Prerequisites
+
+- Official Hyperliquid Plugin installed.
+- Onchain OS available.
+- Hyperliquid account and funding readiness.
+- User confirmation before live trading.
+
+## Quick Start
+
+Ask:
+
+> "Use Hyperliquid Risk Alpha to check whether BTC or ETH is worth a small trade today."
+
+The skill should answer:
+
+1. account/funding/trading readiness;
+2. BTC/ETH market data quality;
+3. opportunity score;
+4. order plan if appropriate;
+5. risk check and dry-run requirements;
+6. final confirmation prompt before any live action;
+7. post-entry protection and review plan.
+
+## Safety
+
+Hyperliquid Risk Alpha does not promise profit, does not force a trade, and does not submit a live order without explicit confirmation.

--- a/skills/hyperliquid-risk-alpha/plugin.yaml
+++ b/skills/hyperliquid-risk-alpha/plugin.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+name: hyperliquid-risk-alpha
+version: "1.0.0"
+description: "Hyperliquid Risk Alpha checks readiness, scores BTC/ETH opportunities, plans small trades, and manages risk before and after entry."
+author:
+  name: "cbl980712-coder"
+  github: "cbl980712-coder"
+license: MIT
+category: defi-protocol
+tags:
+  - hyperliquid
+  - perpetuals
+  - trading
+  - risk-management
+  - onchainos
+  - derivatives
+
+components:
+  skill:
+    dir: "."
+
+api_calls:
+  - "https://api.hyperliquid.xyz"
+  - "https://api.hyperliquid-testnet.xyz"
+  - "https://arbitrum-one-rpc.publicnode.com"
+  - "https://app.hyperliquid.xyz"
+  - "https://rpc.hyperliquid.xyz"
+  - "https://api.relay.link"

--- a/skills/hyperliquid-risk-alpha/plugin.yaml
+++ b/skills/hyperliquid-risk-alpha/plugin.yaml
@@ -6,7 +6,7 @@ author:
   name: "cbl980712-coder"
   github: "cbl980712-coder"
 license: MIT
-category: defi-protocol
+category: strategy
 tags:
   - hyperliquid
   - perpetuals
@@ -14,6 +14,14 @@ tags:
   - risk-management
   - onchainos
   - derivatives
+
+dependent_plugin:
+  - name: hyperliquid-plugin
+    version: "^0.3.9"
+
+risk_level: high
+supported_venues:
+  - hyperliquid
 
 components:
   skill:


### PR DESCRIPTION
Plugin Submission
Plugin name: hyperliquid-risk-alpha
Product name: Hyperliquid Risk Alpha
Strategy ID: risk-alpha-xy
Version: 1.0.0
Type: Skill-only

Checklist
 plugin-store lint passes locally with no errors
 I have read the Development Guide
 My plugin does NOT use reserved prefixes (okx-, official-, plugin-store-)
 LICENSE file is included
 SKILL.md has YAML frontmatter with name and description
English
What does this plugin do?
Hyperliquid Risk Alpha is a small risk-controlled BTC/ETH trading product built on top of the official Hyperliquid Plugin and Onchain OS.

It helps users move through a disciplined trading workflow instead of opening unmanaged positions. The product checks whether the account, funding, and trading path are ready; reads a light market data layer; scores fresh BTC/ETH opportunities; prepares a small order plan; runs risk check and dry-run; requires final confirmation; and then prioritizes post-entry protection and lifecycle review.

Core capabilities:

account / funding / trading readiness
market data light layer
fresh opportunity score
order planning
risk check
dry-run
final confirmation
live order only after confirmation
post-entry guard
executable exit plan
reduce-only protection principles
lifecycle watcher
trade journal
guard state
final review
This plugin does not claim high win rate or guaranteed profit. Its value is reducing execution mistakes, unmanaged-position risk, and undisciplined follow-up trades.

Which commands does it use?
This skill is designed to work with official command names:

hyperliquid-plugin
onchainos
It does not rely on local wrappers, copied binaries, private wallet files, or development-only relay tools.

Safety considerations
No private keys are handled by the skill.
No wallet seed phrase or local session data is required by the public skill.
The skill does not promise profit or high win rate.
The skill does not open new positions while an existing position is unmanaged.
The skill does not force trades just because readiness is true.
Public documentation does not include private wallet addresses, API keys, local machine paths, or private logs.
Testing / Package
Prepared as a Skill-only Plugin Store submission under:

skills/hyperliquid-risk-alpha/
Included files:

plugin.yaml
.claude-plugin/plugin.json
SKILL.md
SUMMARY.md
README.md
LICENSE
Development validation completed a first real Hyperliquid tiny-trade lifecycle: live entry, protection order, stop-loss exit attribution, trade journal update, guard state update, and final review. Private wallet data and local evidence logs are not included in this public package.

Please run:

plugin-store lint skills/hyperliquid-risk-alpha
中文说明
这个插件是做什么的？
Hyperliquid Risk Alpha 是一个基于官方 Hyperliquid Plugin 和 Onchain OS 的小额风控交易产品。

它不是高胜率神策略，也不承诺稳定盈利。它的目标是让用户在 BTC / ETH 小额交易中少犯执行错误，避免裸仓、乱开仓、无风控、无复盘。

用户一句话可以问：

“现在 BTC 或 ETH 有没有值得做的一笔小额单？”

系统会先回答：

账户是否 ready？
资金是否 ready？
交易路径是否 ready？
BTC / ETH 哪个更值得看？
当前是 no_trade、watch、tradable_light 还是 tradable_full？
如果要做，订单计划是什么？
风险检查是否通过？
dry-run 是否通过？
是否需要最终人工确认？
开仓后是否已经有保护？
这笔交易最后怎么复盘？
核心能力
account / funding / trading readiness
市场数据轻层
fresh opportunity score
交易计划
risk check
dry-run
final confirmation
真实下单
post-entry guard
executable exit plan
protection
lifecycle watcher
trade_journal
guard_state
final review
产品价值
Hyperliquid Risk Alpha 的价值不是“帮用户无脑刷单”，而是把真实交易变成有纪律的流程：

readiness ready 不等于必须交易
没有好机会可以输出 watch / no_trade
下单前必须 risk check 和 dry-run
没有确认不提交 live
开仓后优先检查是否裸仓
有仓位先保护，再考虑下一笔
交易结束后必须归因和复盘
真实验证
开发验证中已经完成第一笔真实 Hyperliquid tiny trade 的生命周期：

真实开仓
提交保护订单
stop-loss 退出归因
trade journal 更新
guard state 更新
final review
这些证明产品不是只会生成计划，而是能跑完整交易流程。公开包不包含私密钱包数据、本地日志或敏感路径。

安全边界
不承诺收益
不承诺高胜率
不自动连续开单
不在已有仓位未管理好时开第二笔
不绕过确认流程
所有 live 写操作必须先经过计划、risk check、dry-run 和人工确认
